### PR TITLE
Fix to build Amnezia desktop app on Apple Silicon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,10 @@ if(ANDROID)
     set(QT_ANDROID_BUILD_ALL_ABIS ON)
 endif()
 
+if(APPLE AND NOT IOS)
+    set(CMAKE_OSX_ARCHITECTURES "x86_64")
+endif()
+
 add_subdirectory(client)
 
 if(NOT IOS AND NOT ANDROID)


### PR DESCRIPTION
Fix to build at least x86_64 version of Amnezia desktop app on Apple Silicon (still can't build native arm64 version)