### PR TITLE
bugfix/sftp-files-permissions

### DIFF
--- a/client/core/sshclient.cpp
+++ b/client/core/sshclient.cpp
@@ -6,7 +6,7 @@
 #include <fstream>
 
 #ifdef Q_OS_WINDOWS
-#define S_IRWXU 0
+const uint32_t S_IRWXU = 0644;
 #endif
 
 namespace libssh {


### PR DESCRIPTION
set the value S_IRWXU for windows, so that when copying via sftp, the necessary permissions for the file are set