### PR TITLE
Mark client/3rd/ as vendored code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@ deploy/data/windows/x64/tap/windows_7/OemVista.inf eol=crlf
 deploy/data/windows/x64/tap/windows_10/OemVista.inf eol=crlf
 deploy/data/windows/x32/tap/windows_7/OemVista.inf eol=crlf
 deploy/data/windows/x32/tap/windows_10/OemVista.inf eol=crlf
+client/3rd/* linguist-vendored


### PR DESCRIPTION
This should fix GitHub's language detection for the repo, which currently looks too C-heavy:
![image](https://github.com/amnezia-vpn/amnezia-client/assets/25753618/632565c9-1ad6-4d16-a0c7-57a36aae81c7)
See [docs](https://github.com/github-linguist/linguist/blob/master/docs/overrides.md#vendored-code).