### PR TITLE
Update OpenVPNAdapter to prevent crash OpenVPN-over-Cloak

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -179,6 +179,7 @@ jobs:
         
     - name: 'Build project'
       run: |
+        git submodule update --init --recursive
         export QT_BIN_DIR="${{ runner.temp }}/Qt/${{ env.QT_VERSION }}/ios/bin"
         export QT_MACOS_ROOT_DIR="${{ runner.temp }}/Qt/${{ env.QT_VERSION }}/macos"
         export PATH=$PATH:~/go/bin


### PR DESCRIPTION
Fix OpenVPN-over-Cloak crash on iOS. 