### PR TITLE
Fix path to OpenVPN executable

### DIFF
--- a/client/utilities.cpp
+++ b/client/utilities.cpp
@@ -219,7 +219,9 @@ QString Utils::openVpnExecPath()
 #ifdef Q_OS_WIN
     return Utils::executable("openvpn/openvpn", true);
 #elif defined Q_OS_LINUX
-    return Utils::executable("openvpn", true);
+    // We have service that runs OpenVPN on Linux. We need to make same
+    // path for client and service.
+    return Utils::executable("../../client/bin/openvpn", true);
 #else
     return Utils::executable("/openvpn", true);
 #endif


### PR DESCRIPTION
We have service that runs OpenVPN on Linux.  We need to make same path for client and service.