### PR TITLE
Make check_user_in_sudo.sh use sudo -l

### DIFF
--- a/client/core/servercontroller.cpp
+++ b/client/core/servercontroller.cpp
@@ -691,7 +691,7 @@ ErrorCode ServerController::isUserInSudo(const ServerCredentials &credentials, D
     const QString scriptData = amnezia::scriptData(SharedScriptType::check_user_in_sudo);
     ErrorCode error = runScript(credentials, replaceVars(scriptData, genVarsForScript(credentials)), cbReadStdOut, cbReadStdErr);
 
-    if (!stdOut.contains("sudo")) return ErrorCode::ServerUserNotInSudo;
+    if (!stdOut.contains("(ALL) NOPASSWD: ALL")) return ErrorCode::ServerUserNotInSudo;
 
     return error;
 }

--- a/client/server_scripts/check_user_in_sudo.sh
+++ b/client/server_scripts/check_user_in_sudo.sh
@@ -1,2 +1,1 @@
-CUR_USER=$(whoami);\
-groups $CUR_USER
+sudo -l


### PR DESCRIPTION
Sudo group is not sufficient in all Linux systems. Correct way is to search for `(ALL) NOPASSWD: ALL` in output of `sudo -l` command.
See https://superuser.com/questions/553932/how-to-check-if-i-have-sudo-access as an example.