### PR TITLE
fixed: text field can not be updated to memory, including site and port

### DIFF
--- a/client/ui/pages_logic/protocols/CloakLogic.cpp
+++ b/client/ui/pages_logic/protocols/CloakLogic.cpp
@@ -47,7 +47,11 @@ void CloakLogic::updateProtocolPage(const QJsonObject &ckConfig, DockerContainer
 QJsonObject CloakLogic::getProtocolConfigFromPage(QJsonObject oldConfig)
 {
     oldConfig.insert(config_key::cipher, comboBoxCipherText());
-    oldConfig.insert(config_key::site, lineEditSiteText());
+
+    QString newSite = lineEditSiteText();
+    newSite.replace("https://", "");
+    oldConfig.insert(config_key::site, newSite);
+
     oldConfig.insert(config_key::port, lineEditPortText());
 
     return oldConfig;

--- a/client/ui/qml/Pages/Protocols/PageProtoCloak.qml
+++ b/client/ui/qml/Pages/Protocols/PageProtoCloak.qml
@@ -76,9 +76,14 @@ PageProtocolBase {
             TextFieldType {
                 id: lineEdit_proto_cloak_site
                 Layout.fillWidth: true
+                focus: true
                 height: 31
                 text: logic.lineEditSiteText
                 onEditingFinished: {
+                    logic.lineEditSiteText = text
+                }
+
+                onCursorRectangleChanged: {
                     logic.lineEditSiteText = text
                 }
             }
@@ -96,12 +101,17 @@ PageProtocolBase {
             TextFieldType {
                 id: lineEdit_proto_cloak_port
                 Layout.fillWidth: true
+                focus: true
                 height: 31
                 text: logic.lineEditPortText
                 onEditingFinished: {
                     logic.lineEditPortText = text
                 }
                 enabled: logic.lineEditPortEnabled
+
+                onCursorRectangleChanged: {
+                    logic.lineEditPortText = text
+                }
             }
         }
 


### PR DESCRIPTION
fixed text field can not be updated to memory in the Cloak protocol config page, including site and port