### PR TITLE
Restoring autostart and enable docker for CentOS 7

### DIFF
--- a/client/server_scripts/install_docker.sh
+++ b/client/server_scripts/install_docker.sh
@@ -8,7 +8,7 @@ if ! command -v sudo > /dev/null 2>&1; then $pm update -yq; $pm install -yq sudo
 if ! command -v fuser > /dev/null 2>&1; then sudo $pm install -yq psmisc; fi;\
 if ! command -v lsof > /dev/null 2>&1; then sudo $pm install -yq lsof; fi;\
 if ! command -v docker > /dev/null 2>&1; then sudo $pm update -yq; sudo $pm install -yq $docker_pkg;\
-  if [ "$dist" = "fedora" ] || [ "$dist" = "debian" ]; then sudo systemctl enable docker && sudo systemctl start docker; fi;\
+  if [ "$dist" = "centos" ] || [ "$dist" = "debian" ]; then sudo systemctl enable docker && sudo systemctl start docker; fi;\
 fi;\
 if [ "$dist" = "debian" ]; then \
   docker_service=$(systemctl list-units --full --all | grep docker.service | grep -v inactive | grep -v dead | grep -v failed);\


### PR DESCRIPTION
Replacing the incorrect dist="fedora" with dist="centos" to restore CentOS 7 support.
Since doing sudo systemctl enable docker && sudo systemctl start docker doesn't make sense for podman on CentOS 8 (dnf), but is necessary for docker on CentOS 7 (yum) and Debian|Ubuntu (apt).