### PR TITLE
Use DNS over VPN for ForwardSites mode split tunnel

### DIFF
--- a/client/vpnconnection.cpp
+++ b/client/vpnconnection.cpp
@@ -377,7 +377,8 @@ void VpnConnection::appendSplitTunnelingConfig()
 
     // Allow traffic to Amezia DNS
     if (routeMode == Settings::VpnOnlyForwardSites){
-        sitesJsonArray.append(amnezia::protocols::dns::amneziaDnsIp);
+        sitesJsonArray.append(m_vpnConfiguration.value(config_key::dns1).toString());
+        sitesJsonArray.append(m_vpnConfiguration.value(config_key::dns2).toString());
     }
 
     m_vpnConfiguration.insert(config_key::splitTunnelType, routeMode);


### PR DESCRIPTION
This feature was in previous version of Split Tunnel