### PR TITLE
Fix import of some native WG configs

### DIFF
--- a/client/ui/controllers/importController.cpp
+++ b/client/ui/controllers/importController.cpp
@@ -239,7 +239,16 @@ QJsonObject ImportController::extractWireGuardConfig(const QString &data)
 //        && !configMap.value("PresharedKey").isEmpty() && !configMap.value("PublicKey").isEmpty()) {
         lastConfig[config_key::client_priv_key] = configMap.value("PrivateKey");
         lastConfig[config_key::client_ip] = configMap.value("Address");
-        lastConfig[config_key::psk_key] = configMap.value("PresharedKey");
+        if (!configMap.value("PresharedKey").isEmpty()) {
+            lastConfig[config_key::psk_key] = configMap.value("PresharedKey");
+        } else if (!configMap.value("PreSharedKey").isEmpty()) {
+            lastConfig[config_key::psk_key] = configMap.value("PreSharedKey");
+        } else {
+            qDebug() << "Failed to import profile";
+            emit importErrorOccurred(errorString(ErrorCode::ImportInvalidConfigError));
+            return QJsonObject();
+        }
+
         lastConfig[config_key::server_pub_key] = configMap.value("PublicKey");
 //    } else {
 //        qDebug() << "Failed to import profile";

--- a/client/ui/controllers/importController.cpp
+++ b/client/ui/controllers/importController.cpp
@@ -243,10 +243,6 @@ QJsonObject ImportController::extractWireGuardConfig(const QString &data)
             lastConfig[config_key::psk_key] = configMap.value("PresharedKey");
         } else if (!configMap.value("PreSharedKey").isEmpty()) {
             lastConfig[config_key::psk_key] = configMap.value("PreSharedKey");
-        } else {
-            qDebug() << "Failed to import profile";
-            emit importErrorOccurred(errorString(ErrorCode::ImportInvalidConfigError));
-            return QJsonObject();
         }
 
         lastConfig[config_key::server_pub_key] = configMap.value("PublicKey");


### PR DESCRIPTION
Detailed in #499.

This fixes native WG config import for desktop clients. Some of native WG configs uses PreSharedKey filed instead of PresharedKey field.