### PR TITLE
Replace sftp with scp 

### DIFF
--- a/client/configurators/openvpn_configurator.cpp
+++ b/client/configurators/openvpn_configurator.cpp
@@ -76,7 +76,7 @@ OpenVpnConfigurator::ConnectionData OpenVpnConfigurator::prepareOpenVpnConfig(co
 
     if (connData.caCert.isEmpty() || connData.clientCert.isEmpty() || connData.taKey.isEmpty()) {
         if (errorCode)
-            *errorCode = ErrorCode::OpenVpnUnknownError;
+            *errorCode = ErrorCode::SshScpFailureError;
     }
 
     return connData;

--- a/client/configurators/openvpn_configurator.cpp
+++ b/client/configurators/openvpn_configurator.cpp
@@ -76,7 +76,7 @@ OpenVpnConfigurator::ConnectionData OpenVpnConfigurator::prepareOpenVpnConfig(co
 
     if (connData.caCert.isEmpty() || connData.clientCert.isEmpty() || connData.taKey.isEmpty()) {
         if (errorCode)
-            *errorCode = ErrorCode::SshSftpFailureError;
+            *errorCode = ErrorCode::OpenVpnUnknownError;
     }
 
     return connData;

--- a/client/configurators/wireguard_configurator.cpp
+++ b/client/configurators/wireguard_configurator.cpp
@@ -159,7 +159,7 @@ WireguardConfigurator::ConnectionData WireguardConfigurator::prepareWireguardCon
                                  .arg(connData.clientPubKey, connData.pskKey, connData.clientIP);
 
     e = serverController.uploadTextFileToContainer(container, credentials, configPart, m_serverConfigPath,
-                                                   libssh::SftpOverwriteMode::SftpAppendToExisting);
+                                                   libssh::ScpOverwriteMode::ScpAppendToExisting);
 
     if (e) {
         if (errorCode)

--- a/client/core/controllers/serverController.cpp
+++ b/client/core/controllers/serverController.cpp
@@ -118,7 +118,7 @@ ServerController::runContainerScript(const ServerCredentials &credentials, Docke
 
 ErrorCode ServerController::uploadTextFileToContainer(DockerContainer container, const ServerCredentials &credentials,
                                                       const QString &file, const QString &path,
-                                                      libssh::SftpOverwriteMode overwriteMode)
+                                                      libssh::ScpOverwriteMode overwriteMode)
 {
     ErrorCode e = ErrorCode::NoError;
     QString tmpFileName = QString("/tmp/%1.tmp").arg(Utils::getRandomString(16));
@@ -139,7 +139,7 @@ ErrorCode ServerController::uploadTextFileToContainer(DockerContainer container,
     if (e)
         return e;
 
-    if (overwriteMode == libssh::SftpOverwriteMode::SftpOverwriteExisting) {
+    if (overwriteMode == libssh::ScpOverwriteMode::ScpOverwriteExisting) {
         e = runScript(credentials,
                       replaceVars(QString("sudo docker cp %1 $CONTAINER_NAME:/%2").arg(tmpFileName).arg(path),
                                   genVarsForScript(credentials, container)),
@@ -147,7 +147,7 @@ ErrorCode ServerController::uploadTextFileToContainer(DockerContainer container,
 
         if (e)
             return e;
-    } else if (overwriteMode == libssh::SftpOverwriteMode::SftpAppendToExisting) {
+    } else if (overwriteMode == libssh::ScpOverwriteMode::ScpAppendToExisting) {
         e = runScript(credentials,
                       replaceVars(QString("sudo docker cp %1 $CONTAINER_NAME:/%2").arg(tmpFileName).arg(tmpFileName),
                                   genVarsForScript(credentials, container)),
@@ -199,7 +199,7 @@ QByteArray ServerController::getTextFileFromContainer(DockerContainer container,
 }
 
 ErrorCode ServerController::uploadFileToHost(const ServerCredentials &credentials, const QByteArray &data,
-                                             const QString &remotePath, libssh::SftpOverwriteMode overwriteMode)
+                                             const QString &remotePath, libssh::ScpOverwriteMode overwriteMode)
 {
     auto error = m_sshClient.connectToHost(credentials);
     if (error != ErrorCode::NoError) {

--- a/client/core/controllers/serverController.cpp
+++ b/client/core/controllers/serverController.cpp
@@ -212,10 +212,10 @@ ErrorCode ServerController::uploadFileToHost(const ServerCredentials &credential
     localFile.close();
 
 #ifdef Q_OS_WINDOWS
-    error = m_sshClient.sftpFileCopy(overwriteMode, localFile.fileName().toLocal8Bit().toStdString(), remotePath.toStdString(),
+    error = m_sshClient.scpFileCopy(overwriteMode, localFile.fileName().toLocal8Bit().toStdString(), remotePath.toStdString(),
                                      "non_desc");
 #else
-    error = m_sshClient.sftpFileCopy(overwriteMode, localFile.fileName().toStdString(), remotePath.toStdString(),
+    error = m_sshClient.scpFileCopy(overwriteMode, localFile.fileName().toStdString(), remotePath.toStdString(),
                                      "non_desc");
 #endif
 

--- a/client/core/controllers/serverController.h
+++ b/client/core/controllers/serverController.h
@@ -38,7 +38,7 @@ public:
 
     ErrorCode uploadTextFileToContainer(
             DockerContainer container, const ServerCredentials &credentials, const QString &file, const QString &path,
-            libssh::SftpOverwriteMode overwriteMode = libssh::SftpOverwriteMode::SftpOverwriteExisting);
+            libssh::ScpOverwriteMode overwriteMode = libssh::ScpOverwriteMode::ScpOverwriteExisting);
     QByteArray getTextFileFromContainer(DockerContainer container, const ServerCredentials &credentials,
                                         const QString &path, ErrorCode *errorCode = nullptr);
 
@@ -80,7 +80,7 @@ private:
     ErrorCode isServerDpkgBusy(const ServerCredentials &credentials, DockerContainer container);
 
     ErrorCode uploadFileToHost(const ServerCredentials &credentials, const QByteArray &data, const QString &remotePath,
-                               libssh::SftpOverwriteMode overwriteMode = libssh::SftpOverwriteMode::SftpOverwriteExisting);
+                               libssh::ScpOverwriteMode overwriteMode = libssh::ScpOverwriteMode::ScpOverwriteExisting);
 
     ErrorCode setupServerFirewall(const ServerCredentials &credentials);
 

--- a/client/core/defs.h
+++ b/client/core/defs.h
@@ -48,10 +48,6 @@ namespace amnezia
 
         // Ssh scp errors
         SshScpFailureError = 400,
-        SshScpOpenError = 401,
-        SshScpReadError = 402,
-        SshScpPermissionsError = 403,
-        SshScpUnspecifiedError = 404,
 
         // Local errors
         OpenVpnConfigMissing = 500,
@@ -83,7 +79,13 @@ namespace amnezia
 
         // Api errors
         ApiConfigDownloadError = 1100,
-        ApiConfigAlreadyAdded = 1101
+        ApiConfigAlreadyAdded = 1101,
+
+        // QFile errors
+        OpenError = 1200,
+        ReadError = 1201,
+        PermissionsError = 1202,
+        UnspecifiedError = 1203,
     };
 
 } // namespace amnezia

--- a/client/core/defs.h
+++ b/client/core/defs.h
@@ -86,6 +86,8 @@ namespace amnezia
         ReadError = 1201,
         PermissionsError = 1202,
         UnspecifiedError = 1203,
+        FatalError = 1204,
+        AbortError = 1205
     };
 
 } // namespace amnezia

--- a/client/core/defs.h
+++ b/client/core/defs.h
@@ -46,21 +46,6 @@ namespace amnezia
         SshPrivateKeyFormatError = 304,
         SshTimeoutError = 305,
 
-        // Ssh sftp errors
-        SshSftpEofError = 400,
-        SshSftpNoSuchFileError = 401,
-        SshSftpPermissionDeniedError = 402,
-        SshSftpFailureError = 403,
-        SshSftpBadMessageError = 404,
-        SshSftpNoConnectionError = 405,
-        SshSftpConnectionLostError = 406,
-        SshSftpOpUnsupportedError = 407,
-        SshSftpInvalidHandleError = 408,
-        SshSftpNoSuchPathError = 409,
-        SshSftpFileAlreadyExistsError = 410,
-        SshSftpWriteProtectError = 411,
-        SshSftpNoMediaError = 412,
-
         // Local errors
         OpenVpnConfigMissing = 500,
         OpenVpnManagementServerError = 501,

--- a/client/core/defs.h
+++ b/client/core/defs.h
@@ -56,7 +56,6 @@ namespace amnezia
         // Local errors
         OpenVpnConfigMissing = 500,
         OpenVpnManagementServerError = 501,
-        ConfigMissing = 502,
 
         // Distro errors
         OpenVpnExecutableMissing = 600,

--- a/client/core/defs.h
+++ b/client/core/defs.h
@@ -46,6 +46,13 @@ namespace amnezia
         SshPrivateKeyFormatError = 304,
         SshTimeoutError = 305,
 
+        // Ssh scp errors
+        SshScpFailureError = 400,
+        SshScpOpenError = 401,
+        SshScpReadError = 402,
+        SshScpPermissionsError = 403,
+        SshScpUnspecifiedError = 404,
+
         // Local errors
         OpenVpnConfigMissing = 500,
         OpenVpnManagementServerError = 501,

--- a/client/core/errorstrings.cpp
+++ b/client/core/errorstrings.cpp
@@ -61,6 +61,8 @@ QString errorString(ErrorCode code) {
     case(ReadError): errorMessage = QObject::tr("QFile error: An error occurred when reading from the file"); break;
     case(PermissionsError): errorMessage = QObject::tr("QFile error: The file could not be accessed"); break;
     case(UnspecifiedError): errorMessage =  QObject::tr("QFile error: An unspecified error occurred"); break;
+    case(FatalError): errorMessage =  QObject::tr("QFile error: A fatal error occurred"); break;
+    case(AbortError): errorMessage =  QObject::tr("QFile error: The operation was aborted"); break;
 
     case(InternalError):
     default:

--- a/client/core/errorstrings.cpp
+++ b/client/core/errorstrings.cpp
@@ -28,21 +28,6 @@ QString errorString(ErrorCode code) {
     case(SshPrivateKeyFormatError): errorMessage = QObject::tr("The selected private key format is not supported, use openssh ED25519 key types or PEM key types"); break;
     case(SshTimeoutError): errorMessage = QObject::tr("Timeout connecting to server"); break;
 
-    // Libssh sftp errors
-    case(SshSftpEofError): errorMessage = QObject::tr("Sftp error: End-of-file encountered"); break;
-    case(SshSftpNoSuchFileError): errorMessage = QObject::tr("Sftp error: File does not exist"); break;
-    case(SshSftpPermissionDeniedError): errorMessage = QObject::tr("Sftp error: Permission denied"); break;
-    case(SshSftpFailureError): errorMessage = QObject::tr("Sftp error: Generic failure"); break;
-    case(SshSftpBadMessageError): errorMessage = QObject::tr("Sftp error: Garbage received from server"); break;
-    case(SshSftpNoConnectionError): errorMessage = QObject::tr("Sftp error: No connection has been set up"); break;
-    case(SshSftpConnectionLostError): errorMessage = QObject::tr("Sftp error: There was a connection, but we lost it"); break;
-    case(SshSftpOpUnsupportedError): errorMessage = QObject::tr("Sftp error: Operation not supported by libssh yet"); break;
-    case(SshSftpInvalidHandleError): errorMessage = QObject::tr("Sftp error: Invalid file handle"); break;
-    case(SshSftpNoSuchPathError): errorMessage = QObject::tr("Sftp error: No such file or directory path exists"); break;
-    case(SshSftpFileAlreadyExistsError): errorMessage = QObject::tr("Sftp error: An attempt to create an already existing file or directory has been made"); break;
-    case(SshSftpWriteProtectError): errorMessage = QObject::tr("Sftp error: Write-protected filesystem"); break;
-    case(SshSftpNoMediaError): errorMessage = QObject::tr("Sftp error: No media was in remote drive"); break;
-
     // Local errors
     case (OpenVpnConfigMissing): errorMessage = QObject::tr("OpenVPN config missing"); break;
     case (OpenVpnManagementServerError): errorMessage = QObject::tr("OpenVPN management server error"); break;

--- a/client/core/errorstrings.cpp
+++ b/client/core/errorstrings.cpp
@@ -30,10 +30,6 @@ QString errorString(ErrorCode code) {
 
     // Ssh scp errors
     case(SshScpFailureError): errorMessage = QObject::tr("Scp error: Generic failure"); break;
-    case(SshScpOpenError): errorMessage = QObject::tr("Scp error: The file could not be opened"); break;
-    case(SshScpReadError): errorMessage = QObject::tr("Scp error: An error occurred when reading from the file"); break;
-    case(SshScpPermissionsError): errorMessage = QObject::tr("Scp error: The file could not be accessed"); break;
-    case(SshScpUnspecifiedError): errorMessage =  QObject::tr("Scp error: An unspecified error occurred"); break;
 
     // Local errors
     case (OpenVpnConfigMissing): errorMessage = QObject::tr("OpenVPN config missing"); break;
@@ -59,6 +55,12 @@ QString errorString(ErrorCode code) {
     // Api errors
     case (ApiConfigDownloadError): errorMessage = QObject::tr("Error when retrieving configuration from API"); break;
     case (ApiConfigAlreadyAdded): errorMessage = QObject::tr("This config has already been added to the application"); break;
+
+    // QFile errors
+    case(OpenError): errorMessage = QObject::tr("QFile error: The file could not be opened"); break;
+    case(ReadError): errorMessage = QObject::tr("QFile error: An error occurred when reading from the file"); break;
+    case(PermissionsError): errorMessage = QObject::tr("QFile error: The file could not be accessed"); break;
+    case(UnspecifiedError): errorMessage =  QObject::tr("QFile error: An unspecified error occurred"); break;
 
     case(InternalError):
     default:

--- a/client/core/errorstrings.cpp
+++ b/client/core/errorstrings.cpp
@@ -28,6 +28,13 @@ QString errorString(ErrorCode code) {
     case(SshPrivateKeyFormatError): errorMessage = QObject::tr("The selected private key format is not supported, use openssh ED25519 key types or PEM key types"); break;
     case(SshTimeoutError): errorMessage = QObject::tr("Timeout connecting to server"); break;
 
+    // Ssh scp errors
+    case(SshScpFailureError): errorMessage = QObject::tr("Scp error: Generic failure"); break;
+    case(SshScpOpenError): errorMessage = QObject::tr("Scp error: The file could not be opened"); break;
+    case(SshScpReadError): errorMessage = QObject::tr("Scp error: An error occurred when reading from the file"); break;
+    case(SshScpPermissionsError): errorMessage = QObject::tr("Scp error: The file could not be accessed"); break;
+    case(SshScpUnspecifiedError): errorMessage =  QObject::tr("Scp error: An unspecified error occurred"); break;
+
     // Local errors
     case (OpenVpnConfigMissing): errorMessage = QObject::tr("OpenVPN config missing"); break;
     case (OpenVpnManagementServerError): errorMessage = QObject::tr("OpenVPN management server error"); break;

--- a/client/core/sshclient.cpp
+++ b/client/core/sshclient.cpp
@@ -256,7 +256,7 @@ namespace libssh {
                     QByteArray chunk = fin.read(bufferSize);
                     if (chunk.size() != bufferSize) {
                         fin.close();
-                        return ErrorCode::SshSftpEofError;
+                        return ErrorCode::InternalError;
                     }
 
                     rc = ssh_scp_write(m_scpSession, chunk.data(), chunk.size());
@@ -272,7 +272,7 @@ namespace libssh {
                     QByteArray lastChunk = fin.read(lastChunkSize);
                     if (lastChunk.size() != lastChunkSize) {
                         fin.close();
-                        return ErrorCode::SshSftpEofError;
+                        return ErrorCode::InternalError;
                     }
 
                     rc = ssh_scp_write(m_scpSession, lastChunk.data(), lastChunk.size());

--- a/client/core/sshclient.cpp
+++ b/client/core/sshclient.cpp
@@ -328,6 +328,17 @@ namespace libssh {
         }
     }
 
+    ErrorCode Client::fromFileErrorCode(QFileDevice::FileError fileError)
+    {
+        switch (fileError) {
+        case QFileDevice::NoError: return ErrorCode::NoError;
+        case QFileDevice::ReadError: return ErrorCode::SshScpReadError;
+        case QFileDevice::OpenError: return ErrorCode::SshScpOpenError;
+        case QFileDevice::PermissionsError: return ErrorCode::SshScpPermissionsError;
+        default: return ErrorCode::SshScpUnspecifiedError;
+        }
+    }
+
     ErrorCode Client::getDecryptedPrivateKey(const ServerCredentials &credentials, QString &decryptedPrivateKey, const std::function<QString()> &passphraseCallback)
     {
         int authResult = SSH_ERROR;

--- a/client/core/sshclient.cpp
+++ b/client/core/sshclient.cpp
@@ -222,7 +222,7 @@ namespace libssh {
         return fromLibsshErrorCode();
     }
 
-    ErrorCode Client::scpFileCopy(const SftpOverwriteMode overwriteMode, const QString& localPath, const QString& remotePath, const QString &fileDesc)
+    ErrorCode Client::scpFileCopy(const ScpOverwriteMode overwriteMode, const QString& localPath, const QString& remotePath, const QString &fileDesc)
     {
         m_scpSession = ssh_scp_new(m_session, SSH_SCP_WRITE, remotePath.toStdString().c_str());
 

--- a/client/core/sshclient.cpp
+++ b/client/core/sshclient.cpp
@@ -315,10 +315,10 @@ namespace libssh {
     {
         switch (fileError) {
         case QFileDevice::NoError: return ErrorCode::NoError;
-        case QFileDevice::ReadError: return ErrorCode::SshScpReadError;
-        case QFileDevice::OpenError: return ErrorCode::SshScpOpenError;
-        case QFileDevice::PermissionsError: return ErrorCode::SshScpPermissionsError;
-        default: return ErrorCode::SshScpUnspecifiedError;
+        case QFileDevice::ReadError: return ErrorCode::ReadError;
+        case QFileDevice::OpenError: return ErrorCode::OpenError;
+        case QFileDevice::PermissionsError: return ErrorCode::PermissionsError;
+        default: return ErrorCode::UnspecifiedError;
         }
     }
 

--- a/client/core/sshclient.cpp
+++ b/client/core/sshclient.cpp
@@ -165,13 +165,13 @@ namespace libssh {
                     return ErrorCode::NoError;
                 };
 
-                auto error = readOutput(false);
-                if (error != ErrorCode::NoError) {
-                    return error;
+                auto errorCode = readOutput(false);
+                if (errorCode != ErrorCode::NoError) {
+                    return errorCode;
                 }
-                error = readOutput(true);
-                if (error != ErrorCode::NoError) {
-                    return error;
+                errorCode = readOutput(true);
+                if (errorCode != ErrorCode::NoError) {
+                    return errorCode;
                 }
             } else {
                 return closeChannel();
@@ -225,9 +225,9 @@ namespace libssh {
         }
 
         if (ssh_scp_init(m_scpSession) != SSH_OK) {
-            auto re = fromLibsshErrorCode();
+            auto errorCode = fromLibsshErrorCode();
             closeScpSession();
-            return re;
+            return errorCode;
         }
 
         QFutureWatcher<ErrorCode> watcher;
@@ -236,8 +236,8 @@ namespace libssh {
             const int accessType = O_WRONLY | O_CREAT | overwriteMode;
             const int localFileSize = QFileInfo(localPath).size();
 
-            int rc = ssh_scp_push_file(m_scpSession, remotePath.toStdString().c_str(), localFileSize, accessType);
-            if (rc != SSH_OK) {
+            int result = ssh_scp_push_file(m_scpSession, remotePath.toStdString().c_str(), localFileSize, accessType);
+            if (result != SSH_OK) {
                 return fromLibsshErrorCode();
             }
 
@@ -260,8 +260,8 @@ namespace libssh {
                         return fromFileErrorCode(fin.error());
                     }
 
-                    rc = ssh_scp_write(m_scpSession, chunk.data(), chunk.size());
-                    if (rc != SSH_OK) {
+                    result = ssh_scp_write(m_scpSession, chunk.data(), chunk.size());
+                    if (result != SSH_OK) {
                         return fromLibsshErrorCode();
                     }
 

--- a/client/core/sshclient.cpp
+++ b/client/core/sshclient.cpp
@@ -318,6 +318,8 @@ namespace libssh {
         case QFileDevice::ReadError: return ErrorCode::ReadError;
         case QFileDevice::OpenError: return ErrorCode::OpenError;
         case QFileDevice::PermissionsError: return ErrorCode::PermissionsError;
+        case QFileDevice::FatalError: return ErrorCode::FatalError;
+        case QFileDevice::AbortError: return ErrorCode::AbortError;
         default: return ErrorCode::UnspecifiedError;
         }
     }

--- a/client/core/sshclient.cpp
+++ b/client/core/sshclient.cpp
@@ -14,12 +14,6 @@ namespace libssh {
 
     std::function<QString()> Client::m_passphraseCallback;
 
-    Client::Client(QObject *parent) : QObject(parent)
-    { }
-
-    Client::~Client()
-    { }
-
     int Client::callback(const char *prompt, char *buf, size_t len, int echo, int verify, void *userdata)
     {
         auto passphrase = m_passphraseCallback();

--- a/client/core/sshclient.cpp
+++ b/client/core/sshclient.cpp
@@ -275,7 +275,7 @@ namespace libssh {
                         return ErrorCode::SshSftpEofError;
                     }
 
-                    rc = ssh_scp_write(m_scpSession, lastChunk.data(), lastChunkSize);
+                    rc = ssh_scp_write(m_scpSession, lastChunk.data(), lastChunk.size());
                     if (rc != SSH_OK) {
                         fin.close();
                         return closeScpSession();
@@ -300,12 +300,11 @@ namespace libssh {
 
     ErrorCode Client::closeScpSession()
     {
-        auto errorCode = fromLibsshSftpErrorCode(ssh_get_error_code(m_scpSession));
+        auto errorCode = fromLibsshErrorCode();
         if (m_scpSession != nullptr) {
             ssh_scp_free(m_scpSession);
             m_scpSession = nullptr;
         }
-        qCritical() << ssh_get_error(m_session);
         return errorCode;
     }
 
@@ -326,27 +325,6 @@ namespace libssh {
         case(SSH_EINTR): return ErrorCode::SshInterruptedError;
         case(SSH_FATAL): return ErrorCode::SshInternalError;
         default: return ErrorCode::SshInternalError;
-        }
-    }
-
-    ErrorCode Client::fromLibsshSftpErrorCode(int errorCode)
-    {
-        switch (errorCode) {
-        case(SSH_FX_OK): return ErrorCode::NoError;
-        case(SSH_FX_EOF): return ErrorCode::SshSftpEofError;
-        case(SSH_FX_NO_SUCH_FILE): return ErrorCode::SshSftpNoSuchFileError;
-        case(SSH_FX_PERMISSION_DENIED): return ErrorCode::SshSftpPermissionDeniedError;
-        case(SSH_FX_FAILURE): return ErrorCode::SshSftpFailureError;
-        case(SSH_FX_BAD_MESSAGE): return ErrorCode::SshSftpBadMessageError;
-        case(SSH_FX_NO_CONNECTION): return ErrorCode::SshSftpNoConnectionError;
-        case(SSH_FX_CONNECTION_LOST): return ErrorCode::SshSftpConnectionLostError;
-        case(SSH_FX_OP_UNSUPPORTED): return ErrorCode::SshSftpOpUnsupportedError;
-        case(SSH_FX_INVALID_HANDLE): return ErrorCode::SshSftpInvalidHandleError;
-        case(SSH_FX_NO_SUCH_PATH): return ErrorCode::SshSftpNoSuchPathError;
-        case(SSH_FX_FILE_ALREADY_EXISTS): return ErrorCode::SshSftpFileAlreadyExistsError;
-        case(SSH_FX_WRITE_PROTECT): return ErrorCode::SshSftpWriteProtectError;
-        case(SSH_FX_NO_MEDIA): return ErrorCode::SshSftpNoMediaError;
-        default: return ErrorCode::SshSftpFailureError;
         }
     }
 

--- a/client/core/sshclient.cpp
+++ b/client/core/sshclient.cpp
@@ -10,7 +10,7 @@ const uint32_t S_IRWXU = 0644;
 #endif
 
 namespace libssh {
-    const QString libsshTimeoutError = "Timeout connecting to";
+    constexpr auto libsshTimeoutError{"Timeout connecting to"};
 
     std::function<QString()> Client::m_passphraseCallback;
 

--- a/client/core/sshclient.h
+++ b/client/core/sshclient.h
@@ -32,26 +32,26 @@ namespace libssh {
                                  const std::function<ErrorCode (const QString &, Client &)> &cbReadStdOut,
                                  const std::function<ErrorCode (const QString &, Client &)> &cbReadStdErr);
         ErrorCode writeResponse(const QString &data);
-        ErrorCode sftpFileCopy(const SftpOverwriteMode overwriteMode,
+        ErrorCode scpFileCopy(const SftpOverwriteMode overwriteMode,
                                const std::string& localPath,
                                const std::string& remotePath,
                                const std::string& fileDesc);
         ErrorCode getDecryptedPrivateKey(const ServerCredentials &credentials, QString &decryptedPrivateKey, const std::function<QString()> &passphraseCallback);
     private:
         ErrorCode closeChannel();
-        ErrorCode closeSftpSession();
+        ErrorCode closeScpSession();
         ErrorCode fromLibsshErrorCode();
         ErrorCode fromLibsshSftpErrorCode(int errorCode);
         static int callback(const char *prompt, char *buf, size_t len, int echo, int verify, void *userdata);
 
         ssh_session m_session = nullptr;
         ssh_channel m_channel = nullptr;
-        sftp_session m_sftpSession = nullptr;
+        ssh_scp m_scpSession = nullptr;
 
         static std::function<QString()> m_passphraseCallback;
     signals:
         void writeToChannelFinished();
-        void sftpFileCopyFinished();
+        void scpFileCopyFinished();
     };
 }
 

--- a/client/core/sshclient.h
+++ b/client/core/sshclient.h
@@ -6,7 +6,6 @@
 #include <fcntl.h>
 
 #include <libssh/libssh.h>
-#include <libssh/sftp.h>
 
 #include "defs.h"
 
@@ -41,7 +40,6 @@ namespace libssh {
         ErrorCode closeChannel();
         ErrorCode closeScpSession();
         ErrorCode fromLibsshErrorCode();
-        ErrorCode fromLibsshSftpErrorCode(int errorCode);
         static int callback(const char *prompt, char *buf, size_t len, int echo, int verify, void *userdata);
 
         ssh_session m_session = nullptr;

--- a/client/core/sshclient.h
+++ b/client/core/sshclient.h
@@ -2,6 +2,7 @@
 #define SSHCLIENT_H
 
 #include <QObject>
+#include <QFile>
 
 #include <fcntl.h>
 
@@ -40,6 +41,7 @@ namespace libssh {
         ErrorCode closeChannel();
         ErrorCode closeScpSession();
         ErrorCode fromLibsshErrorCode();
+        ErrorCode fromFileErrorCode(QFileDevice::FileError fileError);
         static int callback(const char *prompt, char *buf, size_t len, int echo, int verify, void *userdata);
 
         ssh_session m_session = nullptr;

--- a/client/core/sshclient.h
+++ b/client/core/sshclient.h
@@ -35,11 +35,11 @@ namespace libssh {
         ErrorCode scpFileCopy(const ScpOverwriteMode overwriteMode,
                                const QString &localPath,
                                const QString &remotePath,
-                               const QString& fileDesc);
+                               const QString &fileDesc);
         ErrorCode getDecryptedPrivateKey(const ServerCredentials &credentials, QString &decryptedPrivateKey, const std::function<QString()> &passphraseCallback);
     private:
         ErrorCode closeChannel();
-        ErrorCode closeScpSession();
+        void closeScpSession();
         ErrorCode fromLibsshErrorCode();
         ErrorCode fromFileErrorCode(QFileDevice::FileError fileError);
         static int callback(const char *prompt, char *buf, size_t len, int echo, int verify, void *userdata);

--- a/client/core/sshclient.h
+++ b/client/core/sshclient.h
@@ -13,11 +13,11 @@
 using namespace amnezia;
 
 namespace libssh {
-    enum SftpOverwriteMode {
+    enum ScpOverwriteMode {
         /*! Overwrite any existing files */
-        SftpOverwriteExisting = O_TRUNC,
+        ScpOverwriteExisting = O_TRUNC,
         /*! Append new content if the file already exists */
-        SftpAppendToExisting = O_APPEND
+        ScpAppendToExisting = O_APPEND
     };
     class Client : public QObject
     {
@@ -32,7 +32,7 @@ namespace libssh {
                                  const std::function<ErrorCode (const QString &, Client &)> &cbReadStdOut,
                                  const std::function<ErrorCode (const QString &, Client &)> &cbReadStdErr);
         ErrorCode writeResponse(const QString &data);
-        ErrorCode scpFileCopy(const SftpOverwriteMode overwriteMode,
+        ErrorCode scpFileCopy(const ScpOverwriteMode overwriteMode,
                                const QString &localPath,
                                const QString &remotePath,
                                const QString& fileDesc);

--- a/client/core/sshclient.h
+++ b/client/core/sshclient.h
@@ -23,8 +23,8 @@ namespace libssh {
     {
         Q_OBJECT
     public:
-        Client(QObject *parent = nullptr);
-        ~Client();
+        Client() = default;
+        ~Client() = default;
 
         ErrorCode connectToHost(const ServerCredentials &credentials);
         void disconnectFromHost();


### PR DESCRIPTION
Replacing the libssh::Client::sftpFileCopy  wtih libssh::Client::scpFileCopy. (#428)