### PR TITLE
resetting QR page content when generating a QR code after the first time

### DIFF
--- a/client/ui/controllers/exportController.cpp
+++ b/client/ui/controllers/exportController.cpp
@@ -418,4 +418,6 @@ void ExportController::clearPreviousConfig()
     m_config.clear();
     m_nativeConfigString.clear();
     m_qrCodes.clear();
+
+    emit exportConfigChanged();
 }

--- a/client/ui/qml/Components/ShareConnectionDrawer.qml
+++ b/client/ui/qml/Components/ShareConnectionDrawer.qml
@@ -279,6 +279,8 @@ DrawerType2 {
                 }
 
                 Rectangle {
+                    id: qrCodeContainer
+
                     Layout.fillWidth: true
                     Layout.preferredHeight: width
                     Layout.topMargin: 20


### PR DESCRIPTION
fixed the first-generated QR code is visible while generating another QR code bug