### PR TITLE
ISSUE: In start page, icon is highlighted not correctly when press ESC key

### DIFF
--- a/client/ui/qml/Pages2/PageStart.qml
+++ b/client/ui/qml/Pages2/PageStart.qml
@@ -43,9 +43,6 @@ PageType {
         }
 
         function onClosePage() {
-            tabBar.isServerInfoShow = tabBarStackView.currentItem.objectName !== PageController.getPagePath(PageEnum.PageSettingsServerInfo)
-                                        && tabBarStackView.currentItem.objectName !== PageController.getPagePath(PageEnum.PageSettingsSplitTunneling)
-
             if (tabBarStackView.depth <= 1) {
                 return
             }
@@ -60,8 +57,6 @@ PageType {
             } else {
                 tabBarStackView.push(pagePath, { "objectName" : pagePath }, StackView.Immediate)
             }
-
-            tabBar.isServerInfoShow = (page === PageEnum.PageSettingsServerInfo) || (page === PageEnum.PageSettingsSplitTunneling) || tabBar.isServerInfoShow
         }
 
         function onGoToStartPage() {
@@ -147,7 +142,6 @@ PageType {
             var pagePath = PageController.getPagePath(page)
             tabBarStackView.clear(StackView.Immediate)
             tabBarStackView.replace(pagePath, { "objectName" : pagePath }, StackView.Immediate)
-            tabBar.isServerInfoShow = false
         }
 
         Component.onCompleted: {
@@ -161,7 +155,6 @@ PageType {
         id: tabBar
 
         property int previousIndex: 0
-        property bool isServerInfoShow: false
 
         anchors.right: parent.right
         anchors.left: parent.left
@@ -192,7 +185,7 @@ PageType {
         }
 
         TabImageButtonType {
-            isSelected: tabBar.isServerInfoShow ? false : tabBar.currentIndex === 0
+            isSelected: tabBar.currentIndex === 0
             image: "qrc:/images/controls/home.svg"
             onClicked: {
                 tabBarStackView.goToTabBarPage(PageEnum.PageHome)
@@ -226,7 +219,7 @@ PageType {
         }
 
         TabImageButtonType {
-            isSelected: tabBar.isServerInfoShow ? true : tabBar.currentIndex === 2
+            isSelected: tabBar.currentIndex === 2
             image: "qrc:/images/controls/settings-2.svg"
             onClicked: {
                 tabBarStackView.goToTabBarPage(PageEnum.PageSettings)


### PR DESCRIPTION
ROOT CAUSE: The button state is decided by the attribute isServerInfoShow and it was added by commit 68fe20ddf637acc45e459f84d1619887e0501f4f. The logic to decide whether server info showed is not correct

ACTION: Revert commit 68fe20ddf637acc45e459f84d1619887e0501f4f