### PR TITLE
First element auto-focus disabled for the mobile platforms

### DIFF
--- a/client/ui/qml/Components/ShareConnectionDrawer.qml
+++ b/client/ui/qml/Components/ShareConnectionDrawer.qml
@@ -40,7 +40,7 @@ DrawerType2 {
 
         Connections {
             target: root
-
+            enabled: !GC.isMobile()
             function onOpened() {
                 header.forceActiveFocus()
             }

--- a/client/ui/qml/Controls2/PageType.qml
+++ b/client/ui/qml/Controls2/PageType.qml
@@ -2,6 +2,8 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 
+import "../Config"
+
 Item {
     id: root
 
@@ -32,6 +34,6 @@ Item {
             }
         }
         repeat: false // Stop the timer after one trigger
-        running: true // Start the timer
+        running: !GC.isMobile()  // Start the timer
     }
 }

--- a/client/ui/qml/Controls2/TextFieldWithHeaderType.qml
+++ b/client/ui/qml/Controls2/TextFieldWithHeaderType.qml
@@ -137,6 +137,7 @@ Item {
 //                    textColor: "#D7D8DB"
 //                    borderWidth: 0
 
+                    focusPolicy: Qt.NoFocus
                     text: root.buttonText
                     imageSource: root.buttonImageSource
 

--- a/client/ui/qml/Pages2/PageSettingsServerInfo.qml
+++ b/client/ui/qml/Pages2/PageSettingsServerInfo.qml
@@ -93,6 +93,7 @@ PageType {
 
                         Connections {
                             target: serverNameEditDrawer
+                            enabled: !GC.isMobile()
                             function onOpened() {
                                 serverName.textField.forceActiveFocus()
                             }

--- a/client/ui/qml/Pages2/PageShare.qml
+++ b/client/ui/qml/Pages2/PageShare.qml
@@ -648,6 +648,7 @@ PageType {
 
                                             Connections {
                                                 target: clientNameEditDrawer
+                                                enabled: !GC.isMobile()
                                                 function onOpened() {
                                                     clientNameEditor.textField.forceActiveFocus()
                                                 }


### PR DESCRIPTION
- Removed additional focus frames for buttons inside text fields.
- For mobile platforms, disabled auto-focus on the first element when navigating on the page.