### PR TITLE
ISSUE: Service is crashed after disconnecting

### DIFF
--- a/client/platforms/windows/daemon/windowstunnelservice.cpp
+++ b/client/platforms/windows/daemon/windowstunnelservice.cpp
@@ -58,7 +58,6 @@ void WindowsTunnelService::stop() {
   if (m_logworker) {
     m_logthread.quit();
     m_logthread.wait();
-    delete m_logworker;
     m_logworker = nullptr;
   }
 }
@@ -104,6 +103,7 @@ bool WindowsTunnelService::start(const QString& configData) {
 
   m_logworker = new WindowsTunnelLogger(WindowsCommons::tunnelLogFile());
   m_logworker->moveToThread(&m_logthread);
+  connect(&m_logthread, &QThread::finished, m_logworker, &QObject::deleteLater);
   m_logthread.start();
 
   SC_HANDLE scm = (SC_HANDLE)m_scm;


### PR DESCRIPTION
ROOT CAUSE: When disconnecting service, m_logworker is deleted in thread which does not have affinity with m_logworker.
			The time m_logworker is deleted, it may be used by m_logthread and make the service crashed

ACTION: Connect signal finished() of m_logthread to deleteLater() slot of m_logworker to safety delete it.