### PR TITLE
[macOS] Fix tray icon color states

### DIFF
--- a/client/ui/systemtray_notificationhandler.cpp
+++ b/client/ui/systemtray_notificationhandler.cpp
@@ -67,7 +67,9 @@ void SystemTrayNotificationHandler::onTranslationsUpdated()
 void SystemTrayNotificationHandler::setTrayIcon(const QString &iconPath)
 {
     QIcon trayIconMask(QPixmap(iconPath).scaled(128,128));
+#ifndef Q_OS_MAC
     trayIconMask.setIsMask(true);
+#endif
     m_systemTrayIcon.setIcon(trayIconMask);
 }
 


### PR DESCRIPTION
<img width="705" alt="image" src="https://github.com/amnezia-vpn/amnezia-client/assets/34045014/fecb1239-8239-4f75-bb65-48bd9c964587">
<img width="707" alt="image" src="https://github.com/amnezia-vpn/amnezia-client/assets/34045014/014cc842-9c57-4a84-a942-6386ed7f69b3">
<img width="705" alt="image" src="https://github.com/amnezia-vpn/amnezia-client/assets/34045014/60ed2eb3-8ffa-4375-b46c-7a5d2fdd0c3e">

Fixed this issue https://github.com/amnezia-vpn/amnezia-client/issues/59