### PR TITLE
hotfix for typo introduced in #857

### DIFF
--- a/client/translations/amneziavpn_ru_RU.ts
+++ b/client/translations/amneziavpn_ru_RU.ts
@@ -694,7 +694,7 @@ Already installed containers were found on the server. All installed containers 
     <message>
         <location filename="../ui/qml/Pages2/PageProtocolWireGuardSettings.qml" line="83"/>
         <source>Port</source>
-        <translation">Порт</translation>
+        <translation>Порт</translation>
     </message>
     <message>
         <location filename="../ui/qml/Pages2/PageProtocolWireGuardSettings.qml" line="102"/>


### PR DESCRIPTION
```
Parse error at /home/runner/work/amnezia-client/amnezia-client/client/translations/amneziavpn_ru_RU.ts:697:21: Expected '>' or '/', but got '"'.
```

I'm sorry for this!

Is it possible to manually trigger GitHub build workflows with the aim to spot such bugs before they go to `dev` branch?