### PR TITLE
Fix TorWebsite setup in UI

### DIFF
--- a/client/ui/qml/Pages2/PageSetupWizardProtocolSettings.qml
+++ b/client/ui/qml/Pages2/PageSetupWizardProtocolSettings.qml
@@ -261,7 +261,8 @@ PageType {
                             Keys.onTabPressed: lastItemTabClicked(focusItem)
 
                             clickedFunc: function() {
-                                if (!port.textField.acceptableInput) {
+                                if (!port.textField.acceptableInput &&
+                                        ContainerProps.containerTypeToString(dockerContainer) !== "torwebsite") {
                                     port.errorText = qsTr("The port must be in the range of 1 to 65535")
                                     return
                                 }


### PR DESCRIPTION
Fixes torwebsite container setup from UI. 
Without this fix "Install" button just do nothing for Tor container. 