### PR TITLE
Renaming OpenVPN over ShadowsSocks

### DIFF
--- a/client/containers/containers_defs.cpp
+++ b/client/containers/containers_defs.cpp
@@ -90,7 +90,7 @@ QMap<DockerContainer, QString> ContainerProps::containerHumanNames()
 {
     return { { DockerContainer::None, "Not installed" },
              { DockerContainer::OpenVpn, "OpenVPN" },
-             { DockerContainer::ShadowSocks, "ShadowSocks" },
+             { DockerContainer::ShadowSocks, "OpenVPN over SS" },
              { DockerContainer::Cloak, "OpenVPN over Cloak" },
              { DockerContainer::WireGuard, "WireGuard" },
              { DockerContainer::Awg, "AmneziaWG" },


### PR DESCRIPTION
Renaming OpenVPN over ShadowsSocks to avoid confusion with the SSXray name.