### PR TITLE
fix start Minimized feature issue on linux, Closes  #1016

### DIFF
--- a/client/ui/controllers/pageController.cpp
+++ b/client/ui/controllers/pageController.cpp
@@ -135,6 +135,8 @@ void PageController::showOnStartup()
         emit hideMainWindow();
 #elif defined Q_OS_MACX
         setDockIconVisible(false);
+#elif defined Q_OS_LINUX
+        emit hideMainWindow();
 #endif
     }
 }

--- a/client/ui/controllers/pageController.cpp
+++ b/client/ui/controllers/pageController.cpp
@@ -131,12 +131,10 @@ void PageController::showOnStartup()
     if (!m_settings->isStartMinimized()) {
         emit raiseMainWindow();
     } else {
-#ifdef Q_OS_WIN
+#if defined(Q_OS_WIN) || defined(Q_OS_LINUX)
         emit hideMainWindow();
 #elif defined Q_OS_MACX
         setDockIconVisible(false);
-#elif defined Q_OS_LINUX
-        emit hideMainWindow();
 #endif
     }
 }


### PR DESCRIPTION
As the issue #1016 says: the "start minimized" option in amnezia settings wasn't working on Linux, I fixed it.