### PR TITLE
Added list of AllowedIPs for WireGuard/AWG connections on Share -> Users ->ExpandedContent page

### DIFF
--- a/client/ui/models/clientManagementModel.cpp
+++ b/client/ui/models/clientManagementModel.cpp
@@ -20,6 +20,7 @@ namespace
         constexpr char latestHandshake[] = "latestHandshake";
         constexpr char dataReceived[] = "dataReceived";
         constexpr char dataSent[] = "dataSent";
+        constexpr char allowedIPs[] = "allowedIPs";
     }
 }
 
@@ -49,6 +50,7 @@ QVariant ClientManagementModel::data(const QModelIndex &index, int role) const
     case LatestHandshakeRole: return userData.value(configKey::latestHandshake).toString();
     case DataReceivedRole: return userData.value(configKey::dataReceived).toString();
     case DataSentRole: return userData.value(configKey::dataSent).toString();
+    case AllowedIPsRole: return userData.value(configKey::allowedIPs).toString();
     }
 
     return QVariant();
@@ -139,6 +141,10 @@ ErrorCode ClientManagementModel::updateModel(const DockerContainer container, co
 
                     if (!client.dataSent.isEmpty()) {
                         userData[configKey::dataSent] = client.dataSent;
+                    }
+
+                    if (!client.allowedIPs.isEmpty()) {
+                        userData[configKey::allowedIPs] = client.allowedIPs;
                     }
 
                     obj[configKey::userData] = userData;
@@ -266,8 +272,9 @@ ErrorCode ClientManagementModel::wgShow(const DockerContainer container, const S
     const auto peerList = parts.filter("peer:");
     const auto latestHandshakeList = parts.filter("latest handshake:");
     const auto transferredDataList = parts.filter("transfer:");
+    const auto allowedIPsList = parts.filter("allowed ips:");
 
-    if (latestHandshakeList.isEmpty() || transferredDataList.isEmpty() || peerList.isEmpty()) {
+    if (allowedIPsList.isEmpty() || latestHandshakeList.isEmpty() || transferredDataList.isEmpty() || peerList.isEmpty()) {
         return error;
     }
 
@@ -281,19 +288,20 @@ ErrorCode ClientManagementModel::wgShow(const DockerContainer container, const S
         }
     };
 
-    for (int i = 0; i < peerList.size() && i < transferredDataList.size() && i < latestHandshakeList.size(); ++i) {
+    for (int i = 0; i < peerList.size() && i < transferredDataList.size() && i < latestHandshakeList.size() && i < allowedIPsList.size(); ++i) {
 
         const auto transferredData = getStrValue(transferredDataList[i]).split(",");
         auto latestHandshake = getStrValue(latestHandshakeList[i]);
         auto serverBytesReceived = transferredData.front().trimmed();
         auto serverBytesSent = transferredData.back().trimmed();
+        auto allowedIPs = getStrValue(allowedIPsList[i]);
 
         changeHandshakeFormat(latestHandshake);
 
         serverBytesReceived.chop(QStringLiteral(" received").length());
         serverBytesSent.chop(QStringLiteral(" sent").length());
 
-        data.push_back({ getStrValue(peerList[i]), latestHandshake, serverBytesSent, serverBytesReceived });
+        data.push_back({ getStrValue(peerList[i]), latestHandshake, serverBytesSent, serverBytesReceived, allowedIPs });
     }
 
     return error;

--- a/client/ui/models/clientManagementModel.cpp
+++ b/client/ui/models/clientManagementModel.cpp
@@ -20,7 +20,7 @@ namespace
         constexpr char latestHandshake[] = "latestHandshake";
         constexpr char dataReceived[] = "dataReceived";
         constexpr char dataSent[] = "dataSent";
-        constexpr char allowedIPs[] = "allowedIPs";
+        constexpr char allowedIps[] = "allowedIps";
     }
 }
 
@@ -50,7 +50,7 @@ QVariant ClientManagementModel::data(const QModelIndex &index, int role) const
     case LatestHandshakeRole: return userData.value(configKey::latestHandshake).toString();
     case DataReceivedRole: return userData.value(configKey::dataReceived).toString();
     case DataSentRole: return userData.value(configKey::dataSent).toString();
-    case AllowedIPsRole: return userData.value(configKey::allowedIPs).toString();
+    case AllowedIpsRole: return userData.value(configKey::allowedIps).toString();
     }
 
     return QVariant();
@@ -143,8 +143,8 @@ ErrorCode ClientManagementModel::updateModel(const DockerContainer container, co
                         userData[configKey::dataSent] = client.dataSent;
                     }
 
-                    if (!client.allowedIPs.isEmpty()) {
-                        userData[configKey::allowedIPs] = client.allowedIPs;
+                    if (!client.allowedIps.isEmpty()) {
+                        userData[configKey::allowedIps] = client.allowedIps;
                     }
 
                     obj[configKey::userData] = userData;
@@ -272,9 +272,9 @@ ErrorCode ClientManagementModel::wgShow(const DockerContainer container, const S
     const auto peerList = parts.filter("peer:");
     const auto latestHandshakeList = parts.filter("latest handshake:");
     const auto transferredDataList = parts.filter("transfer:");
-    const auto allowedIPsList = parts.filter("allowed ips:");
+    const auto allowedIpsList = parts.filter("allowed ips:");
 
-    if (allowedIPsList.isEmpty() || latestHandshakeList.isEmpty() || transferredDataList.isEmpty() || peerList.isEmpty()) {
+    if (allowedIpsList.isEmpty() || latestHandshakeList.isEmpty() || transferredDataList.isEmpty() || peerList.isEmpty()) {
         return error;
     }
 
@@ -288,20 +288,20 @@ ErrorCode ClientManagementModel::wgShow(const DockerContainer container, const S
         }
     };
 
-    for (int i = 0; i < peerList.size() && i < transferredDataList.size() && i < latestHandshakeList.size() && i < allowedIPsList.size(); ++i) {
+    for (int i = 0; i < peerList.size() && i < transferredDataList.size() && i < latestHandshakeList.size() && i < allowedIpsList.size(); ++i) {
 
         const auto transferredData = getStrValue(transferredDataList[i]).split(",");
         auto latestHandshake = getStrValue(latestHandshakeList[i]);
         auto serverBytesReceived = transferredData.front().trimmed();
         auto serverBytesSent = transferredData.back().trimmed();
-        auto allowedIPs = getStrValue(allowedIPsList[i]);
+        auto allowedIps = getStrValue(allowedIpsList[i]);
 
         changeHandshakeFormat(latestHandshake);
 
         serverBytesReceived.chop(QStringLiteral(" received").length());
         serverBytesSent.chop(QStringLiteral(" sent").length());
 
-        data.push_back({ getStrValue(peerList[i]), latestHandshake, serverBytesSent, serverBytesReceived, allowedIPs });
+        data.push_back({ getStrValue(peerList[i]), latestHandshake, serverBytesSent, serverBytesReceived, allowedIps });
     }
 
     return error;

--- a/client/ui/models/clientManagementModel.h
+++ b/client/ui/models/clientManagementModel.h
@@ -17,7 +17,8 @@ public:
         CreationDateRole,
         LatestHandshakeRole,
         DataReceivedRole,
-        DataSentRole
+        DataSentRole,
+        AllowedIPsRole
     };
 
     struct WgShowData
@@ -26,6 +27,7 @@ public:
         QString latestHandshake;
         QString dataReceived;
         QString dataSent;
+        QString allowedIPs;
     };
 
     ClientManagementModel(std::shared_ptr<Settings> settings, QObject *parent = nullptr);

--- a/client/ui/models/clientManagementModel.h
+++ b/client/ui/models/clientManagementModel.h
@@ -18,7 +18,7 @@ public:
         LatestHandshakeRole,
         DataReceivedRole,
         DataSentRole,
-        AllowedIPsRole
+        AllowedIpsRole
     };
 
     struct WgShowData
@@ -27,7 +27,7 @@ public:
         QString latestHandshake;
         QString dataReceived;
         QString dataSent;
-        QString allowedIPs;
+        QString allowedIps;
     };
 
     ClientManagementModel(std::shared_ptr<Settings> settings, QObject *parent = nullptr);

--- a/client/ui/qml/Pages2/PageShare.qml
+++ b/client/ui/qml/Pages2/PageShare.qml
@@ -840,6 +840,14 @@ PageType {
 
                                         text: qsTr("Data sent: %1").arg(dataSent)
                                     }
+
+                                    ParagraphTextType {
+                                        color: textColumn.textColor
+                                        visible: allowedIPs
+                                        Layout.fillWidth: true
+
+                                        text: qsTr("Allowed IPs: %1").arg(allowedIPs)
+                                    }
                                 }
 
                                 Item {

--- a/client/ui/qml/Pages2/PageShare.qml
+++ b/client/ui/qml/Pages2/PageShare.qml
@@ -843,10 +843,10 @@ PageType {
 
                                     ParagraphTextType {
                                         color: textColumn.textColor
-                                        visible: allowedIPs
+                                        visible: allowedIps
                                         Layout.fillWidth: true
 
-                                        text: qsTr("Allowed IPs: %1").arg(allowedIPs)
+                                        text: qsTr("Allowed IPs: %1").arg(allowedIps)
                                     }
                                 }
 


### PR DESCRIPTION
This code fully based on the previously merged PR from fameowner99: https://github.com/amnezia-vpn/amnezia-client/pull/764

This PR just adds the additional row with **AllowedIPs** list on Share -> Users page -> Expandable Pane.

AmneziaVPN is a perfect VPN solution but in my case I would like also to access from one device to another inside the VPN network.

So the field 'Allowed IPS' could be very useful for see the list IPs for each user, **without going to the server console**. For e.g.:
- Client1: `Allowed IPs: 10.8.1.2/32`
- Client2: `Allowed IPs: 10.8.1.3/32, 192.168.2.0/24`

The field is optional same to other fields there and just will be hidden if no data available.

Thanks! Hope you can merge this =)