### PR TITLE
Introducing Amnezia VPN Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 [![Build Status](https://github.com/amnezia-vpn/amnezia-client/actions/workflows/deploy.yml/badge.svg?branch=dev)](https://github.com/amnezia-vpn/amnezia-client/actions/workflows/deploy.yml?query=branch:dev)
 [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/amnezia-vpn/amnezia-client)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Amnezia%20VPN%20Guru-006BFF)](https://gurubase.io/g/amnezia-vpn)
 
 Amnezia is an open-source VPN client, with a key feature that enables you to deploy your own VPN server on your server.
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Amnezia VPN Guru](https://gurubase.io/g/amnezia-vpn) to Gurubase. Amnezia VPN Guru uses the data from this repo and data from the [docs](https://docs.amnezia.org/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Amnezia VPN Guru", which highlights that Amnezia VPN now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Amnezia VPN Guru in Gurubase, just let me know that's totally fine.
