### PR TITLE
SteamDeck/OS installation fix

### DIFF
--- a/deploy/data/linux/post_install.sh
+++ b/deploy/data/linux/post_install.sh
@@ -19,6 +19,11 @@ date > $LOG_FILE
 echo "Script started" >> $LOG_FILE
 sudo killall -9 $APP_NAME 2>> $LOG_FILE
 
+if command -v steamos-readonly &> /dev/null; then
+        sudo steamos-readonly disable >> $LOG_FILE
+        echo "steamos-readonly disabled" >> $LOG_FILE
+fi
+
 if sudo systemctl is-active --quiet $APP_NAME; then
 	sudo systemctl stop $APP_NAME >> $LOG_FILE
 	sudo systemctl disable $APP_NAME >> $LOG_FILE
@@ -41,6 +46,11 @@ sudo cp $APP_PATH/$APP_NAME.png /usr/share/pixmaps/ >> $LOG_FILE
 sudo chmod 555 /usr/share/applications/$APP_NAME.desktop >> $LOG_FILE
 
 echo "user desktop creation loop ended" >> $LOG_FILE
+
+if command -v steamos-readonly &> /dev/null; then
+        sudo steamos-readonly enable >> $LOG_FILE
+        echo "steamos-readonly enabled" >> $LOG_FILE
+fi
 
 date >> $LOG_FILE
 echo "Service status:" >> $LOG_FILE

--- a/deploy/data/linux/post_uninstall.sh
+++ b/deploy/data/linux/post_uninstall.sh
@@ -13,6 +13,11 @@ date >> $LOG_FILE
 echo "Uninstall Script started" >> $LOG_FILE
 sudo killall -9 $APP_NAME 2>> $LOG_FILE
 
+if command -v steamos-readonly &> /dev/null; then
+	sudo steamos-readonly disable >> $LOG_FILE
+	echo "steamos-readonly disabled" >> $LOG_FILE
+fi
+
 ls /opt/AmneziaVPN/client/lib/* | while IFS=: read -r dir; do
 	sudo unlink $dir  >> $LOG_FILE
 done
@@ -57,6 +62,11 @@ fi
 if test -f /usr/share/pixmaps/$APP_NAME.png; then
 	sudo rm -f /usr/share/pixmaps/$APP_NAME.png >> $LOG_FILE
 
+fi
+
+if command -v steamos-readonly &> /dev/null; then
+	sudo steamos-readonly enable >> $LOG_FILE
+	echo "steamos-readonly enabled" >> $LOG_FILE
 fi
 
 date >> $LOG_FILE


### PR DESCRIPTION
By default SteamOS has read-only file system so post-install/uninstall scripts can't create app descriptions files and links.