### PR TITLE
fix: segmentation violation due to missing return

### DIFF
--- a/client/utilities.cpp
+++ b/client/utilities.cpp
@@ -248,7 +248,7 @@ bool Utils::killProcessByName(const QString &name)
 #elif defined Q_OS_IOS || defined(Q_OS_ANDROID)
     return false;
 #else
-    QProcess::execute(QString("pkill %1").arg(name));
+    return QProcess::execute(QString("pkill %1").arg(name)) == 0;
 #endif
 }
 


### PR DESCRIPTION
Fixed `SIGSEGV` that appears when amnezia service tries to kill a child process.
Segfault coredump looks like
```
Module .AmneziaVPN-service-wrapped without build-id.
Stack trace of thread 14640:
#0  0x00000000004246a9 Utils::killProcessByName(QString) (.AmneziaVPN-service-wrapped + 0x246a9)
#1  0x000000000042d4df IpcServerProcess::start() (.AmneziaVPN-service-wrapped + 0x2d4df)
#2  0x0000000000485b63 IpcProcessInterfaceSource::qt_metacall(QMetaObject::Call, int, void**) (.AmneziaVPN-service-wrapped + 0x85b63)
#3  0x00007f35755b9545 QRemoteObjectSourceBase::invoke(QMetaObject::Call, int, QList<QVariant> const&, void*) (libQt6RemoteObjects.so.6 + 0xba545)
#4  0x00007f35755c4196 QRemoteObjectSourceIo::onServerRead(QObject*) (libQt6RemoteObjects.so.6 + 0xc5196)
#5  0x00007f35741f961b doActivate(QObject*, int, void**) (libQt6Core.so.6 + 0x1f961b)
#6  0x00007f35741f961b doActivate(QObject*, int, void**) (libQt6Core.so.6 + 0x1f961b)
#7  0x00007f35741f9bdc doActivate(QObject*, int, void**) (libQt6Core.so.6 + 0x1f9bdc)
#8  0x00007f35752d6827 QAbstractSocketPrivate::canReadNotification() (libQt6Network.so.6 + 0xd6827)
#9  0x00007f35752df519 QReadNotifier::event(QEvent*) (libQt6Network.so.6 + 0xdf519)
#10 0x00007f357419691d QCoreApplication::notifyInternal2(QObject*, QEvent*) (libQt6Core.so.6 + 0x19691d)
#11 0x00007f3574476194 socketNotifierSourceDispatch(_GSource*, int (*)(void*), void*) (libQt6Core.so.6 + 0x476194)
#12 0x00007f357130b571 g_main_context_dispatch_unlocked (libglib-2.0.so.0 + 0x60571)
#13 0x00007f357130d6b0 g_main_context_iterate_unlocked.isra.0 (libglib-2.0.so.0 + 0x626b0)
#14 0x00007f357130de9c g_main_context_iteration (libglib-2.0.so.0 + 0x62e9c)
#15 0x00007f3574474f51 QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) (libQt6Core.so.6 + 0x474f51)
#16 0x00007f35741a39fa QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) (libQt6Core.so.6 + 0x1a39fa)
#17 0x00007f357419f166 QCoreApplication::exec() (libQt6Core.so.6 + 0x19f166)
#18 0x0000000000431ca0 runApplication(int, char**) (.AmneziaVPN-service-wrapped + 0x31ca0)
#19 0x00007f3573a3127e __libc_start_call_main (libc.so.6 + 0x2a27e)
#20 0x00007f3573a31339 __libc_start_main (libc.so.6 + 0x2a339)
#21 0x000000000041e6f5 _start (.AmneziaVPN-service-wrapped + 0x1e6f5)
```