### PR TITLE
fix: adding second new VMess links now works

### DIFF
--- a/client/core/serialization/vmess_new.cpp
+++ b/client/core/serialization/vmess_new.cpp
@@ -104,7 +104,7 @@ QJsonObject Deserialize(const QString &vmessStr, QString *alias, QString *errMes
         server.users.first().security = "auto";
     }
 
-    const static auto getQueryValue = [&query](const QString &key, const QString &defaultValue) {
+    const auto getQueryValue = [&query](const QString &key, const QString &defaultValue) {
         if (query.hasQueryItem(key))
             return query.queryItemValue(key, QUrl::FullyDecoded);
         else


### PR DESCRIPTION
When a second new-style VMess link was added, it was not parsed correctly, since `static` caused the lambda to use `query` reference from the first function invocation.

To repro: Add a new-style VMess link (e.g., `vmess://http+tls:0c3994d8-c709-4b2b-9547-3e971325831a@1.2.3.4:44332?host=lol.xyz&path=/1&tlsServerName=lol.xyz`), use "Show content" button to check that it was parsed correctly. Then add another one (e.g., `vmess://http+tls:14974c49-5682-4e35-8ce2-9ea1057ea967@5.6.7.8:21100?host=lol.wtf&path=/2&tlsServerName=lol.wtf`), and use "Show content" button to see that it was *not* parsed correctly (in this example, `httpSettings.host`, `httpSettings.path`, and `tlsSettings.serverName` are garbage).