### PR TITLE
bugfix: Correctly use QProcess::start and QProcess::execute

### DIFF
--- a/client/utilities.cpp
+++ b/client/utilities.cpp
@@ -194,8 +194,13 @@ bool Utils::processIsRunning(const QString &fileName, const bool fullFlag)
     return false;
 #else
     QProcess process;
+    QStringList arguments;
+    if (fullFlag) {
+        arguments << "-f";
+    }
+    arguments << fileName;
     process.setProcessChannelMode(QProcess::MergedChannels);
-    process.start("pgrep", QStringList({ fullFlag ? "-f" : "", fileName }));
+    process.start("pgrep", arguments);
     process.waitForFinished();
     if (process.exitStatus() == QProcess::NormalExit) {
         if (fullFlag) {
@@ -248,7 +253,7 @@ bool Utils::killProcessByName(const QString &name)
 #elif defined Q_OS_IOS || defined(Q_OS_ANDROID)
     return false;
 #else
-    return QProcess::execute(QString("pkill %1").arg(name)) == 0;
+    return QProcess::execute("pkill", { name }) == 0;
 #endif
 }
 

--- a/service/server/router_linux.cpp
+++ b/service/server/router_linux.cpp
@@ -162,11 +162,11 @@ void RouterLinux::flushDns()
         || QFileInfo::exists("/usr/sbin/nscd")
         || QFileInfo::exists("/usr/lib/systemd/system/nscd.service"))
     {
-        p.start("systemctl restart nscd");
+        p.start("systemctl", { "restart", "nscd" });
     }
     else
     {
-        p.start("systemctl restart systemd-resolved");
+        p.start("systemctl", { "restart", "systemd-resolved" });
     }
 
     p.waitForFinished();


### PR DESCRIPTION
Affected functions (all on Linux/Mac):
 - `RouterLinux::flushDns` was not reloading the DNS manager.
 - `Utils::processIsRunning` was always saying that the process is not running when `fullFlag` was set to `false`.
 - `Utils::killProcessByName` was not killing anything.