### PR TITLE
fix: rewrite linux router dns flusher

### DIFF
--- a/service/server/router_linux.h
+++ b/service/server/router_linux.h
@@ -43,6 +43,7 @@ private:
     RouterLinux(RouterLinux const &) = delete;
     RouterLinux& operator= (RouterLinux const&) = delete;
 
+    bool isServiceActive(const QString &serviceName);
     QList<Route> m_addedRoutes;
     DnsUtilsLinux *m_dnsUtil;
 };


### PR DESCRIPTION
Rewrite the current linux's router method that finds out which DNS manager is being used from checking the `.service` path to `systemctl list-units`.
Context: https://github.com/NixOS/nixpkgs/pull/367972#discussion_r1900237580