### PR TITLE
Error handling for cgroup

### DIFF
--- a/client/core/controllers/serverController.cpp
+++ b/client/core/controllers/serverController.cpp
@@ -444,12 +444,12 @@ ErrorCode ServerController::buildContainerWorker(const ServerCredentials &creden
         return ErrorCode::NoError;
     };
 
-    errorCode error =
+    ErrorCode error =
             runScript(credentials,
                       replaceVars(amnezia::scriptData(SharedScriptType::build_container), genVarsForScript(credentials, container, config)),
                       cbReadStdOut, cbReadStdErr);
     
-    if (stdOut.contains("runc doesn't work on cgroups v2") )
+    if (stdOut.contains("runc doesn't work on cgroups v2"))
         return ErrorCode::ServerRuncNotWorkOnCgroupsV2;
 
     return error;

--- a/client/core/controllers/serverController.cpp
+++ b/client/core/controllers/serverController.cpp
@@ -439,15 +439,20 @@ ErrorCode ServerController::buildContainerWorker(const ServerCredentials &creden
         stdOut += data + "\n";
         return ErrorCode::NoError;
     };
+    auto cbReadStdErr = [&](const QString &data, libssh::Client &) {
+        stdOut += data + "\n";
+        return ErrorCode::NoError;
+    };
 
-    errorCode =
+    errorCode error =
             runScript(credentials,
                       replaceVars(amnezia::scriptData(SharedScriptType::build_container), genVarsForScript(credentials, container, config)),
-                      cbReadStdOut);
-    if (errorCode)
-        return errorCode;
+                      cbReadStdOut, cbReadStdErr);
+    
+    if (stdOut.contains("runc doesn't work on cgroups v2") )
+        return ErrorCode::ServerRuncNotWorkOnCgroupsV2;
 
-    return errorCode;
+    return error;
 }
 
 ErrorCode ServerController::runContainerWorker(const ServerCredentials &credentials, DockerContainer container, QJsonObject &config)

--- a/client/core/controllers/serverController.cpp
+++ b/client/core/controllers/serverController.cpp
@@ -465,7 +465,7 @@ ErrorCode ServerController::runContainerWorker(const ServerCredentials &credenti
     ErrorCode e = runScript(credentials,
                             replaceVars(amnezia::scriptData(ProtocolScriptType::run_container, container),
                                         genVarsForScript(credentials, container, config)),
-                            cbReadStdOut);
+                            cbReadStdOut, cbReadStdErr);
 
     if (stdOut.contains("address already in use"))
         return ErrorCode::ServerPortAlreadyAllocatedError;

--- a/client/core/controllers/serverController.cpp
+++ b/client/core/controllers/serverController.cpp
@@ -439,15 +439,11 @@ ErrorCode ServerController::buildContainerWorker(const ServerCredentials &creden
         stdOut += data + "\n";
         return ErrorCode::NoError;
     };
-    auto cbReadStdErr = [&](const QString &data, libssh::Client &) {
-        stdOut += data + "\n";
-        return ErrorCode::NoError;
-    };
 
     ErrorCode error =
             runScript(credentials,
                       replaceVars(amnezia::scriptData(SharedScriptType::build_container), genVarsForScript(credentials, container, config)),
-                      cbReadStdOut);
+                      cbReadStdOut, cbReadStdErr);
     
     if (stdOut.contains("runc doesn't work on cgroups v2"))
         return ErrorCode::ServerRuncNotWorkOnCgroupsV2;

--- a/client/core/controllers/serverController.cpp
+++ b/client/core/controllers/serverController.cpp
@@ -467,6 +467,8 @@ ErrorCode ServerController::runContainerWorker(const ServerCredentials &credenti
         return ErrorCode::ServerPortAlreadyAllocatedError;
     if (stdOut.contains("is already in use by container"))
         return ErrorCode::ServerPortAlreadyAllocatedError;
+    if (stdOut.contains("cgroup mountpoint does not exist"))
+        return ErrorCode::ServerCgroupMuntpointDoesNotExist;
     if (stdOut.contains("invalid publish"))
         return ErrorCode::ServerDockerFailedError;
 

--- a/client/core/controllers/serverController.cpp
+++ b/client/core/controllers/serverController.cpp
@@ -439,6 +439,10 @@ ErrorCode ServerController::buildContainerWorker(const ServerCredentials &creden
         stdOut += data + "\n";
         return ErrorCode::NoError;
     };
+    auto cbReadStdErr = [&](const QString &data, libssh::Client &) {
+        stdOut += data + "\n";
+        return ErrorCode::NoError;
+    };
 
     ErrorCode error =
             runScript(credentials,
@@ -447,6 +451,8 @@ ErrorCode ServerController::buildContainerWorker(const ServerCredentials &creden
     
     if (stdOut.contains("runc doesn't work on cgroups v2"))
         return ErrorCode::ServerRuncNotWorkOnCgroupsV2;
+    if (stdOut.contains("cgroup mountpoint does not exist"))
+        return ErrorCode::ServerCgroupMountpointDoesNotExist;
 
     return error;
 }
@@ -458,24 +464,16 @@ ErrorCode ServerController::runContainerWorker(const ServerCredentials &credenti
         stdOut += data + "\n";
         return ErrorCode::NoError;
     };
-    auto cbReadStdErr = [&](const QString &data, libssh::Client &) {
-        stdOut += data + "\n";
-        return ErrorCode::NoError;
-    };
 
     ErrorCode e = runScript(credentials,
                             replaceVars(amnezia::scriptData(ProtocolScriptType::run_container, container),
                                         genVarsForScript(credentials, container, config)),
-                            cbReadStdOut, cbReadStdErr);
+                            cbReadStdOut);
 
     if (stdOut.contains("address already in use"))
         return ErrorCode::ServerPortAlreadyAllocatedError;
     if (stdOut.contains("is already in use by container"))
         return ErrorCode::ServerPortAlreadyAllocatedError;
-    if (stdOut.contains("runc doesn't work on cgroups v2") )
-        return ErrorCode::ServerRuncNotWorkOnCgroupsV2;
-    if (stdOut.contains("cgroup mountpoint does not exist"))
-        return ErrorCode::ServerCgroupMountpointDoesNotExist;
     if (stdOut.contains("invalid publish"))
         return ErrorCode::ServerDockerFailedError;
 

--- a/client/core/controllers/serverController.cpp
+++ b/client/core/controllers/serverController.cpp
@@ -447,7 +447,7 @@ ErrorCode ServerController::buildContainerWorker(const ServerCredentials &creden
     ErrorCode error =
             runScript(credentials,
                       replaceVars(amnezia::scriptData(SharedScriptType::build_container), genVarsForScript(credentials, container, config)),
-                      cbReadStdOut, cbReadStdErr);
+                      cbReadStdOut);
     
     if (stdOut.contains("runc doesn't work on cgroups v2"))
         return ErrorCode::ServerRuncNotWorkOnCgroupsV2;

--- a/client/core/controllers/serverController.cpp
+++ b/client/core/controllers/serverController.cpp
@@ -467,6 +467,8 @@ ErrorCode ServerController::runContainerWorker(const ServerCredentials &credenti
         return ErrorCode::ServerPortAlreadyAllocatedError;
     if (stdOut.contains("is already in use by container"))
         return ErrorCode::ServerPortAlreadyAllocatedError;
+    if (stdOut.contains("runc doesn't work on cgroups v2") )
+        return ErrorCode::ServerRuncNotWorkOnCgroupsV2;
     if (stdOut.contains("cgroup mountpoint does not exist"))
         return ErrorCode::ServerCgroupMountpointDoesNotExist;
     if (stdOut.contains("invalid publish"))

--- a/client/core/controllers/serverController.cpp
+++ b/client/core/controllers/serverController.cpp
@@ -468,7 +468,7 @@ ErrorCode ServerController::runContainerWorker(const ServerCredentials &credenti
     if (stdOut.contains("is already in use by container"))
         return ErrorCode::ServerPortAlreadyAllocatedError;
     if (stdOut.contains("cgroup mountpoint does not exist"))
-        return ErrorCode::ServerCgroupMuntpointDoesNotExist;
+        return ErrorCode::ServerCgroupMountpointDoesNotExist;
     if (stdOut.contains("invalid publish"))
         return ErrorCode::ServerDockerFailedError;
 

--- a/client/core/controllers/serverController.cpp
+++ b/client/core/controllers/serverController.cpp
@@ -457,6 +457,10 @@ ErrorCode ServerController::runContainerWorker(const ServerCredentials &credenti
         stdOut += data + "\n";
         return ErrorCode::NoError;
     };
+    auto cbReadStdErr = [&](const QString &data, libssh::Client &) {
+        stdOut += data + "\n";
+        return ErrorCode::NoError;
+    };
 
     ErrorCode e = runScript(credentials,
                             replaceVars(amnezia::scriptData(ProtocolScriptType::run_container, container),

--- a/client/core/controllers/serverController.cpp
+++ b/client/core/controllers/serverController.cpp
@@ -449,10 +449,10 @@ ErrorCode ServerController::buildContainerWorker(const ServerCredentials &creden
                       replaceVars(amnezia::scriptData(SharedScriptType::build_container), genVarsForScript(credentials, container, config)),
                       cbReadStdOut, cbReadStdErr);
     
-    if (stdOut.contains("runc doesn't work on cgroups v2"))
-        return ErrorCode::ServerRuncNotWorkOnCgroupsV2;
+    if (stdOut.contains("doesn't work on cgroups v2"))
+        return ErrorCode::ServerDockerOnCgroupsV2;
     if (stdOut.contains("cgroup mountpoint does not exist"))
-        return ErrorCode::ServerCgroupMountpointDoesNotExist;
+        return ErrorCode::ServerCgroupMountpoint;
 
     return error;
 }

--- a/client/core/defs.h
+++ b/client/core/defs.h
@@ -58,7 +58,8 @@ namespace amnezia
         ServerUserDirectoryNotAccessible = 208,
         ServerUserNotAllowedInSudoers = 209,
         ServerUserPasswordRequired = 210,
-        ServerCgroupMountpointDoesNotExist = 211,
+        ServerRuncNotWorkOnCgroupsV2 = 211,
+        ServerCgroupMountpointDoesNotExist = 212,
 
         // Ssh connection errors
         SshRequestDeniedError = 300,

--- a/client/core/defs.h
+++ b/client/core/defs.h
@@ -58,6 +58,7 @@ namespace amnezia
         ServerUserDirectoryNotAccessible = 208,
         ServerUserNotAllowedInSudoers = 209,
         ServerUserPasswordRequired = 210,
+        ServerCgroupMountpointDoesNotExist = 211,
 
         // Ssh connection errors
         SshRequestDeniedError = 300,

--- a/client/core/defs.h
+++ b/client/core/defs.h
@@ -58,8 +58,8 @@ namespace amnezia
         ServerUserDirectoryNotAccessible = 208,
         ServerUserNotAllowedInSudoers = 209,
         ServerUserPasswordRequired = 210,
-        ServerRuncNotWorkOnCgroupsV2 = 211,
-        ServerCgroupMountpointDoesNotExist = 212,
+        ServerDockerOnCgroupsV2 = 211,
+        ServerCgroupMountpoint = 212,
 
         // Ssh connection errors
         SshRequestDeniedError = 300,

--- a/client/core/errorstrings.cpp
+++ b/client/core/errorstrings.cpp
@@ -26,8 +26,8 @@ QString errorString(ErrorCode code) {
     case(ErrorCode::ServerUserDirectoryNotAccessible): errorMessage = QObject::tr("The server user's home directory is not accessible"); break;
     case(ErrorCode::ServerUserNotAllowedInSudoers): errorMessage = QObject::tr("Action not allowed in sudoers"); break;
     case(ErrorCode::ServerUserPasswordRequired): errorMessage = QObject::tr("The user's password is required"); break;
-    case(ErrorCode::ServerRuncNotWorkOnCgroupsV2): errorMessage = QObject::tr("Docker error: Runc dosn't work on cgroups v2"); break;
-    case(ErrorCode::ServerCgroupMountpointDoesNotExist): errorMessage = QObject::tr("Docker error: cgroup mountpoint does not exist"); break;
+    case(ErrorCode::ServerDockerOnCgroupsV2): errorMessage = QObject::tr("Docker error: dosn't work on cgroups v2"); break;
+    case(ErrorCode::ServerCgroupMountpoint): errorMessage = QObject::tr("Server error: cgroup mountpoint does not exist"); break;
 
     // Libssh errors
     case(ErrorCode::SshRequestDeniedError): errorMessage = QObject::tr("SSH request was denied"); break;

--- a/client/core/errorstrings.cpp
+++ b/client/core/errorstrings.cpp
@@ -26,6 +26,7 @@ QString errorString(ErrorCode code) {
     case(ErrorCode::ServerUserDirectoryNotAccessible): errorMessage = QObject::tr("The server user's home directory is not accessible"); break;
     case(ErrorCode::ServerUserNotAllowedInSudoers): errorMessage = QObject::tr("Action not allowed in sudoers"); break;
     case(ErrorCode::ServerUserPasswordRequired): errorMessage = QObject::tr("The user's password is required"); break;
+    case(ErrorCode::ServerCgroupMountpointDoesNotExist): errorMessage = QObject::tr("Docker error: cgroup mountpoint does not exist"); break;
 
     // Libssh errors
     case(ErrorCode::SshRequestDeniedError): errorMessage = QObject::tr("SSH request was denied"); break;

--- a/client/core/errorstrings.cpp
+++ b/client/core/errorstrings.cpp
@@ -26,6 +26,7 @@ QString errorString(ErrorCode code) {
     case(ErrorCode::ServerUserDirectoryNotAccessible): errorMessage = QObject::tr("The server user's home directory is not accessible"); break;
     case(ErrorCode::ServerUserNotAllowedInSudoers): errorMessage = QObject::tr("Action not allowed in sudoers"); break;
     case(ErrorCode::ServerUserPasswordRequired): errorMessage = QObject::tr("The user's password is required"); break;
+    case(ErrorCode::ServerRuncNotWorkOnCgroupsV2): errorMessage = QObject::tr("Docker error: Runc dosn't work on cgroups v2"); break;
     case(ErrorCode::ServerCgroupMountpointDoesNotExist): errorMessage = QObject::tr("Docker error: cgroup mountpoint does not exist"); break;
 
     // Libssh errors

--- a/client/core/errorstrings.cpp
+++ b/client/core/errorstrings.cpp
@@ -26,7 +26,7 @@ QString errorString(ErrorCode code) {
     case(ErrorCode::ServerUserDirectoryNotAccessible): errorMessage = QObject::tr("The server user's home directory is not accessible"); break;
     case(ErrorCode::ServerUserNotAllowedInSudoers): errorMessage = QObject::tr("Action not allowed in sudoers"); break;
     case(ErrorCode::ServerUserPasswordRequired): errorMessage = QObject::tr("The user's password is required"); break;
-    case(ErrorCode::ServerDockerOnCgroupsV2): errorMessage = QObject::tr("Docker error: dosn't work on cgroups v2"); break;
+    case(ErrorCode::ServerDockerOnCgroupsV2): errorMessage = QObject::tr("Docker error: runc doesn't work on cgroups v2"); break;
     case(ErrorCode::ServerCgroupMountpoint): errorMessage = QObject::tr("Server error: cgroup mountpoint does not exist"); break;
 
     // Libssh errors


### PR DESCRIPTION
Added error handling for:
1) cgroup mountpoint does not exist
2) (runc) does not work in cgroups v2