### PR TITLE
fix: add missing include

### DIFF
--- a/client/daemon/interfaceconfig.h
+++ b/client/daemon/interfaceconfig.h
@@ -6,6 +6,7 @@
 #define INTERFACECONFIG_H
 
 #include <QList>
+#include <QMap>
 #include <QString>
 
 #include "ipaddress.h"


### PR DESCRIPTION
Add missing include, which can cause build failure with QT 6.9
Context: https://github.com/NixOS/nixpkgs/pull/398334