### PR TITLE
Updated Xray version to 25.8.3

### DIFF
--- a/client/server_scripts/xray/Dockerfile
+++ b/client/server_scripts/xray/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.15
 LABEL maintainer="AmneziaVPN"
 
-ARG XRAY_RELEASE="v1.8.6"
+ARG XRAY_RELEASE="v25.8.3"
 
 RUN apk add --no-cache curl unzip bash openssl netcat-openbsd dumb-init rng-tools xz
 RUN apk --update upgrade --no-cache


### PR DESCRIPTION
The current version of xray-core is very outdated (about 2 years old) and does not work correctly with reality, so update to latest