### PR TITLE
Support multiple comma-separated IPs per host in split tunneling

### DIFF
--- a/client/settings.cpp
+++ b/client/settings.cpp
@@ -308,8 +308,17 @@ QStringList Settings::getVpnIps(RouteMode mode) const
     for (auto i = m.constBegin(); i != m.constEnd(); ++i) {
         if (NetworkUtilities::checkIpSubnetFormat(i.key())) {
             ips.append(i.key());
-        } else if (NetworkUtilities::checkIpSubnetFormat(i.value().toString())) {
-            ips.append(i.value().toString());
+        } else {
+            QString ipValue = i.value().toString();
+            if (!ipValue.isEmpty()) {
+                QStringList splitIps = ipValue.split(',', Qt::SkipEmptyParts);
+                for (const QString &ip : splitIps) {
+                    QString trimmedIp = ip.trimmed();
+                    if (NetworkUtilities::checkIpSubnetFormat(trimmedIp)) {
+                        ips.append(trimmedIp);
+                    }
+                }
+            }
         }
     }
     ips.removeDuplicates();

--- a/client/settings.cpp
+++ b/client/settings.cpp
@@ -308,16 +308,19 @@ QStringList Settings::getVpnIps(RouteMode mode) const
     for (auto i = m.constBegin(); i != m.constEnd(); ++i) {
         if (NetworkUtilities::checkIpSubnetFormat(i.key())) {
             ips.append(i.key());
-        } else {
-            QString ipValue = i.value().toString();
-            if (!ipValue.isEmpty()) {
-                QStringList splitIps = ipValue.split(',', Qt::SkipEmptyParts);
-                for (const QString &ip : splitIps) {
-                    QString trimmedIp = ip.trimmed();
-                    if (NetworkUtilities::checkIpSubnetFormat(trimmedIp)) {
-                        ips.append(trimmedIp);
-                    }
-                }
+            continue;
+        }
+
+        QString ipValue = i.value().toString();
+        if (ipValue.isEmpty()) {
+            continue;
+        }
+
+        QStringList splitIps = ipValue.split(',', Qt::SkipEmptyParts);
+        for (const QString &ip : splitIps) {
+            QString trimmedIp = ip.trimmed();
+            if (NetworkUtilities::checkIpSubnetFormat(trimmedIp)) {
+                ips.append(trimmedIp);
             }
         }
     }

--- a/client/ui/controllers/sitesController.cpp
+++ b/client/ui/controllers/sitesController.cpp
@@ -51,7 +51,6 @@ void SitesController::addSite(QString hostname)
         for (const QHostAddress &addr : hostInfo.addresses()) {
             if (addr.protocol() == QAbstractSocket::NetworkLayerProtocol::IPv4Protocol) {
                 processSite(hostInfo.hostName(), addr.toString());
-                break;
             }
         }
     };

--- a/client/ui/controllers/sitesController.cpp
+++ b/client/ui/controllers/sitesController.cpp
@@ -38,8 +38,18 @@ void SitesController::addSite(QString hostname)
         m_sitesModel->addSite(hostname, ip);
 
         if (!ip.isEmpty()) {
-            QMetaObject::invokeMethod(m_vpnConnection.get(), "addRoutes", Qt::QueuedConnection,
-                                      Q_ARG(QStringList, QStringList() << ip));
+            QStringList ips = ip.split(',', Qt::SkipEmptyParts);
+            QStringList validIps;
+            for (const QString &singleIp : ips) {
+                QString trimmedIp = singleIp.trimmed();
+                if (NetworkUtilities::checkIpSubnetFormat(trimmedIp)) {
+                    validIps.append(trimmedIp);
+                }
+            }
+            if (!validIps.isEmpty()) {
+                QMetaObject::invokeMethod(m_vpnConnection.get(), "addRoutes", Qt::QueuedConnection,
+                                          Q_ARG(QStringList, validIps));
+            }
         } else if (NetworkUtilities::ipAddressWithSubnetRegExp().exactMatch(hostname)) {
             QMetaObject::invokeMethod(m_vpnConnection.get(), "addRoutes", Qt::QueuedConnection,
                                       Q_ARG(QStringList, QStringList() << hostname));
@@ -48,10 +58,17 @@ void SitesController::addSite(QString hostname)
 
     const auto &resolveCallback = [this, processSite](const QHostInfo &hostInfo) {
         const QList<QHostAddress> &addresses = hostInfo.addresses();
+        QStringList resolvedIps;
+
         for (const QHostAddress &addr : hostInfo.addresses()) {
             if (addr.protocol() == QAbstractSocket::NetworkLayerProtocol::IPv4Protocol) {
-                processSite(hostInfo.hostName(), addr.toString());
+                resolvedIps.append(addr.toString());
             }
+        }
+
+        if (!resolvedIps.isEmpty()) {
+            QString aggregatedIps = resolvedIps.join(',');
+            processSite(hostInfo.hostName(), aggregatedIps);
         }
     };
 
@@ -119,10 +136,32 @@ void SitesController::importSites(const QString &fileName, bool replaceExisting)
 
         if (ip.isEmpty()) {
             ips.append(hostname);
+            sites.insert(hostname, ip);
         } else {
-            ips.append(ip);
+            QStringList importedIps = ip.split(',', Qt::SkipEmptyParts);
+            QStringList validIps;
+            for (const QString &singleIp : importedIps) {
+                QString trimmedIp = singleIp.trimmed();
+                if (NetworkUtilities::checkIpSubnetFormat(trimmedIp)) {
+                    validIps.append(trimmedIp);
+                    ips.append(trimmedIp);
+                }
+            }
+
+            if (sites.contains(hostname)) {
+                QString existingIps = sites.value(hostname);
+                if (!existingIps.isEmpty()) {
+                    QStringList existingIpList = existingIps.split(',', Qt::SkipEmptyParts);
+                    existingIpList.append(validIps);
+                    existingIpList.removeDuplicates();
+                    sites.insert(hostname, existingIpList.join(','));
+                } else {
+                    sites.insert(hostname, validIps.join(','));
+                }
+            } else {
+                sites.insert(hostname, validIps.join(','));
+            }
         }
-        sites.insert(hostname, ip);
     }
 
     m_sitesModel->addSites(sites, replaceExisting);

--- a/client/ui/controllers/sitesController.cpp
+++ b/client/ui/controllers/sitesController.cpp
@@ -37,22 +37,26 @@ void SitesController::addSite(QString hostname)
     const auto &processSite = [this](const QString &hostname, const QString &ip) {
         m_sitesModel->addSite(hostname, ip);
 
-        if (!ip.isEmpty()) {
-            QStringList ips = ip.split(',', Qt::SkipEmptyParts);
-            QStringList validIps;
-            for (const QString &singleIp : ips) {
-                QString trimmedIp = singleIp.trimmed();
-                if (NetworkUtilities::checkIpSubnetFormat(trimmedIp)) {
-                    validIps.append(trimmedIp);
-                }
-            }
-            if (!validIps.isEmpty()) {
+        if (ip.isEmpty()) {
+            if (NetworkUtilities::ipAddressWithSubnetRegExp().exactMatch(hostname)) {
                 QMetaObject::invokeMethod(m_vpnConnection.get(), "addRoutes", Qt::QueuedConnection,
-                                          Q_ARG(QStringList, validIps));
+                                          Q_ARG(QStringList, QStringList() << hostname));
             }
-        } else if (NetworkUtilities::ipAddressWithSubnetRegExp().exactMatch(hostname)) {
+            return;
+        }
+
+        QStringList ips = ip.split(',', Qt::SkipEmptyParts);
+        QStringList validIps;
+        for (const QString &singleIp : ips) {
+            QString trimmedIp = singleIp.trimmed();
+            if (NetworkUtilities::checkIpSubnetFormat(trimmedIp)) {
+                validIps.append(trimmedIp);
+            }
+        }
+
+        if (!validIps.isEmpty()) {
             QMetaObject::invokeMethod(m_vpnConnection.get(), "addRoutes", Qt::QueuedConnection,
-                                      Q_ARG(QStringList, QStringList() << hostname));
+                                      Q_ARG(QStringList, validIps));
         }
     };
 

--- a/client/vpnconnection.cpp
+++ b/client/vpnconnection.cpp
@@ -171,10 +171,9 @@ void VpnConnection::addSitesRoutes(const QString &gw, Settings::RouteMode mode)
                         IpcClient::Interface()->routeAddList(gw, QStringList() << ip);
                         m_settings->addVpnSite(mode, site, ip);
                     }
-                    flushDns();
-                    break;
                 }
             }
+            flushDns();
         };
         QHostInfo::lookupHost(site, this, cbResolv);
     }

--- a/client/vpnconnection.cpp
+++ b/client/vpnconnection.cpp
@@ -162,16 +162,26 @@ void VpnConnection::addSitesRoutes(const QString &gw, Settings::RouteMode mode)
     for (const QString &site : sites) {
         const auto &cbResolv = [this, site, gw, mode, ips](const QHostInfo &hostInfo) {
             const QList<QHostAddress> &addresses = hostInfo.addresses();
-            QString ipv4Addr;
+            QStringList newIps;
+            QString existingIpsStr = m_settings->vpnSites(mode).value(site).toString();
+            QStringList existingIps = existingIpsStr.split(',', Qt::SkipEmptyParts);
+            
             for (const QHostAddress &addr : hostInfo.addresses()) {
                 if (addr.protocol() == QAbstractSocket::NetworkLayerProtocol::IPv4Protocol) {
                     const QString &ip = addr.toString();
                     // qDebug() << "VpnConnection::addSitesRoutes updating site" << site << ip;
-                    if (!ips.contains(ip)) {
+                    if (!ips.contains(ip) && !existingIps.contains(ip)) {
                         IpcClient::Interface()->routeAddList(gw, QStringList() << ip);
-                        m_settings->addVpnSite(mode, site, ip);
+                        newIps.append(ip);
                     }
                 }
+            }
+
+            if (!newIps.isEmpty()) {
+                existingIps.append(newIps);
+                existingIps.removeDuplicates();
+                QString aggregatedIps = existingIps.join(',');
+                m_settings->addVpnSite(mode, site, aggregatedIps);
             }
             flushDns();
         };


### PR DESCRIPTION
A bit hacky, but a minimal **non-bc-breaking** solution to support multiple IPs per hostname.

## Changes
- Collect all IPs from hostname resolution instead of stopping at the first IP
- Store multiple resolved IPs as comma-separated strings when adding hostnames  
- Parse comma-separated IP strings from settings and import/export
- Support multiple IPs per host in split tunneling

## Testing
- ✅ Tested on bbc.com IPs: `151.101.128.81,151.101.192.81,151.101.64.81,151.101.0.81`
- ✅ Non-first IPs (e.g., `151.101.64.81`) accessible through VPN
- ✅ Selective split tunneling works correctly
- ✅ Import/Export functionality preserved

## Import/Export Format
The feature supports comma-separated IPs in the import/export JSON format:
```json
[
    {
        "hostname": "bbc.com",
        "ip": "151.101.0.81,151.101.64.81,151.101.128.81,151.101.192.81"
    }
]
```

## UI preview
<img width="382" height="712" alt="image" src="https://github.com/user-attachments/assets/984f71e9-6636-4a15-92ec-8e5c968e587a" />

## Fixes
Resolves #1750 