### PR TITLE
fix: clean service/client logs in uninstall scripts

### DIFF
--- a/deploy/data/linux/post_uninstall.sh
+++ b/deploy/data/linux/post_uninstall.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 APP_NAME=AmneziaVPN
+ORG_NAME=AmneziaVPN.ORG
 LOG_FOLDER=/var/log/$APP_NAME
 LOG_FILE="$LOG_FOLDER/post-uninstall.log"
 APP_PATH=/opt/$APP_NAME
@@ -63,6 +64,24 @@ if test -f /usr/share/pixmaps/$APP_NAME.png; then
 	sudo rm -f /usr/share/pixmaps/$APP_NAME.png >> $LOG_FILE
 
 fi
+
+### Remove the service log file (keep post-uninstall.log)
+if test -f "$LOG_FOLDER/AmneziaVPN-service.log"; then
+    sudo rm -f "$LOG_FOLDER/AmneziaVPN-service.log" >> $LOG_FILE 2>&1
+fi
+
+### Remove user logs for current user only
+TARGET_HOME="$HOME"
+if [ -n "$SUDO_USER" ] && [ "$SUDO_USER" != "root" ]; then
+    TARGET_HOME=$(getent passwd "$SUDO_USER" | cut -d: -f6)
+fi
+if test -d "$TARGET_HOME/.local/share/$ORG_NAME/$APP_NAME/log"; then
+    rm -rf "$TARGET_HOME/.local/share/$ORG_NAME/$APP_NAME/log" >> $LOG_FILE 2>&1
+fi
+
+# Try to remove empty app and organization directories under user share
+if rmdir "$TARGET_HOME/.local/share/$ORG_NAME/$APP_NAME" 2>/dev/null; then :; fi
+if rmdir "$TARGET_HOME/.local/share/$ORG_NAME" 2>/dev/null; then :; fi
 
 if command -v steamos-readonly &> /dev/null; then
 	sudo steamos-readonly enable >> $LOG_FILE

--- a/deploy/data/windows/x32/post_uninstall.cmd
+++ b/deploy/data/windows/x32/post_uninstall.cmd
@@ -1,7 +1,14 @@
 set AmneziaPath=%~dp0
 echo %AmneziaPath%
 
-"%AmneziaPath%\AmneziaVPN.exe" -c
+rem Define directories for logs
+set "ORG_DIR=%AppData%\AmneziaVPN.ORG"
+set "USER_APP_DIR=%ORG_DIR%\AmneziaVPN"
+set "USER_LOG_DIR=%USER_APP_DIR%\log"
+set "SYS_APP_DIR=%ProgramData%\AmneziaVPN"
+set "SYS_LOG_DIR=%SYS_APP_DIR%\log"
+set "SYS_LOG_FILE=%SYS_LOG_DIR%\AmneziaVPN-service.log"
+
 timeout /t 1
 sc stop AmneziaVPN-service
 sc delete AmneziaVPN-service
@@ -9,4 +16,17 @@ sc stop AmneziaWGTunnel$AmneziaVPN
 sc delete AmneziaWGTunnel$AmneziaVPN
 taskkill /IM "AmneziaVPN-service.exe" /F
 taskkill /IM "AmneziaVPN.exe" /F
+
+rem Delete the service log file under ProgramData
+if exist "%SYS_LOG_FILE%" del /F /Q "%SYS_LOG_FILE%"
+if exist "%SYS_LOG_DIR%" rmdir /S /Q "%SYS_LOG_DIR%"
+rem Try to remove application dir if empty
+rd "%SYS_APP_DIR%" 2>nul
+
+rem Delete client logs under current user's AppData\Roaming (Organization\Application)
+if exist "%USER_LOG_DIR%" rmdir /S /Q "%USER_LOG_DIR%"
+rem Try to remove app and org directories if empty
+rd "%USER_APP_DIR%" 2>nul
+rd "%ORG_DIR%" 2>nul
+
 exit /b 0

--- a/deploy/data/windows/x64/post_uninstall.cmd
+++ b/deploy/data/windows/x64/post_uninstall.cmd
@@ -1,7 +1,14 @@
 set AmneziaPath=%~dp0
 echo %AmneziaPath%
 
-"%AmneziaPath%\AmneziaVPN.exe" -c
+rem Define directories for logs
+set "ORG_DIR=%AppData%\AmneziaVPN.ORG"
+set "USER_APP_DIR=%ORG_DIR%\AmneziaVPN"
+set "USER_LOG_DIR=%USER_APP_DIR%\log"
+set "SYS_APP_DIR=%ProgramData%\AmneziaVPN"
+set "SYS_LOG_DIR=%SYS_APP_DIR%\log"
+set "SYS_LOG_FILE=%SYS_LOG_DIR%\AmneziaVPN-service.log"
+
 timeout /t 1
 sc stop AmneziaVPN-service
 sc delete AmneziaVPN-service
@@ -9,4 +16,17 @@ sc stop AmneziaWGTunnel$AmneziaVPN
 sc delete AmneziaWGTunnel$AmneziaVPN
 taskkill /IM "AmneziaVPN-service.exe" /F
 taskkill /IM "AmneziaVPN.exe" /F
+
+rem Delete the service log file under ProgramData
+if exist "%SYS_LOG_FILE%" del /F /Q "%SYS_LOG_FILE%"
+if exist "%SYS_LOG_DIR%" rmdir /S /Q "%SYS_LOG_DIR%"
+rem Try to remove application dir if empty
+rd "%SYS_APP_DIR%" 2>nul
+
+rem Delete client logs under current user's AppData\Roaming (Organization\Application)
+if exist "%USER_LOG_DIR%" rmdir /S /Q "%USER_LOG_DIR%"
+rem Try to remove app and org directories if empty
+rd "%USER_APP_DIR%" 2>nul
+rd "%ORG_DIR%" 2>nul
+
 exit /b 0


### PR DESCRIPTION
- Windows (x64/x86):
  - Remove delegation to `AmneziaVPN.exe -c`
  - Delete `%ProgramData%\AmneziaVPN\log\AmneziaVPN-service.log`
  - Delete current user logs at `%AppData%\AmneziaVPN.ORG\AmneziaVPN\log`
  - Remove empty parent dirs (app/org, log)

- Linux:
  - Delete only `/var/log/AmneziaVPN/AmneziaVPN-service.log` (preserve `post-uninstall.log`)
  - Delete current user logs at `$HOME/.local/share/AmneziaVPN.ORG/AmneziaVPN/log`