### PR TITLE
fix GetBestRoute always returning 1231 error

### DIFF
--- a/client/core/networkUtilities.cpp
+++ b/client/core/networkUtilities.cpp
@@ -170,11 +170,11 @@ int NetworkUtilities::AdapterIndexTo(const QHostAddress& dst) {
 #ifdef Q_OS_WIN
     qDebug() << "Getting Current Internet Adapter that routes to"
              << dst.toString();
+    quint32 ipBigEndian;
     quint32 ip = dst.toIPv4Address();
-    quint32 ipBigEndian = qToBigEndian(ip);
-    DWORD dwDestAddr = static_cast<DWORD>(ipBigEndian);
+    qToBigEndian(ip, &ipBigEndian);
     _MIB_IPFORWARDROW routeInfo;
-    auto result = GetBestRoute(dwDestAddr, 0, &routeInfo);
+    auto result = GetBestRoute(ipBigEndian, 0, &routeInfo);
     if (result != NO_ERROR) {
         return -1;
     }

--- a/client/core/networkUtilities.cpp
+++ b/client/core/networkUtilities.cpp
@@ -170,11 +170,11 @@ int NetworkUtilities::AdapterIndexTo(const QHostAddress& dst) {
 #ifdef Q_OS_WIN
     qDebug() << "Getting Current Internet Adapter that routes to"
              << dst.toString();
-    quint32_be ipBigEndian;
     quint32 ip = dst.toIPv4Address();
-    qToBigEndian(ip, &ipBigEndian);
+    quint32 ipBigEndian = qToBigEndian(ip);
+    DWORD dwDestAddr = static_cast<DWORD>(ipBigEndian);
     _MIB_IPFORWARDROW routeInfo;
-    auto result = GetBestRoute(ipBigEndian, 0, &routeInfo);
+    auto result = GetBestRoute(dwDestAddr, 0, &routeInfo);
     if (result != NO_ERROR) {
         return -1;
     }


### PR DESCRIPTION
I've been having a problem where the app on windows 10 21H2 would always fail to find inet adapter index and subsequently split app tunneling wouldn't work. When troubleshooting the issue i found that `GetBestRoute` in `AdapterIndexTo` function of networkUtilities would always return 1231 error (which i believe is network cannot be reached error). I've changed `ipBigEndian` type from `quint32_be` to `quint32` and that fixed the issue for me. Tested on my pc and a virtual machine with two different Internet connections.