### PR TITLE
fix: fix Android 14 foreground service crash for VPN services

### DIFF
--- a/client/android/AndroidManifest.xml
+++ b/client/android/AndroidManifest.xml
@@ -24,7 +24,7 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SYSTEM_EXEMPTED" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" android:minSdkVersion="34" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" tools:ignore="QueryAllPackagesPermission" />
 
@@ -156,7 +156,7 @@
             android:name=".AwgService"
             android:process=":amneziaAwgService"
             android:permission="android.permission.BIND_VPN_SERVICE"
-            android:foregroundServiceType="systemExempted"
+            android:foregroundServiceType="specialUse"
             android:exported="false"
             tools:ignore="ForegroundServicePermission">
 
@@ -169,7 +169,7 @@
             android:name=".OpenVpnService"
             android:process=":amneziaOpenVpnService"
             android:permission="android.permission.BIND_VPN_SERVICE"
-            android:foregroundServiceType="systemExempted"
+            android:foregroundServiceType="specialUse"
             android:exported="false"
             tools:ignore="ForegroundServicePermission">
 
@@ -182,7 +182,7 @@
             android:name=".XrayService"
             android:process=":amneziaXrayService"
             android:permission="android.permission.BIND_VPN_SERVICE"
-            android:foregroundServiceType="systemExempted"
+            android:foregroundServiceType="specialUse"
             android:exported="false"
             tools:ignore="ForegroundServicePermission">
 

--- a/client/android/src/org/amnezia/vpn/AmneziaVpnService.kt
+++ b/client/android/src/org/amnezia/vpn/AmneziaVpnService.kt
@@ -8,7 +8,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MANIFEST
-import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_SYSTEM_EXEMPTED
+import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
 import android.net.VpnService
 import android.os.Build
 import android.os.Handler
@@ -194,7 +194,7 @@ open class AmneziaVpnService : VpnService() {
      */
     private val foregroundServiceTypeCompat
         get() = when {
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE -> FOREGROUND_SERVICE_TYPE_SYSTEM_EXEMPTED
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE -> FOREGROUND_SERVICE_TYPE_SPECIAL_USE
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q -> FOREGROUND_SERVICE_TYPE_MANIFEST
             else -> 0
         }


### PR DESCRIPTION
Replace FOREGROUND_SERVICE_TYPE_SYSTEM_EXEMPTED with FOREGROUND_SERVICE_TYPE_SPECIAL_USE to fix InvalidForegroundServiceTypeException on Android 14 (SDK 34).

Changes:
- Update AmneziaVpnService.kt to use FOREGROUND_SERVICE_TYPE_SPECIAL_USE for Android 14+
- Update AndroidManifest.xml permission from FOREGROUND_SERVICE_SYSTEM_EXEMPTED to FOREGROUND_SERVICE_SPECIAL_USE
- Change foregroundServiceType from "systemExempted" to "specialUse" for all VPN services (AwgService, OpenVpnService, XrayService)

Fixes crash on Samsung A33 Android 14 when starting VPN services.