### PR TITLE
Fix: Application freeze on quit from tray

### DIFF
--- a/client/amnezia_application.cpp
+++ b/client/amnezia_application.cpp
@@ -54,6 +54,7 @@ AmneziaApplication::AmneziaApplication(int &argc, char *argv[]) : AMNEZIA_BASE_C
 AmneziaApplication::~AmneziaApplication()
 {
     m_vpnConnectionThread.quit();
+    m_vpnConnectionThread.wait();
 
     if (m_engine) {
         QObject::disconnect(m_engine, 0, 0, 0);


### PR DESCRIPTION
Fixes an issue where the application would freeze when quitting from the system tray menu. Added a wait() call to the AmneziaApplication destructor to ensure the VPN connection thread terminates correctly.