### PR TITLE
fix(linux/qt): fix the missing taskbar icon on Wayland

### DIFF
--- a/client/amnezia_application.cpp
+++ b/client/amnezia_application.cpp
@@ -35,6 +35,7 @@ AmneziaApplication::AmneziaApplication(int &argc, char *argv[]) : AMNEZIA_BASE_C
       m_optConnect  ({QStringLiteral("connect")}, QStringLiteral("Connect to server by index on startup"), QStringLiteral("index")),
       m_optImport   ({QStringLiteral("import")}, QStringLiteral("Import configuration from data string"), QStringLiteral("data"))
 {
+    setDesktopFileName(QStringLiteral(APPLICATION_NAME));
     setQuitOnLastWindowClosed(false);
 
     // Fix config file permissions


### PR DESCRIPTION
This change ensures that the application reports a valid Wayland `app_id`, allowing compositors like Mutter to correctly match the window with its .desktop file.

See: https://nicolasfella.de/posts/fixing-wayland-taskbar-icons/