### PR TITLE
fix(ci): fix macOS build workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -328,7 +328,7 @@ jobs:
     - name: 'Setup xcode'
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '15.4.0'
+        xcode-version: '16.4.0'
 
     - name: 'Install Qt'
       uses: jurplel/install-qt-action@v3
@@ -405,7 +405,7 @@ jobs:
     - name: 'Setup xcode'
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '16.2.0'
+        xcode-version: '16.4.0'
 
     - name: 'Install Qt'
       uses: jurplel/install-qt-action@v4
@@ -468,6 +468,10 @@ jobs:
 
     env:
       QT_VERSION: 6.10.1
+
+      MAC_TRUST_CERT_BASE64: ${{ secrets.MAC_TRUST_CERT_BASE64 }}
+      MAC_SIGNING_CERT_BASE64: ${{ secrets.MAC_SIGNING_CERT_BASE64 }}
+      MAC_SIGNING_CERT_PASSWORD: ${{ secrets.MAC_SIGNING_CERT_PASSWORD }}
 
       MAC_TEAM_ID: ${{ secrets.MAC_TEAM_ID }}
 


### PR DESCRIPTION
Problem:
macOS workflows were failing due to unsupported Xcode version and Network Extension secrets.

fix:
- Switch workflows to Xcode 16.4
