### PR TITLE
fix(Ubuntu 24.04): DNS resolution fails when VPN connects due to systemd-resolved restart

### DIFF
--- a/client/daemon/daemonlocalserver.cpp
+++ b/client/daemon/daemonlocalserver.cpp
@@ -42,7 +42,8 @@ bool DaemonLocalServer::initialize() {
   }
 
   if (!m_server.listen(path)) {
-    logger.error() << "Failed to listen the daemon path";
+    logger.error() << "Failed to listen the daemon path:"
+                   << m_server.errorString();
     return false;
   }
 

--- a/client/platforms/linux/daemon/dnsutilslinux.cpp
+++ b/client/platforms/linux/daemon/dnsutilslinux.cpp
@@ -4,6 +4,8 @@
 
 #include "dnsutilslinux.h"
 
+#include <cerrno>
+#include <cstring>
 #include <net/if.h>
 
 #include <QDBusVariant>
@@ -29,6 +31,11 @@ DnsUtilsLinux::DnsUtilsLinux(QObject* parent) : DnsUtils(parent) {
   QDBusConnection conn = QDBusConnection::systemBus();
   m_resolver = new QDBusInterface(DBUS_RESOLVE_SERVICE, DBUS_RESOLVE_PATH,
                                   DBUS_RESOLVE_MANAGER, conn, this);
+  if (!m_resolver->isValid()) {
+    logger.error() << "Failed to create D-Bus interface to systemd-resolved:"
+                   << m_resolver->lastError().name()
+                   << m_resolver->lastError().message();
+  }
 }
 
 DnsUtilsLinux::~DnsUtilsLinux() {
@@ -54,7 +61,8 @@ bool DnsUtilsLinux::updateResolvers(const QString& ifname,
                                     const QList<QHostAddress>& resolvers) {
   m_ifindex = if_nametoindex(qPrintable(ifname));
   if (m_ifindex <= 0) {
-    logger.error() << "Unable to resolve ifindex for" << ifname;
+    logger.error() << "Unable to resolve ifindex for" << ifname << ":"
+                   << strerror(errno);
     return false;
   }
 
@@ -90,7 +98,8 @@ bool DnsUtilsLinux::restoreResolvers() {
 void DnsUtilsLinux::dnsCallCompleted(QDBusPendingCallWatcher* call) {
   QDBusPendingReply<> reply = *call;
   if (reply.isError()) {
-    logger.error() << "Error received from the DBus service";
+    logger.error() << "Error received from the DBus service:"
+                   << reply.error().name() << reply.error().message();
   }
   delete call;
 }
@@ -175,7 +184,8 @@ void DnsUtilsLinux::updateLinkDomains() {
 void DnsUtilsLinux::dnsDomainsReceived(QDBusPendingCallWatcher* call) {
   QDBusPendingReply<QVariant> reply = *call;
   if (reply.isError()) {
-    logger.error() << "Error retrieving the DNS  domains from the DBus service";
+    logger.error() << "Error retrieving the DNS domains from the DBus service:"
+                   << reply.error().name() << reply.error().message();
     delete call;
     return;
   }

--- a/service/server/router_linux.cpp
+++ b/service/server/router_linux.cpp
@@ -170,8 +170,13 @@ bool RouterLinux::flushDns()
         qDebug() << "Restarting nscd.service";
         p.start("systemctl", { "restart", "nscd" });
     } else if (isServiceActive("systemd-resolved.service")) {
-        qDebug() << "Restarting systemd-resolved.service";
-        p.start("systemctl", { "restart", "systemd-resolved" });
+        qDebug() << "Flushing systemd-resolved caches";
+        p.start("resolvectl", { "flush-caches" });
+        p.waitForFinished();
+        if (p.exitCode() != 0) {
+            qDebug() << "resolvectl not available, restarting systemd-resolved";
+            p.start("systemctl", { "restart", "systemd-resolved" });
+        }
     } else {
         qDebug() << "No suitable DNS manager found.";
         return false;
@@ -182,7 +187,7 @@ bool RouterLinux::flushDns()
     if (output.isEmpty())
         qDebug().noquote() << "Flush dns completed";
     else
-        qDebug().noquote() << "OUTPUT systemctl restart nscd/systemd-resolved: " + output;
+        qDebug().noquote() << "OUTPUT flush dns: " + output;
 
     return true;
 }

--- a/service/server/router_linux.cpp
+++ b/service/server/router_linux.cpp
@@ -172,10 +172,19 @@ bool RouterLinux::flushDns()
     } else if (isServiceActive("systemd-resolved.service")) {
         qDebug() << "Flushing systemd-resolved caches";
         p.start("resolvectl", { "flush-caches" });
-        p.waitForFinished();
-        if (p.exitCode() != 0) {
-            qDebug() << "resolvectl not available, restarting systemd-resolved";
-            p.start("systemctl", { "restart", "systemd-resolved" });
+        p.waitForStarted();
+        // Use a short timeout — resolvectl can hang for ~25s if systemd-resolved
+        // is busy processing DNS config changes we just made via DBus.
+        // A failed cache flush is harmless (stale cache entries will expire naturally).
+        // Do NOT fall back to restarting systemd-resolved, as that destroys the
+        // per-link DNS configuration we just set up on the VPN interface.
+        if (!p.waitForFinished(5000)) {
+            qWarning() << "resolvectl flush-caches timed out after 5s, killing process";
+            p.kill();
+            p.waitForFinished(1000);
+        } else if (p.exitCode() != 0) {
+            qWarning() << "resolvectl flush-caches failed with exit code" << p.exitCode()
+                       << "output:" << p.readAll();
         }
     } else {
         qDebug() << "No suitable DNS manager found.";


### PR DESCRIPTION
  flushDns() was restarting systemd-resolved via systemctl restart, which killed the D-Bus connection while async DNS configuration
   calls (SetLinkDNS, SetLinkDefaultRoute, Domains query) from DnsUtilsLinux were still in-flight. This caused all D-Bus calls to
  fail with NoReply, leaving DNS unconfigured on the VPN interface.

  - Use resolvectl flush-caches instead of restarting systemd-resolved, with fallback to restart for older distros
  - Add D-Bus error detail logging (error name + message) to dnsCallCompleted and dnsDomainsReceived
  - Add QDBusInterface validity check at construction time
  - Add errno details to ifindex resolution failure
  - Fix double-space typo in "DNS  domains" log message
  
