### PR TITLE
Fix custom DNS for non-Admin profiles + preserve DNS order in Android WireGuard

### DIFF
--- a/client/android/protocolApi/src/main/kotlin/ProtocolConfig.kt
+++ b/client/android/protocolApi/src/main/kotlin/ProtocolConfig.kt
@@ -40,7 +40,8 @@ open class ProtocolConfig protected constructor(
 
     open class Builder(blockingMode: Boolean) {
         internal val addresses: MutableSet<InetNetwork> = hashSetOf()
-        internal val dnsServers: MutableSet<InetAddress> = hashSetOf()
+        // Preserve insertion order: Android treats the first DNS as primary.
+        internal val dnsServers: MutableSet<InetAddress> = linkedSetOf()
         internal val routes: MutableSet<Route> = mutableSetOf()
         internal val includedAddresses: MutableSet<InetNetwork> = hashSetOf()
         internal val excludedAddresses: MutableSet<InetNetwork> = hashSetOf()

--- a/client/ui/models/servers_model.cpp
+++ b/client/ui/models/servers_model.cpp
@@ -649,7 +649,13 @@ QPair<QString, QString> ServersModel::getDnsPair(int serverIndex)
 {
     QPair<QString, QString> dns;
 
-    const QJsonObject &server = m_servers.at(m_processedServerIndex).toObject();
+    if (serverIndex < 0 || serverIndex >= m_servers.size()) {
+        dns.first = m_settings->primaryDns();
+        dns.second = m_settings->secondaryDns();
+        return dns;
+    }
+
+    const QJsonObject &server = m_servers.at(serverIndex).toObject();
     const auto containers = server.value(config_key::containers).toArray();
     bool isDnsContainerInstalled = false;
     for (const QJsonValue &container : containers) {
@@ -658,8 +664,15 @@ QPair<QString, QString> ServersModel::getDnsPair(int serverIndex)
         }
     }
 
-    dns.first = server.value(config_key::dns1).toString();
-    dns.second = server.value(config_key::dns2).toString();
+    // For configs with configVersion == 0, prefer DNS from app settings.
+    const bool isApiConfig = server.value(config_key::configVersion).toInt() != 0;
+    if (isApiConfig) {
+        dns.first = server.value(config_key::dns1).toString();
+        dns.second = server.value(config_key::dns2).toString();
+    } else {
+        dns.first = m_settings->primaryDns();
+        dns.second = m_settings->secondaryDns();
+    }
 
     if (dns.first.isEmpty() || !NetworkUtilities::checkIPv4Format(dns.first)) {
         if (m_isAmneziaDnsEnabled && isDnsContainerInstalled) {
@@ -671,7 +684,8 @@ QPair<QString, QString> ServersModel::getDnsPair(int serverIndex)
         dns.second = m_settings->secondaryDns();
     }
 
-    qDebug() << "VpnConfigurator::getDnsForConfig" << dns.first << dns.second;
+    qDebug() << "VpnConfigurator::getDnsForConfig" << dns.first << dns.second
+             << "isApiConfig:" << isApiConfig << "serverIndex:" << serverIndex;
     return dns;
 }
 


### PR DESCRIPTION
## Problem
  For non-API profiles (`config_version == 0`), Custom DNS from app settings could be ignored.
  This was especially visible for shared/imported self-hosted profiles, where DNS embedded in the profile overrode GUI Custom DNS.

Additionally, Android WireGuard could apply DNS in the wrong primary/secondary order.

## Root cause
- DNS selection for non-API profiles did not consistently prioritize app DNS settings.
- `ServersModel::getDnsPair()` was not strictly tied to the requested server index.
- Android WG config generation did not preserve DNS order from input.

## Solution
- Updated `ServersModel::getDnsPair(serverIndex)` to always use the requested `serverIndex`.
- For non-API profiles (`config_version == 0`), prefer app Custom DNS (`primaryDns`/`secondaryDns`).
- Kept API-config behavior unchanged (server-provided DNS is still used there).
- Preserved primary/secondary DNS order in Android WireGuard config generation.

## Result
- Custom DNS now works for shared/imported non-API profiles (including self-hosted flows).
- Android WireGuard keeps DNS order exactly as configured.

## Related issues
- #1591