### PR TITLE
Fix systemd-resolved CPU spikes caused by Kill Switch DNS leak protection on Linux

### DIFF
--- a/client/platforms/linux/daemon/dnsutilslinux.cpp
+++ b/client/platforms/linux/daemon/dnsutilslinux.cpp
@@ -7,8 +7,10 @@
 #include <net/if.h>
 
 #include <QDBusVariant>
+#include <QNetworkInterface>
 #include <QtDBus/QtDBus>
 
+#include "core/networkUtilities.h"
 #include "leakdetector.h"
 #include "logger.h"
 
@@ -34,6 +36,16 @@ DnsUtilsLinux::DnsUtilsLinux(QObject* parent) : DnsUtils(parent) {
 DnsUtilsLinux::~DnsUtilsLinux() {
   MZ_COUNT_DTOR(DnsUtilsLinux);
 
+  for (auto iterator = m_linkDefaultRoutes.constBegin();
+       iterator != m_linkDefaultRoutes.constEnd(); ++iterator) {
+    QList<QVariant> argumentList;
+    argumentList << QVariant::fromValue(iterator.key());
+    argumentList << QVariant::fromValue(iterator.value());
+    m_resolver->asyncCallWithArgumentList(QStringLiteral("SetLinkDefaultRoute"),
+                                          argumentList);
+  }
+  m_linkDefaultRoutes.clear();
+
   for (auto iterator = m_linkDomains.constBegin();
        iterator != m_linkDomains.constEnd(); ++iterator) {
     QList<QVariant> argumentList;
@@ -52,12 +64,21 @@ DnsUtilsLinux::~DnsUtilsLinux() {
 
 bool DnsUtilsLinux::updateResolvers(const QString& ifname,
                                     const QList<QHostAddress>& resolvers) {
+  for (auto iterator = m_linkDefaultRoutes.constBegin();
+       iterator != m_linkDefaultRoutes.constEnd(); ++iterator) {
+    setLinkDefaultRoute(iterator.key(), iterator.value());
+  }
+  m_linkDefaultRoutes.clear();
+
   m_ifindex = if_nametoindex(qPrintable(ifname));
   if (m_ifindex <= 0) {
     logger.error() << "Unable to resolve ifindex for" << ifname;
     return false;
   }
 
+  // Avoid transient "both links are default-route" state: this state can
+  // overload systemd-resolved when the uplink DNS becomes unreachable via VPN.
+  updateLinkDefaultRoutes();
   setLinkDNS(m_ifindex, resolvers);
   setLinkDefaultRoute(m_ifindex, true);
   updateLinkDomains();
@@ -65,6 +86,12 @@ bool DnsUtilsLinux::updateResolvers(const QString& ifname,
 }
 
 bool DnsUtilsLinux::restoreResolvers() {
+  for (auto iterator = m_linkDefaultRoutes.constBegin();
+       iterator != m_linkDefaultRoutes.constEnd(); ++iterator) {
+    setLinkDefaultRoute(iterator.key(), iterator.value());
+  }
+  m_linkDefaultRoutes.clear();
+
   for (auto iterator = m_linkDomains.constBegin();
        iterator != m_linkDomains.constEnd(); ++iterator) {
     setLinkDomains(iterator.key(), iterator.value());
@@ -155,6 +182,23 @@ void DnsUtilsLinux::setLinkDefaultRoute(int ifindex, bool enable) {
                    SLOT(dnsCallCompleted(QDBusPendingCallWatcher*)));
 }
 
+void DnsUtilsLinux::updateLinkDefaultRoutes() {
+  const QNetworkInterface defaultIface = NetworkUtilities::getGatewayAndIface().second;
+  const int ifindex = defaultIface.index();
+  if (ifindex <= 0) {
+    logger.warning() << "Unable to determine default route interface";
+    return;
+  }
+  if ((ifindex == m_ifindex) || m_linkDefaultRoutes.contains(ifindex)) {
+    return;
+  }
+
+  // Gateway link normally has DefaultRoute=yes. Keep behavior simple:
+  // disable it while VPN DNS is active and restore to yes on teardown.
+  m_linkDefaultRoutes[ifindex] = true;
+  setLinkDefaultRoute(ifindex, false);
+}
+
 void DnsUtilsLinux::updateLinkDomains() {
   /* Get the list of search domains, and remove any others that might conspire
    * to satisfy DNS resolution. Unfortunately, this is a pain because Qt doesn't
@@ -206,6 +250,7 @@ void DnsUtilsLinux::dnsDomainsReceived(QDBusPendingCallWatcher* call) {
   /* Add a root search domain for the new interface. */
   QList<DnsLinkDomain> newlist = {root};
   setLinkDomains(m_ifindex, newlist);
+  updateLinkDefaultRoutes();
   delete call;
 }
 

--- a/client/platforms/linux/daemon/dnsutilslinux.h
+++ b/client/platforms/linux/daemon/dnsutilslinux.h
@@ -26,6 +26,7 @@ class DnsUtilsLinux final : public DnsUtils {
   void setLinkDNS(int ifindex, const QList<QHostAddress>& resolvers);
   void setLinkDomains(int ifindex, const QList<DnsLinkDomain>& domains);
   void setLinkDefaultRoute(int ifindex, bool enable);
+  void updateLinkDefaultRoutes();
   void updateLinkDomains();
 
  private slots:
@@ -35,6 +36,7 @@ class DnsUtilsLinux final : public DnsUtils {
  private:
   int m_ifindex = 0;
   QMap<int, DnsLinkDomainList> m_linkDomains;
+  QMap<int, bool> m_linkDefaultRoutes;
   QDBusInterface* m_resolver = nullptr;
 };
 

--- a/service/server/router_linux.cpp
+++ b/service/server/router_linux.cpp
@@ -170,19 +170,24 @@ bool RouterLinux::flushDns()
         qDebug() << "Restarting nscd.service";
         p.start("systemctl", { "restart", "nscd" });
     } else if (isServiceActive("systemd-resolved.service")) {
-        qDebug() << "Restarting systemd-resolved.service";
-        p.start("systemctl", { "restart", "systemd-resolved" });
+        qDebug() << "Flushing systemd-resolved DNS cache";
+        p.start("resolvectl", { "flush-caches" });
     } else {
         qDebug() << "No suitable DNS manager found.";
         return false;
     }
 
     p.waitForFinished();
-    QByteArray output(p.readAll());
+    QByteArray output = p.readAll();
+    if ((p.exitStatus() != QProcess::NormalExit) || (p.exitCode() != 0)) {
+        qDebug().noquote() << "Failed to flush DNS: " + output;
+        return false;
+    }
+
     if (output.isEmpty())
         qDebug().noquote() << "Flush dns completed";
     else
-        qDebug().noquote() << "OUTPUT systemctl restart nscd/systemd-resolved: " + output;
+        qDebug().noquote() << "OUTPUT dns flush: " + output;
 
     return true;
 }


### PR DESCRIPTION
## Problem
Repro is with Kill Switch enabled (default).

In this mode, Linux firewall enables [`310.blockDNS`](https://github.com/ilsme/amnezia-client/blob/pr/linux-resolved-cpu/client/platforms/linux/daemon/linuxfirewall.cpp#L250-L252) and allows DNS only via [`320.allowDNS`](https://github.com/ilsme/amnezia-client/blob/pr/linux-resolved-cpu/client/platforms/linux/daemon/linuxfirewall.cpp#L248) to configured DNS servers on VPN interfaces ([`updateDNSServers`](https://github.com/ilsme/amnezia-client/blob/pr/linux-resolved-cpu/client/platforms/linux/daemon/linuxfirewall.cpp#L446-L453), rules from [`getDNSRules`](https://github.com/ilsme/amnezia-client/blob/pr/linux-resolved-cpu/client/platforms/linux/daemon/linuxfirewall.cpp#L190-L200)).

So DNS to router/uplink (for example `192.168.50.1:53` on `wlo1`) is rejected by iptables. Kill Switch path that enables this: [`KillSwitch::enableKillSwitch`](https://github.com/ilsme/amnezia-client/blob/pr/linux-resolved-cpu/service/server/killswitch.cpp#L326-L347).

If `systemd-resolved` has `DefaultRoute=yes` on both uplink and tunnel links, it still tries uplink DNS, gets `ECONNREFUSED`, and enters a frequent non-blocking retry loop (epoll/syscall wakeups), causing high CPU usage.

Disabling Kill Switch avoids this path but weakens DNS leak protection.

Related: #1532

## Fix
- During VPN DNS apply, set `DefaultRoute=no` on non-tunnel uplink link.
- Keep `DefaultRoute=yes` on tunnel link.
- Restore previous per-link `DefaultRoute` state on teardown (best-effort).
- Use `resolvectl flush-caches` instead of restarting `systemd-resolved`.
