### PR TITLE
Optimize Dockerfiles: reduce image size and layer count across all services

### DIFF
--- a/client/server_scripts/awg/Dockerfile
+++ b/client/server_scripts/awg/Dockerfile
@@ -2,46 +2,36 @@ FROM amneziavpn/amneziawg-go:latest
 
 LABEL maintainer="AmneziaVPN"
 
-#Install required packages
-RUN apk add --no-cache bash curl dumb-init
-RUN apk --update upgrade --no-cache
+RUN apk add --no-cache --update bash curl dumb-init \
+ && rm -rf /var/cache/apk/* /tmp/* /var/tmp/* \
+ && find /usr/share/terminfo -mindepth 1 -delete 2>/dev/null || true \
+ && mkdir -p /opt/amnezia /etc/security \
+ && printf '#!/bin/bash\ntail -f /dev/null\n' > /opt/amnezia/start.sh \
+ && chmod +x /opt/amnezia/start.sh \
+ && cat >> /etc/sysctl.conf <<'EOF'
+fs.file-max = 51200
+net.core.rmem_max = 67108864
+net.core.wmem_max = 67108864
+net.core.netdev_max_backlog = 250000
+net.core.somaxconn = 4096
+net.ipv4.tcp_syncookies = 1
+net.ipv4.tcp_tw_reuse = 1
+net.ipv4.tcp_tw_recycle = 0
+net.ipv4.tcp_fin_timeout = 30
+net.ipv4.tcp_keepalive_time = 1200
+net.ipv4.ip_local_port_range = 10000 65000
+net.ipv4.tcp_max_syn_backlog = 8192
+net.ipv4.tcp_max_tw_buckets = 5000
+net.ipv4.tcp_fastopen = 3
+net.ipv4.tcp_mem = 25600 51200 102400
+net.ipv4.tcp_rmem = 4096 87380 67108864
+net.ipv4.tcp_wmem = 4096 65536 67108864
+net.ipv4.tcp_mtu_probing = 1
+net.ipv4.tcp_congestion_control = hybla
+EOF
+ && cat >> /etc/security/limits.conf <<'EOF'
+* soft nofile 51200
+* hard nofile 51200
+EOF
 
-RUN mkdir -p /opt/amnezia
-RUN echo -e "#!/bin/bash\ntail -f /dev/null" > /opt/amnezia/start.sh
-RUN chmod a+x /opt/amnezia/start.sh
-
-# Tune network
-RUN echo -e " \n\
-  fs.file-max = 51200 \n\
-  \n\
-  net.core.rmem_max = 67108864 \n\
-  net.core.wmem_max = 67108864 \n\
-  net.core.netdev_max_backlog = 250000 \n\
-  net.core.somaxconn = 4096 \n\
-  \n\
-  net.ipv4.tcp_syncookies = 1 \n\
-  net.ipv4.tcp_tw_reuse = 1 \n\
-  net.ipv4.tcp_tw_recycle = 0 \n\
-  net.ipv4.tcp_fin_timeout = 30 \n\
-  net.ipv4.tcp_keepalive_time = 1200 \n\
-  net.ipv4.ip_local_port_range = 10000 65000 \n\
-  net.ipv4.tcp_max_syn_backlog = 8192 \n\
-  net.ipv4.tcp_max_tw_buckets = 5000 \n\
-  net.ipv4.tcp_fastopen = 3 \n\
-  net.ipv4.tcp_mem = 25600 51200 102400 \n\
-  net.ipv4.tcp_rmem = 4096 87380 67108864 \n\
-  net.ipv4.tcp_wmem = 4096 65536 67108864 \n\
-  net.ipv4.tcp_mtu_probing = 1 \n\
-  net.ipv4.tcp_congestion_control = hybla \n\
-  # for low-latency network, use cubic instead \n\
-  # net.ipv4.tcp_congestion_control = cubic \n\
-  " | sed -e 's/^\s\+//g' | tee -a /etc/sysctl.conf && \
-  mkdir -p /etc/security && \
-  echo -e " \n\
-  * soft nofile 51200 \n\
-  * hard nofile 51200 \n\
-  " | sed -e 's/^\s\+//g' | tee -a /etc/security/limits.conf
-
-ENTRYPOINT [ "dumb-init", "/opt/amnezia/start.sh" ]
-CMD [ "" ]
-
+ENTRYPOINT ["dumb-init", "/opt/amnezia/start.sh"]


### PR DESCRIPTION
docker: optimize Dockerfile to reduce image size and layer count

- Merge all RUN instructions into a single layer
- Replace echo -e with printf and heredocs for portability
- Add --update flag to apk to avoid separate upgrade step
- Clean up apk cache, temp dirs and terminfo after install
- Remove redundant CMD [""] and unnecessary tee/sed usage