### PR TITLE
fix: address AmneziaDNS deploy regressions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ project(${PROJECT} VERSION ${AMNEZIAVPN_VERSION}
         HOMEPAGE_URL "https://amnezia.org/"
 )
 
+include(CTest)
+
 string(TIMESTAMP CURRENT_DATE "%Y-%m-%d")
 set(RELEASE_DATE "${CURRENT_DATE}")
 
@@ -43,6 +45,10 @@ if(APPLE)
 endif()
 
 add_subdirectory(client)
+
+if(BUILD_TESTING)
+    add_subdirectory(client/tests)
+endif()
 
 if(NOT IOS AND NOT ANDROID AND NOT MACOS_NE)
     add_subdirectory(service)

--- a/client/core/controllers/serverController.cpp
+++ b/client/core/controllers/serverController.cpp
@@ -530,7 +530,7 @@ ErrorCode ServerController::configureContainerWorker(const ServerCredentials &cr
 
 ErrorCode ServerController::startupContainerWorker(const ServerCredentials &credentials, DockerContainer container, const QJsonObject &config)
 {
-    QString script = amnezia::scriptData(ProtocolScriptType::container_startup, container);
+    QString script = amnezia::scriptDataIfExists(ProtocolScriptType::container_startup, container);
 
     if (script.isEmpty()) {
         return ErrorCode::NoError;

--- a/client/core/scripts_registry.cpp
+++ b/client/core/scripts_registry.cpp
@@ -4,6 +4,29 @@
 #include <QFile>
 #include <QObject>
 
+namespace
+{
+QString protocolScriptPath(amnezia::ProtocolScriptType type, amnezia::DockerContainer container)
+{
+    return QString(":/server_scripts/%1/%2").arg(amnezia::scriptFolder(container), amnezia::scriptName(type));
+}
+
+QString readProtocolScript(const QString &fileName, bool warnIfMissing)
+{
+    QFile file(fileName);
+    if (!file.open(QIODevice::ReadOnly)) {
+        if (warnIfMissing) {
+            qDebug() << "Warning: script missing" << fileName;
+        }
+        return {};
+    }
+
+    QByteArray data = file.readAll();
+    data.replace("\r", "");
+    return QString::fromUtf8(data);
+}
+} // namespace
+
 QString amnezia::scriptFolder(amnezia::DockerContainer container)
 {
     switch (container) {
@@ -72,13 +95,10 @@ QString amnezia::scriptData(amnezia::SharedScriptType type)
 
 QString amnezia::scriptData(amnezia::ProtocolScriptType type, DockerContainer container)
 {
-    QString fileName = QString(":/server_scripts/%1/%2").arg(amnezia::scriptFolder(container), amnezia::scriptName(type));
-    QFile file(fileName);
-    if (!file.open(QIODevice::ReadOnly)) {
-        qDebug() << "Warning: script missing" << fileName;
-        return "";
-    }
-    QByteArray data = file.readAll();
-    data.replace("\r", "");
-    return data;
+    return readProtocolScript(protocolScriptPath(type, container), true);
+}
+
+QString amnezia::scriptDataIfExists(amnezia::ProtocolScriptType type, DockerContainer container)
+{
+    return readProtocolScript(protocolScriptPath(type, container), false);
 }

--- a/client/core/scripts_registry.h
+++ b/client/core/scripts_registry.h
@@ -39,6 +39,7 @@ QString scriptName(ProtocolScriptType type);
 
 QString scriptData(SharedScriptType type);
 QString scriptData(ProtocolScriptType type, DockerContainer container);
+QString scriptDataIfExists(ProtocolScriptType type, DockerContainer container);
 }
 
 #endif // SCRIPTS_REGISTRY_H

--- a/client/tests/CMakeLists.txt
+++ b/client/tests/CMakeLists.txt
@@ -1,0 +1,64 @@
+cmake_minimum_required(VERSION 3.25.0)
+
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    project(AmneziaClientTests LANGUAGES CXX)
+    set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CLIENT_ROOT_DIR ${CMAKE_CURRENT_LIST_DIR}/..)
+
+find_package(Qt6 REQUIRED COMPONENTS Core Gui Qml Quick QuickTest Test)
+
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    add_subdirectory(${CLIENT_ROOT_DIR}/3rd/SortFilterProxyModel ${CMAKE_CURRENT_BINARY_DIR}/SortFilterProxyModel)
+endif()
+
+add_executable(tst_scripts_registry
+    core/tst_scripts_registry.cpp
+    ${CLIENT_ROOT_DIR}/core/scripts_registry.cpp
+    ${CLIENT_ROOT_DIR}/containers/containers_defs.cpp
+    ${CLIENT_ROOT_DIR}/protocols/protocols_defs.cpp
+    ${CLIENT_ROOT_DIR}/resources.qrc
+)
+
+target_include_directories(tst_scripts_registry PRIVATE
+    ${CLIENT_ROOT_DIR}
+)
+
+target_link_libraries(tst_scripts_registry PRIVATE
+    Qt6::Core
+    Qt6::Qml
+    Qt6::Test
+)
+
+add_executable(tst_client_qml
+    qml/tst_client_qml.cpp
+    ${CLIENT_ROOT_DIR}/resources.qrc
+)
+
+target_compile_definitions(tst_client_qml PRIVATE
+    QUICK_TEST_SOURCE_DIR="${CMAKE_CURRENT_LIST_DIR}/qml"
+    CLIENT_QML_MODULES_DIR="${CLIENT_ROOT_DIR}/ui/qml/Modules"
+)
+
+target_include_directories(tst_client_qml PRIVATE
+    ${CLIENT_ROOT_DIR}
+)
+
+target_link_libraries(tst_client_qml PRIVATE
+    Qt6::Core
+    Qt6::Gui
+    Qt6::Qml
+    Qt6::Quick
+    Qt6::QuickTest
+    SortFilterProxyModel
+)
+
+enable_testing()
+add_test(NAME tst_scripts_registry COMMAND tst_scripts_registry)
+add_test(NAME tst_client_qml COMMAND tst_client_qml)
+set_tests_properties(tst_client_qml PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")

--- a/client/tests/core/tst_scripts_registry.cpp
+++ b/client/tests/core/tst_scripts_registry.cpp
@@ -1,0 +1,60 @@
+#include <QtTest>
+
+#include "core/scripts_registry.h"
+
+namespace
+{
+QStringList *g_messages = nullptr;
+
+void testMessageHandler(QtMsgType, const QMessageLogContext &, const QString &message)
+{
+    if (g_messages) {
+        g_messages->append(message);
+    }
+}
+} // namespace
+
+class ScriptsRegistryTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void optionalStartupLookupReturnsEmptyWithoutWarning();
+    void strictLookupStillWarnsWhenMissing();
+};
+
+void ScriptsRegistryTest::optionalStartupLookupReturnsEmptyWithoutWarning()
+{
+    QStringList messages;
+    g_messages = &messages;
+    const auto previousHandler = qInstallMessageHandler(testMessageHandler);
+
+    const QString script = amnezia::scriptDataIfExists(amnezia::ProtocolScriptType::container_startup, amnezia::DockerContainer::Dns);
+
+    qInstallMessageHandler(previousHandler);
+    g_messages = nullptr;
+
+    QCOMPARE(script, QString());
+    QVERIFY2(!messages.join('\n').contains(":/server_scripts/dns/start.sh"),
+             "optional startup lookups must not emit missing-script warnings");
+}
+
+void ScriptsRegistryTest::strictLookupStillWarnsWhenMissing()
+{
+    QStringList messages;
+    g_messages = &messages;
+    const auto previousHandler = qInstallMessageHandler(testMessageHandler);
+
+    const QString script = amnezia::scriptData(amnezia::ProtocolScriptType::container_startup, amnezia::DockerContainer::Dns);
+
+    qInstallMessageHandler(previousHandler);
+    g_messages = nullptr;
+
+    QCOMPARE(script, QString());
+    QVERIFY2(messages.join('\n').contains(":/server_scripts/dns/start.sh"),
+             "strict startup lookups must keep the existing warning behavior");
+}
+
+QTEST_APPLESS_MAIN(ScriptsRegistryTest)
+
+#include "tst_scripts_registry.moc"

--- a/client/tests/qml/tst_client_qml.cpp
+++ b/client/tests/qml/tst_client_qml.cpp
@@ -1,0 +1,130 @@
+#include <QtQuickTest/quicktest.h>
+
+#include <QQmlContext>
+#include <QQmlEngine>
+#include <QObject>
+
+namespace TestPageEnumNS
+{
+Q_NAMESPACE
+
+enum PageEnum {
+    PageDeinstalling = 0,
+    PageSetupWizardEasy
+};
+Q_ENUM_NS(PageEnum)
+} // namespace TestPageEnumNS
+
+class MockSettingsController : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(int safeAreaTopMargin READ safeAreaTopMargin CONSTANT)
+
+public:
+    int safeAreaTopMargin() const { return 0; }
+
+    Q_INVOKABLE bool isAmneziaDnsEnabled() const { return false; }
+};
+
+class MockContainersModel : public QObject
+{
+    Q_OBJECT
+
+public:
+    Q_INVOKABLE QString getProcessedContainerName() const { return QStringLiteral("AmneziaDNS"); }
+};
+
+class MockFocusController : public QObject
+{
+    Q_OBJECT
+
+public:
+    Q_INVOKABLE void resetRootObject() {}
+    Q_INVOKABLE void setFocusOnDefaultItem() {}
+    Q_INVOKABLE void nextKeyTabItem() {}
+    Q_INVOKABLE void previousKeyTabItem() {}
+    Q_INVOKABLE void nextKeyUpItem() {}
+    Q_INVOKABLE void nextKeyDownItem() {}
+    Q_INVOKABLE void nextKeyLeftItem() {}
+    Q_INVOKABLE void nextKeyRightItem() {}
+};
+
+class MockLanguageModel : public QObject
+{
+    Q_OBJECT
+
+public:
+    Q_INVOKABLE int getLineHeightAppend() const { return 0; }
+};
+
+class MockServersModel : public QObject
+{
+    Q_OBJECT
+
+public:
+    Q_INVOKABLE bool isDefaultServerCurrentlyProcessed() const { return false; }
+};
+
+class MockConnectionController : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(bool isConnected READ isConnected CONSTANT)
+
+public:
+    bool isConnected() const { return false; }
+};
+
+class MockPageController : public QObject
+{
+    Q_OBJECT
+
+public:
+    Q_INVOKABLE void showNotificationMessage(const QString &) {}
+    Q_INVOKABLE void goToPage(int, bool = true) {}
+};
+
+class MockInstallController : public QObject
+{
+    Q_OBJECT
+
+public:
+    Q_INVOKABLE void removeProcessedContainer() {}
+};
+
+class ClientQmlSetup : public QObject
+{
+    Q_OBJECT
+
+public slots:
+    void applicationAvailable()
+    {
+        qmlRegisterUncreatableMetaObject(TestPageEnumNS::staticMetaObject, "PageEnum", 1, 0, "PageEnum", "Error: only enums");
+    }
+
+    void qmlEngineAvailable(QQmlEngine *engine)
+    {
+        engine->addImportPath(QStringLiteral(CLIENT_QML_MODULES_DIR));
+        engine->rootContext()->setContextProperty("SettingsController", &m_settingsController);
+        engine->rootContext()->setContextProperty("ContainersModel", &m_containersModel);
+        engine->rootContext()->setContextProperty("FocusController", &m_focusController);
+        engine->rootContext()->setContextProperty("LanguageModel", &m_languageModel);
+        engine->rootContext()->setContextProperty("ServersModel", &m_serversModel);
+        engine->rootContext()->setContextProperty("ConnectionController", &m_connectionController);
+        engine->rootContext()->setContextProperty("PageController", &m_pageController);
+        engine->rootContext()->setContextProperty("InstallController", &m_installController);
+    }
+
+private:
+    MockSettingsController m_settingsController;
+    MockContainersModel m_containersModel;
+    MockFocusController m_focusController;
+    MockLanguageModel m_languageModel;
+    MockServersModel m_serversModel;
+    MockConnectionController m_connectionController;
+    MockPageController m_pageController;
+    MockInstallController m_installController;
+};
+
+QUICK_TEST_MAIN_WITH_SETUP(ClientQml, ClientQmlSetup)
+
+#include "tst_client_qml.moc"

--- a/client/tests/qml/tst_page_service_dns_settings.qml
+++ b/client/tests/qml/tst_page_service_dns_settings.qml
@@ -1,0 +1,27 @@
+import QtQuick
+import QtTest 1.2
+
+Item {
+    width: 480
+    height: 720
+
+    Loader {
+        id: pageLoader
+        active: false
+        asynchronous: false
+        source: Qt.resolvedUrl("../../ui/qml/Pages2/PageServiceDnsSettings.qml")
+    }
+
+    TestCase {
+        name: "PageServiceDnsSettings"
+        when: windowShown
+
+        function test_page_loads_without_errors() {
+            failOnWarning(/removeButton is not defined/)
+            pageLoader.active = true
+
+            tryCompare(pageLoader, "status", Loader.Ready)
+            verify(pageLoader.item !== null)
+        }
+    }
+}

--- a/client/tests/qml/tst_text_field_with_header_type.qml
+++ b/client/tests/qml/tst_text_field_with_header_type.qml
@@ -1,0 +1,52 @@
+import QtQuick
+import QtTest 1.2
+
+import "../../ui/qml/Controls2"
+
+Item {
+    id: root
+    width: 360
+    height: 120
+    property int clickCount: 0
+
+    TextFieldWithHeaderType {
+        id: field
+        anchors.fill: parent
+        rightButtonClickedOnEnter: true
+        clickedFunc: function() {
+            root.clickCount += 1
+        }
+    }
+
+    TestCase {
+        name: "TextFieldWithHeaderType"
+        when: windowShown
+
+        function focusTextField() {
+            field.textField.forceActiveFocus()
+            verify(field.textField.activeFocus)
+        }
+
+        function test_return_without_visible_button_does_not_trigger() {
+            root.clickCount = 0
+            field.buttonText = ""
+            field.textField.text = "secret"
+            focusTextField()
+
+            keyClick(Qt.Key_Return)
+
+            compare(root.clickCount, 0)
+        }
+
+        function test_enter_with_visible_button_triggers() {
+            root.clickCount = 0
+            field.buttonText = "Toggle"
+            field.textField.text = "secret"
+            focusTextField()
+
+            keyClick(Qt.Key_Enter)
+
+            compare(root.clickCount, 1)
+        }
+    }
+}

--- a/client/ui/qml/Controls2/TextFieldWithHeaderType.qml
+++ b/client/ui/qml/Controls2/TextFieldWithHeaderType.qml
@@ -20,6 +20,7 @@ Item {
     property string buttonText
     property string buttonImageSource
     property var clickedFunc
+    readonly property bool hasRightButtonAction: (buttonText !== "") || (buttonImageSource !== "")
 
     property alias textField: textField
     property string textFieldTextColor: AmneziaStyle.color.paleGray
@@ -181,7 +182,7 @@ Item {
     }
 
     BasicButtonType {
-        visible: (root.buttonText !== "") || (root.buttonImageSource !== "")
+        visible: root.hasRightButtonAction
 
         focusPolicy: Qt.NoFocus
         text: root.buttonText
@@ -207,7 +208,8 @@ Item {
     }
 
     Keys.onEnterPressed: {
-        if (root.rightButtonClickedOnEnter && root.clickedFunc && typeof root.clickedFunc === "function") {
+        if (root.rightButtonClickedOnEnter && root.hasRightButtonAction
+                && root.clickedFunc && typeof root.clickedFunc === "function") {
             clickedFunc()
         }
 
@@ -217,7 +219,8 @@ Item {
     }
 
     Keys.onReturnPressed: {
-        if (root.rightButtonClickedOnEnter &&root.clickedFunc && typeof root.clickedFunc === "function") {
+        if (root.rightButtonClickedOnEnter && root.hasRightButtonAction
+                && root.clickedFunc && typeof root.clickedFunc === "function") {
             clickedFunc()
         }
 

--- a/client/ui/qml/Pages2/PageServiceDnsSettings.qml
+++ b/client/ui/qml/Pages2/PageServiceDnsSettings.qml
@@ -60,6 +60,8 @@ PageType {
             width: listView.width
 
             LabelWithButtonType {
+                id: removeButton
+
                 Layout.fillWidth: true
                 Layout.leftMargin: 16
                 Layout.rightMargin: 16


### PR DESCRIPTION
## Summary
This PR fixes three regressions encountered during AWG + AmneziaDNS installation and adds regression coverage for them.

- suppress the noisy missing `start.sh` warning for containers whose startup script is optional
- prevent `Enter` / `Return` in `TextFieldWithHeaderType` from triggering a hidden right-button action
- fix the undefined `removeButton` reference on the AmneziaDNS settings page
- add focused regression tests for the script registry path and the affected QML behavior

## Root Cause
The DNS deploy flow reused the generic container startup path, which always attempted to load `:/server_scripts/<container>/start.sh` even for containers where that resource does not exist. In parallel, the shared QML text field control invoked its action handler on `Enter` / `Return` without checking whether a right-side button was actually visible, and the DNS settings page referenced `removeButton` without declaring the id.

## Test Plan
- `cmake -S . -B build -DBUILD_TESTING=ON`
- `cmake --build build -j`
- `ctest --test-dir build-tests --output-on-failure -R 'tst_scripts_registry|tst_client_qml'