### PR TITLE
fix: missing system tray and window icons for Linux

### DIFF
--- a/client/main.cpp
+++ b/client/main.cpp
@@ -6,6 +6,7 @@
 #include "core/utils/osSignalHandler.h"
 #include "core/utils/migrations.h"
 #include "version.h"
+#include <QIcon>
 
 #ifdef Q_OS_WIN
     #include "Windows.h"
@@ -69,6 +70,7 @@ int main(int argc, char *argv[])
     app.setApplicationName(APPLICATION_NAME);
     app.setOrganizationName(ORGANIZATION_NAME);
     app.setApplicationDisplayName(APPLICATION_NAME);
+    app.setWindowIcon(QIcon::fromTheme("AmneziaVPN"));
 
     app.loadFonts();
 

--- a/client/ui/utils/systemTrayNotificationHandler.cpp
+++ b/client/ui/utils/systemTrayNotificationHandler.cpp
@@ -22,7 +22,6 @@ SystemTrayNotificationHandler::SystemTrayNotificationHandler(QObject* parent) :
     m_systemTrayIcon(parent)
 
 {
-    m_systemTrayIcon.show();
     connect(&m_systemTrayIcon, &QSystemTrayIcon::activated, this, &SystemTrayNotificationHandler::onTrayActivated);
 
     m_trayActionShow =  m_menu.addAction(QIcon(":/images/tray/application.png"), tr("Show") + " " + APPLICATION_NAME, this, [this](){
@@ -46,6 +45,7 @@ SystemTrayNotificationHandler::SystemTrayNotificationHandler(QObject* parent) :
 
     m_systemTrayIcon.setContextMenu(&m_menu);
     setTrayState(Vpn::ConnectionState::Disconnected);
+    m_systemTrayIcon.show();
 }
 
 SystemTrayNotificationHandler::~SystemTrayNotificationHandler() {


### PR DESCRIPTION
- Defer `QSystemTrayIcon::show()` until after the icon is set to fix the tray icon not appearing
- Add `setWindowIcon(QIcon::fromTheme("AmneziaVPN"))` to display the app icon in the taskbar

Tested on KDE Plasma 6 (Wayland)