### PR TITLE
feat: share all protocols in a single config

### DIFF
--- a/client/translations/amneziavpn_ar_EG.ts
+++ b/client/translations/amneziavpn_ar_EG.ts
@@ -3384,6 +3384,10 @@ Already installed containers were found on the server. All installed containers 
         <translation>اسم المستخدم</translation>
     </message>
     <message>
+        <source>Share all protocols</source>
+        <translation>مشاركة جميع البروتوكولات</translation>
+    </message>
+    <message>
         <location filename="../ui/qml/Pages2/PageShare.qml" line="479"/>
         <location filename="../ui/qml/Pages2/PageShare.qml" line="480"/>
         <source>Connection format</source>

--- a/client/translations/amneziavpn_fa_IR.ts
+++ b/client/translations/amneziavpn_fa_IR.ts
@@ -3530,6 +3530,10 @@ It&apos;s okay as long as it&apos;s from someone you trust.</source>
         <translation>پروتکل</translation>
     </message>
     <message>
+        <source>Share all protocols</source>
+        <translation>اشتراک‌گذاری همه پروتکل‌ها</translation>
+    </message>
+    <message>
         <location filename="../ui/qml/Pages2/PageShare.qml" line="479"/>
         <location filename="../ui/qml/Pages2/PageShare.qml" line="480"/>
         <source>Connection format</source>

--- a/client/translations/amneziavpn_hi_IN.ts
+++ b/client/translations/amneziavpn_hi_IN.ts
@@ -3431,6 +3431,10 @@ Already installed containers were found on the server. All installed containers 
         <translation>उपयोगकर्ता नाम</translation>
     </message>
     <message>
+        <source>Share all protocols</source>
+        <translation>सभी प्रोटोकॉल साझा करें</translation>
+    </message>
+    <message>
         <location filename="../ui/qml/Pages2/PageShare.qml" line="479"/>
         <location filename="../ui/qml/Pages2/PageShare.qml" line="480"/>
         <source>Connection format</source>

--- a/client/translations/amneziavpn_my_MM.ts
+++ b/client/translations/amneziavpn_my_MM.ts
@@ -3396,6 +3396,10 @@ Already installed containers were found on the server. All installed containers 
         <translation>ပရိုတိုကော</translation>
     </message>
     <message>
+        <source>Share all protocols</source>
+        <translation>ပရိုတိုကောအားလုံး မျှဝေမည်</translation>
+    </message>
+    <message>
         <location filename="../ui/qml/Pages2/PageShare.qml" line="479"/>
         <location filename="../ui/qml/Pages2/PageShare.qml" line="480"/>
         <source>Connection format</source>

--- a/client/translations/amneziavpn_ru_RU.ts
+++ b/client/translations/amneziavpn_ru_RU.ts
@@ -3788,6 +3788,10 @@ Thank you for staying with us!</source>
         <translation>Протокол</translation>
     </message>
     <message>
+        <source>Share all protocols</source>
+        <translation>Поделиться всеми протоколами</translation>
+    </message>
+    <message>
         <location filename="../ui/qml/Pages2/PageShare.qml" line="492"/>
         <location filename="../ui/qml/Pages2/PageShare.qml" line="493"/>
         <source>Connection format</source>

--- a/client/translations/amneziavpn_uk_UA.ts
+++ b/client/translations/amneziavpn_uk_UA.ts
@@ -3758,6 +3758,10 @@ and will not be shared or disclosed to the Amnezia or any third parties</source>
         <translation>Протокол</translation>
     </message>
     <message>
+        <source>Share all protocols</source>
+        <translation>Поділитися всіма протоколами</translation>
+    </message>
+    <message>
         <location filename="../ui/qml/Pages2/PageShare.qml" line="479"/>
         <location filename="../ui/qml/Pages2/PageShare.qml" line="480"/>
         <source>Connection format</source>

--- a/client/translations/amneziavpn_ur_PK.ts
+++ b/client/translations/amneziavpn_ur_PK.ts
@@ -3423,6 +3423,10 @@ Already installed containers were found on the server. All installed containers 
         <translation>صارف کا نام</translation>
     </message>
     <message>
+        <source>Share all protocols</source>
+        <translation>تمام پروٹوکولز کا اشتراک کریں</translation>
+    </message>
+    <message>
         <location filename="../ui/qml/Pages2/PageShare.qml" line="479"/>
         <location filename="../ui/qml/Pages2/PageShare.qml" line="480"/>
         <source>Connection format</source>

--- a/client/translations/amneziavpn_zh_CN.ts
+++ b/client/translations/amneziavpn_zh_CN.ts
@@ -3656,6 +3656,10 @@ and will not be shared or disclosed to the Amnezia or any third parties</source>
         <translation>用户名</translation>
     </message>
     <message>
+        <source>Share all protocols</source>
+        <translation>共享所有协议</translation>
+    </message>
+    <message>
         <location filename="../ui/qml/Pages2/PageShare.qml" line="479"/>
         <location filename="../ui/qml/Pages2/PageShare.qml" line="480"/>
         <source>Connection format</source>

--- a/client/ui/controllers/exportController.cpp
+++ b/client/ui/controllers/exportController.cpp
@@ -98,6 +98,77 @@ void ExportController::generateConnectionConfig(const QString &clientName)
     emit exportConfigChanged();
 }
 
+void ExportController::generateMultiConnectionConfig(const QString &clientName)
+{
+    clearPreviousConfig();
+
+    int serverIndex = m_serversModel->getProcessedServerIndex();
+    ServerCredentials credentials = m_serversModel->getServerCredentials(serverIndex);
+    QJsonObject serverConfig = m_serversModel->getServerConfig(serverIndex);
+
+    QJsonArray originalContainers = serverConfig.value(config_key::containers).toArray();
+    QJsonArray newContainers;
+
+    QSharedPointer<ServerController> serverController(new ServerController(m_settings));
+    VpnConfigurationsController vpnConfigurationController(m_settings, serverController);
+
+    DockerContainer defaultContainer = DockerContainer::None;
+
+    for (int i = 0; i < originalContainers.size(); i++) {
+        QJsonObject containerConfig = originalContainers.at(i).toObject();
+        DockerContainer container = ContainerProps::containerFromString(
+            containerConfig.value(config_key::container).toString());
+
+        if (!ContainerProps::isShareable(container)) {
+            continue;
+        }
+
+        ErrorCode errorCode = vpnConfigurationController.createProtocolConfigForContainer(
+            credentials, container, containerConfig);
+        if (errorCode != ErrorCode::NoError) {
+            emit exportErrorOccurred(errorCode);
+            return;
+        }
+
+        errorCode = m_clientManagementModel->appendClient(
+            container, credentials, containerConfig, clientName, serverController);
+        if (errorCode != ErrorCode::NoError) {
+            emit exportErrorOccurred(errorCode);
+            return;
+        }
+
+        newContainers.append(containerConfig);
+
+        if (defaultContainer == DockerContainer::None) {
+            defaultContainer = container;
+        }
+    }
+
+    if (newContainers.isEmpty()) {
+        emit exportErrorOccurred(ErrorCode::InternalError);
+        return;
+    }
+
+    serverConfig.remove(config_key::userName);
+    serverConfig.remove(config_key::password);
+    serverConfig.remove(config_key::port);
+    serverConfig.insert(config_key::containers, newContainers);
+    serverConfig.insert(config_key::defaultContainer,
+        ContainerProps::containerToString(defaultContainer));
+
+    auto dns = m_serversModel->getDnsPair(serverIndex);
+    serverConfig.insert(config_key::dns1, dns.first);
+    serverConfig.insert(config_key::dns2, dns.second);
+
+    QByteArray compressedConfig = QJsonDocument(serverConfig).toJson();
+    compressedConfig = qCompress(compressedConfig, 8);
+    m_config = QString("vpn://%1").arg(QString(compressedConfig.toBase64(
+        QByteArray::Base64UrlEncoding | QByteArray::OmitTrailingEquals)));
+
+    m_qrCodes = qrCodeUtils::generateQrCodeImageSeries(compressedConfig);
+    emit exportConfigChanged();
+}
+
 ErrorCode ExportController::generateNativeConfig(const DockerContainer container, const QString &clientName, const Proto &protocol,
                                                  QJsonObject &jsonNativeConfig)
 {

--- a/client/ui/controllers/exportController.h
+++ b/client/ui/controllers/exportController.h
@@ -23,6 +23,7 @@ public:
 public slots:
     void generateFullAccessConfig();
     void generateConnectionConfig(const QString &clientName);
+    void generateMultiConnectionConfig(const QString &clientName);
     void generateOpenVpnConfig(const QString &clientName);
     void generateWireGuardConfig(const QString &clientName);
     void generateAwgConfig(const QString &clientName);

--- a/client/ui/qml/Pages2/PageShare.qml
+++ b/client/ui/qml/Pages2/PageShare.qml
@@ -26,7 +26,8 @@ PageType {
         Awg,
         ShadowSocks,
         Cloak,
-        Xray
+        Xray,
+        AmneziaMultiConnection
     }
 
     Connections {
@@ -47,6 +48,13 @@ PageType {
             switch (type) {
             case PageShare.ConfigType.AmneziaConnection: {
                 ExportController.generateConnectionConfig(clientNameTextField.textField.text);
+                configCaption = qsTr("Save AmneziaVPN config")
+                configExtension = ".vpn"
+                configFileName = "amnezia_config"
+                break;
+            }
+            case PageShare.ConfigType.AmneziaMultiConnection: {
+                ExportController.generateMultiConnectionConfig(clientNameTextField.textField.text);
                 configCaption = qsTr("Save AmneziaVPN config")
                 configExtension = ".vpn"
                 configFileName = "amnezia_config"
@@ -372,6 +380,18 @@ PageType {
                 }
             }
 
+            CheckBoxType {
+                id: allProtocolsCheckBox
+
+                Layout.fillWidth: true
+                Layout.topMargin: 16
+
+                visible: accessTypeSelector.currentIndex === 0
+
+                text: qsTr("Share all protocols")
+                checked: false
+            }
+
             DropDownType {
                 id: protocolSelector
 
@@ -379,6 +399,8 @@ PageType {
 
                 Layout.fillWidth: true
                 Layout.topMargin: 16
+
+                visible: !allProtocolsCheckBox.checked
 
                 drawerHeight: 0.5
                 drawerParent: root
@@ -486,7 +508,7 @@ PageType {
                 drawerHeight: 0.4375
                 drawerParent: root
 
-                visible: accessTypeSelector.currentIndex === 0
+                visible: accessTypeSelector.currentIndex === 0 && !allProtocolsCheckBox.checked
                 enabled: root.connectionTypesModel.length > 1
 
                 descriptionText: qsTr("Connection format")
@@ -556,7 +578,11 @@ PageType {
 
                 clickedFunc: function(){
                     if (clientNameTextField.textField.text !== "") {
-                        ExportController.generateConfig(root.connectionTypesModel[exportTypeSelector.currentIndex].type)
+                        if (allProtocolsCheckBox.checked) {
+                            ExportController.generateConfig(PageShare.ConfigType.AmneziaMultiConnection)
+                        } else {
+                            ExportController.generateConfig(root.connectionTypesModel[exportTypeSelector.currentIndex].type)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Add ability to share all server protocols at once via a single AmneziaVPN config instead of sharing each protocol separately.

- Add generateMultiConnectionConfig() to ExportController
- Add 'Share all protocols' checkbox to PageShare.qml
- Add translations for all 8 supported languages