### PR TITLE
perf: fix UI freezes, optimize rendering, add live speed indicator

### DIFF
--- a/client/protocols/wireguardprotocol.cpp
+++ b/client/protocols/wireguardprotocol.cpp
@@ -16,6 +16,7 @@ WireguardProtocol::WireguardProtocol(const QJsonObject &configuration, QObject *
     connect(m_impl.get(), &ControllerImpl::connected, this,
             [this](const QString &pubkey, const QDateTime &connectionTimestamp) {
                 setConnectionState(Vpn::ConnectionState::Connected);
+                m_statsTimer.start();
             });
     connect(m_impl.get(), &ControllerImpl::statusUpdated, this,
             [this](const QString& serverIpv4Gateway,
@@ -35,10 +36,18 @@ WireguardProtocol::WireguardProtocol(const QJsonObject &configuration, QObject *
                     (!m_vpnLocalAddress.isEmpty() && m_vpnLocalAddress != previousLocal)) {
                     emit tunnelAddressesUpdated(m_vpnGateway, m_vpnLocalAddress);
                 }
+
+                setBytesChanged(rxBytes, txBytes);
             });
 
+    m_statsTimer.setInterval(1000);
+    connect(&m_statsTimer, &QTimer::timeout, m_impl.get(), &ControllerImpl::checkStatus);
+
     connect(m_impl.get(), &ControllerImpl::disconnected, this,
-            [this]() { setConnectionState(Vpn::ConnectionState::Disconnected); });
+            [this]() {
+                m_statsTimer.stop();
+                setConnectionState(Vpn::ConnectionState::Disconnected);
+            });
     m_impl->initialize(nullptr, nullptr);
 }
 

--- a/client/protocols/wireguardprotocol.h
+++ b/client/protocols/wireguardprotocol.h
@@ -28,6 +28,7 @@ public:
 private:
 
     QScopedPointer<ControllerImpl> m_impl;
+    QTimer m_statsTimer;
 };
 
 #endif // WIREGUARDPROTOCOL_H

--- a/client/ui/controllers/api/apiSettingsController.cpp
+++ b/client/ui/controllers/api/apiSettingsController.cpp
@@ -1,8 +1,6 @@
 #include "apiSettingsController.h"
 
-#include <QEventLoop>
 #include <QJsonDocument>
-#include <QTimer>
 
 #include "core/api/apiUtils.h"
 #include "core/controllers/gatewayController.h"
@@ -45,12 +43,6 @@ ApiSettingsController::~ApiSettingsController()
 
 bool ApiSettingsController::getAccountInfo(bool reload)
 {
-    if (reload) {
-        QEventLoop wait;
-        QTimer::singleShot(1000, &wait, &QEventLoop::quit);
-        wait.exec(QEventLoop::ExcludeUserInputEvents);
-    }
-
     auto processedIndex = m_serversModel->getProcessedServerIndex();
     auto serverConfig = m_serversModel->getServerConfig(processedIndex);
     auto apiConfig = serverConfig.value(configKey::apiConfig).toObject();

--- a/client/ui/controllers/connectionController.cpp
+++ b/client/ui/controllers/connectionController.cpp
@@ -23,6 +23,7 @@ ConnectionController::ConnectionController(const QSharedPointer<ServersModel> &s
       m_settings(settings)
 {
     connect(m_vpnConnection.get(), &VpnConnection::connectionStateChanged, this, &ConnectionController::onConnectionStateChanged);
+    connect(m_vpnConnection.get(), &VpnConnection::bytesChanged, this, &ConnectionController::onBytesChanged);
     connect(this, &ConnectionController::connectToVpn, m_vpnConnection.get(), &VpnConnection::connectToVpn, Qt::QueuedConnection);
     connect(this, &ConnectionController::disconnectFromVpn, m_vpnConnection.get(), &VpnConnection::disconnectFromVpn, Qt::QueuedConnection);
 
@@ -98,6 +99,9 @@ void ConnectionController::onConnectionStateChanged(Vpn::ConnectionState state)
     case Vpn::ConnectionState::Disconnected: {
         m_isConnectionInProgress = false;
         m_connectionStateText = tr("Connect");
+        m_downloadSpeed.clear();
+        m_uploadSpeed.clear();
+        emit speedChanged();
         break;
     }
     case Vpn::ConnectionState::Disconnecting: {
@@ -176,4 +180,31 @@ bool ConnectionController::isConnectionInProgress() const
 bool ConnectionController::isConnected() const
 {
     return m_isConnected;
+}
+
+void ConnectionController::onBytesChanged(quint64 receivedBytes, quint64 sentBytes)
+{
+    qint64 elapsedMs = m_speedTimer.isValid() ? m_speedTimer.elapsed() : 0;
+    m_speedTimer.restart();
+
+    if (elapsedMs > 0) {
+        quint64 rxPerSec = receivedBytes * 1000 / static_cast<quint64>(elapsedMs);
+        quint64 txPerSec = sentBytes * 1000 / static_cast<quint64>(elapsedMs);
+        m_downloadSpeed = VpnConnection::bytesPerSecToText(rxPerSec);
+        m_uploadSpeed   = VpnConnection::bytesPerSecToText(txPerSec);
+    } else {
+        m_downloadSpeed = VpnConnection::bytesPerSecToText(receivedBytes);
+        m_uploadSpeed   = VpnConnection::bytesPerSecToText(sentBytes);
+    }
+    emit speedChanged();
+}
+
+QString ConnectionController::downloadSpeed() const
+{
+    return m_downloadSpeed;
+}
+
+QString ConnectionController::uploadSpeed() const
+{
+    return m_uploadSpeed;
 }

--- a/client/ui/controllers/connectionController.h
+++ b/client/ui/controllers/connectionController.h
@@ -1,6 +1,8 @@
 #ifndef CONNECTIONCONTROLLER_H
 #define CONNECTIONCONTROLLER_H
 
+#include <QElapsedTimer>
+
 #include "protocols/vpnprotocol.h"
 #include "ui/models/clientManagementModel.h"
 #include "ui/models/containers_model.h"
@@ -15,6 +17,8 @@ public:
     Q_PROPERTY(bool isConnected READ isConnected NOTIFY connectionStateChanged)
     Q_PROPERTY(bool isConnectionInProgress READ isConnectionInProgress NOTIFY connectionStateChanged)
     Q_PROPERTY(QString connectionStateText READ connectionStateText NOTIFY connectionStateChanged)
+    Q_PROPERTY(QString downloadSpeed READ downloadSpeed NOTIFY speedChanged)
+    Q_PROPERTY(QString uploadSpeed READ uploadSpeed NOTIFY speedChanged)
 
     explicit ConnectionController(const QSharedPointer<ServersModel> &serversModel, const QSharedPointer<ContainersModel> &containersModel,
                                   const QSharedPointer<ClientManagementModel> &clientManagementModel,
@@ -26,6 +30,8 @@ public:
     bool isConnected() const;
     bool isConnectionInProgress() const;
     QString connectionStateText() const;
+    QString downloadSpeed() const;
+    QString uploadSpeed() const;
 
 public slots:
     void toggleConnection();
@@ -40,6 +46,8 @@ public slots:
 
     void onTranslationsUpdated();
 
+    void onBytesChanged(quint64 receivedBytes, quint64 sentBytes);
+
 signals:
     void connectToVpn(int serverIndex, const ServerCredentials &credentials, DockerContainer container, const QJsonObject &vpnConfiguration);
     void disconnectFromVpn();
@@ -51,6 +59,8 @@ signals:
     void connectButtonClicked();
     void preparingConfig();
     void prepareConfig();
+
+    void speedChanged();
 
 private:
     Vpn::ConnectionState getCurrentConnectionState();
@@ -68,6 +78,10 @@ private:
     bool m_isConnected = false;
     bool m_isConnectionInProgress = false;
     QString m_connectionStateText = tr("Connect");
+
+    QString m_downloadSpeed;
+    QString m_uploadSpeed;
+    QElapsedTimer m_speedTimer;
 
     Vpn::ConnectionState m_state;
 };

--- a/client/ui/qml/Components/ConnectButton.qml
+++ b/client/ui/qml/Components/ConnectButton.qml
@@ -68,15 +68,15 @@ Button {
             height: parent.implicitHeight
             anchors.bottom: parent.bottom
             anchors.right: parent.right
-            layer.enabled: true
+            layer.enabled: !ConnectionController.isConnectionInProgress
             layer.samples: 4
             layer.smooth: true
             layer.effect: DropShadow {
                 anchors.fill: backgroundCircle
                 horizontalOffset: 0
                 verticalOffset: 0
-                radius: 10
-                samples: 25
+                radius: 8
+                samples: 9
                 color: root.buttonActiveFocus ? AmneziaStyle.color.paleGray : AmneziaStyle.color.goldenApricot
                 source: backgroundCircle
             }
@@ -135,8 +135,7 @@ Button {
             height: parent.implicitHeight
             anchors.bottom: parent.bottom
             anchors.right: parent.right
-            layer.enabled: true
-            layer.samples: 4
+            layer.enabled: false
 
             visible: ConnectionController.isConnectionInProgress
 

--- a/client/ui/qml/Components/ServersListView.qml
+++ b/client/ui/qml/Components/ServersListView.qml
@@ -42,6 +42,10 @@ ListViewType {
         property variant delegateData: model
         property VerticalRadioButton serverRadioButtonProperty: serverRadioButton
 
+        readonly property bool isExpired: isSubscriptionExpired
+        readonly property bool isExpiringSoon: isSubscriptionExpiringSoon
+        readonly property bool isApiServer: isServerFromGatewayApi
+
         implicitWidth: root.width
         implicitHeight: serverRadioButtonContent.implicitHeight
 
@@ -127,14 +131,14 @@ ListViewType {
             }
 
             CaptionTextType {
-                visible: isServerFromGatewayApi && (isSubscriptionExpired || isSubscriptionExpiringSoon)
+                visible: menuContentDelegate.isApiServer && (menuContentDelegate.isExpired || menuContentDelegate.isExpiringSoon)
 
                 Layout.fillWidth: true
                 Layout.leftMargin: 64
                 Layout.bottomMargin: 8
 
-                text: isSubscriptionExpired ? qsTr("Subscription expired. Please renew.") : qsTr("Subscription expiring soon.")
-                color: isSubscriptionExpired ? AmneziaStyle.color.vibrantRed : AmneziaStyle.color.goldenApricot
+                text: menuContentDelegate.isExpired ? qsTr("Subscription expired. Please renew.") : qsTr("Subscription expiring soon.")
+                color: menuContentDelegate.isExpired ? AmneziaStyle.color.vibrantRed : AmneziaStyle.color.goldenApricot
                 wrapMode: Text.WordWrap
             }
 

--- a/client/ui/qml/Controls2/BasicButtonType.qml
+++ b/client/ui/qml/Controls2/BasicButtonType.qml
@@ -94,10 +94,6 @@ Button {
             border.color: borderColor
             border.width: borderWidth
 
-            Behavior on color {
-                PropertyAnimation { duration: 200 }
-            }
-
             Rectangle {
                 visible: root.squareLeftSide
 
@@ -117,10 +113,6 @@ Button {
                     } else {
                         return root.disabledColor
                     }
-                }
-
-                Behavior on color {
-                    PropertyAnimation { duration: 200 }
                 }
             }
         }

--- a/client/ui/qml/Controls2/LabelWithButtonType.qml
+++ b/client/ui/qml/Controls2/LabelWithButtonType.qml
@@ -184,9 +184,6 @@ Item {
                 horizontalAlignment: Text.AlignLeft
                 verticalAlignment: Text.AlignVCenter
 
-                Behavior on opacity {
-                    PropertyAnimation { duration: 200 }
-                }
             }
 
 
@@ -215,9 +212,6 @@ Item {
                 horizontalAlignment: Text.AlignLeft
                 verticalAlignment: Text.AlignVCenter
 
-                Behavior on opacity {
-                    PropertyAnimation { duration: 200 }
-                }
 
                 function replaceWithAsterisks(input) {
                     return '*'.repeat(input.length)
@@ -244,9 +238,6 @@ Item {
                 radius: 12
                 color: AmneziaStyle.color.transparent
 
-                Behavior on color {
-                    PropertyAnimation { duration: 200 }
-                }
             }
 
             onClicked: {
@@ -281,9 +272,6 @@ Item {
                 radius: 12
                 color: AmneziaStyle.color.transparent
 
-                Behavior on color {
-                    PropertyAnimation { duration: 200 }
-                }
             }
             onClicked: {
                 if (clickedFunction && typeof clickedFunction === "function") {

--- a/client/ui/qml/Pages2/PageDeinstalling.qml
+++ b/client/ui/qml/Pages2/PageDeinstalling.qml
@@ -65,7 +65,7 @@ PageType {
 
                     interval: 300
                     repeat: true
-                    running: true
+                    running: progressBar.value < 0.95
                     onTriggered: {
                         progressBar.value += 0.003
                     }

--- a/client/ui/qml/Pages2/PageHome.qml
+++ b/client/ui/qml/Pages2/PageHome.qml
@@ -118,12 +118,79 @@ PageType {
                 }
             }
 
-            ConnectButton {
-                id: connectButton
-                objectName: "connectButton"
-
+            Item {
                 Layout.fillHeight: true
-                Layout.alignment: Qt.AlignCenter
+                Layout.fillWidth: true
+
+                ConnectButton {
+                    id: connectButton
+                    objectName: "connectButton"
+
+                    anchors.centerIn: parent
+                }
+
+                RowLayout {
+                    id: speedIndicator
+
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    anchors.bottom: connectButton.top
+                    anchors.bottomMargin: 16
+
+                    spacing: 24
+
+                    opacity: ConnectionController.isConnected ? 1.0 : 0.0
+                    visible: opacity > 0
+
+                    Behavior on opacity {
+                        NumberAnimation { duration: 300; easing.type: Easing.InOutQuad }
+                    }
+
+                    // Download ↓
+                    ColumnLayout {
+                        spacing: 2
+
+                        Text {
+                            Layout.alignment: Qt.AlignHCenter
+                            text: "↓"
+                            font.pixelSize: 11
+                            font.weight: Font.Medium
+                            color: AmneziaStyle.color.mutedGray
+                        }
+
+                        Text {
+                            id: downloadLabel
+                            Layout.alignment: Qt.AlignHCenter
+                            text: ConnectionController.downloadSpeed || "0.00 Mbps"
+                            font.family: "PT Root UI VF"
+                            font.pixelSize: 13
+                            font.weight: Font.Medium
+                            color: AmneziaStyle.color.goldenApricot
+                        }
+                    }
+
+                    // Upload ↑
+                    ColumnLayout {
+                        spacing: 2
+
+                        Text {
+                            Layout.alignment: Qt.AlignHCenter
+                            text: "↑"
+                            font.pixelSize: 11
+                            font.weight: Font.Medium
+                            color: AmneziaStyle.color.mutedGray
+                        }
+
+                        Text {
+                            id: uploadLabel
+                            Layout.alignment: Qt.AlignHCenter
+                            text: ConnectionController.uploadSpeed || "0.00 Mbps"
+                            font.family: "PT Root UI VF"
+                            font.pixelSize: 13
+                            font.weight: Font.Medium
+                            color: AmneziaStyle.color.paleGray
+                        }
+                    }
+                }
             }
 
             BasicButtonType {
@@ -271,9 +338,6 @@ PageType {
                         text: ServersModel.defaultServerName
                         horizontalAlignment: Qt.AlignHCenter
 
-                        Behavior on opacity {
-                            PropertyAnimation { duration: 200 }
-                        }
                     }
 
                     ImageButtonType {

--- a/client/ui/qml/Pages2/PageSetupWizardInstalling.qml
+++ b/client/ui/qml/Pages2/PageSetupWizardInstalling.qml
@@ -124,7 +124,7 @@ PageType {
 
                     interval: 300
                     repeat: true
-                    running: root.isTimerRunning
+                    running: root.isTimerRunning && progressBar.value < 0.95
                     onTriggered: {
                         progressBar.value += 0.003
                     }

--- a/client/vpnconnection.cpp
+++ b/client/vpnconnection.cpp
@@ -57,11 +57,7 @@ void VpnConnection::onKillSwitchModeChanged(bool enabled)
 {
 #ifdef AMNEZIA_DESKTOP
     IpcClient::withInterface([enabled](QSharedPointer<IpcInterfaceReplica> iface){
-        QRemoteObjectPendingReply<bool> reply = iface->refreshKillSwitch(enabled);
-        if (reply.waitForFinished() && reply.returnValue())
-            qDebug() << "VpnConnection::onKillSwitchModeChanged: Killswitch refreshed";
-        else
-            qWarning() << "VpnConnection::onKillSwitchModeChanged: Failed to execute remote refreshKillSwitch call";
+        iface->refreshKillSwitch(enabled);
     });
 #endif
 }
@@ -75,13 +71,7 @@ void VpnConnection::onConnectionStateChanged(Vpn::ConnectionState state)
         switch (state) {
             case Vpn::ConnectionState::Connected: {
                 iface->resetIpStack();
-
-                auto flushDns = iface->flushDns();
-                if (flushDns.waitForFinished() && flushDns.returnValue())
-                    qDebug() << "VpnConnection::onConnectionStateChanged: Successfully flushed DNS";
-                else
-                    qWarning() << "VpnConnection::onConnectionStateChanged: Failed to clear saved routes";
-
+                iface->flushDns();
 
                 if (!ContainerProps::isAwgContainer(container) &&
                     container != DockerContainer::WireGuard) {
@@ -109,17 +99,8 @@ void VpnConnection::onConnectionStateChanged(Vpn::ConnectionState state)
             } break;
             case Vpn::ConnectionState::Disconnected:
             case Vpn::ConnectionState::Error: {
-                auto flushDns = iface->flushDns();
-                if (flushDns.waitForFinished() && flushDns.returnValue())
-                    qDebug() << "VpnConnection::onConnectionStateChanged: Successfully flushed DNS";
-                else
-                    qWarning() << "VpnConnection::onConnectionStateChanged: Failed to flush DNS";
-
-                auto clearSavedRoutes = iface->clearSavedRoutes();
-                if (clearSavedRoutes.waitForFinished() && clearSavedRoutes.returnValue())
-                    qDebug() << "VpnConnection::onConnectionStateChanged: Successfully cleared saved routes";
-                else
-                    qWarning() << "VpnConnection::onConnectionStateChanged: Failed to clear saved routes";
+                iface->flushDns();
+                iface->clearSavedRoutes();
             } break;
             default:
                 break;
@@ -181,9 +162,7 @@ void VpnConnection::addSitesRoutes(const QString &gw, Settings::RouteMode mode)
                         m_settings->addVpnSite(mode, site, ip);
                     }
                     IpcClient::withInterface([](QSharedPointer<IpcInterfaceReplica> iface) {
-                        auto reply = iface->flushDns();
-                        if (reply.waitForFinished() || !reply.returnValue())
-                            qWarning() << "VpnConnection::addSitesRoutes: Failed to flush DNS";
+                        iface->flushDns();
                     });
                     break;
                 }

--- a/client/vpnconnection.cpp
+++ b/client/vpnconnection.cpp
@@ -57,7 +57,15 @@ void VpnConnection::onKillSwitchModeChanged(bool enabled)
 {
 #ifdef AMNEZIA_DESKTOP
     IpcClient::withInterface([enabled](QSharedPointer<IpcInterfaceReplica> iface){
-        iface->refreshKillSwitch(enabled);
+        auto reply = iface->refreshKillSwitch(enabled);
+        auto *watcher = new QRemoteObjectPendingCallWatcher(reply);
+        QObject::connect(watcher, &QRemoteObjectPendingCallWatcher::finished, [watcher]() {
+            if (watcher->returnValue().toBool())
+                qDebug() << "VpnConnection::onKillSwitchModeChanged: Killswitch refreshed";
+            else
+                qWarning() << "VpnConnection::onKillSwitchModeChanged: Failed to refresh killswitch";
+            watcher->deleteLater();
+        });
     });
 #endif
 }
@@ -71,7 +79,15 @@ void VpnConnection::onConnectionStateChanged(Vpn::ConnectionState state)
         switch (state) {
             case Vpn::ConnectionState::Connected: {
                 iface->resetIpStack();
-                iface->flushDns();
+                {
+                    auto reply = iface->flushDns();
+                    auto *w = new QRemoteObjectPendingCallWatcher(reply);
+                    QObject::connect(w, &QRemoteObjectPendingCallWatcher::finished, [w]() {
+                        if (w->returnValue().toBool()) qDebug() << "VpnConnection: DNS flushed on connect";
+                        else qWarning() << "VpnConnection: Failed to flush DNS on connect";
+                        w->deleteLater();
+                    });
+                }
 
                 if (!ContainerProps::isAwgContainer(container) &&
                     container != DockerContainer::WireGuard) {
@@ -99,8 +115,24 @@ void VpnConnection::onConnectionStateChanged(Vpn::ConnectionState state)
             } break;
             case Vpn::ConnectionState::Disconnected:
             case Vpn::ConnectionState::Error: {
-                iface->flushDns();
-                iface->clearSavedRoutes();
+                {
+                    auto reply = iface->flushDns();
+                    auto *w = new QRemoteObjectPendingCallWatcher(reply);
+                    QObject::connect(w, &QRemoteObjectPendingCallWatcher::finished, [w]() {
+                        if (w->returnValue().toBool()) qDebug() << "VpnConnection: DNS flushed on disconnect";
+                        else qWarning() << "VpnConnection: Failed to flush DNS on disconnect";
+                        w->deleteLater();
+                    });
+                }
+                {
+                    auto reply = iface->clearSavedRoutes();
+                    auto *w = new QRemoteObjectPendingCallWatcher(reply);
+                    QObject::connect(w, &QRemoteObjectPendingCallWatcher::finished, [w]() {
+                        if (w->returnValue().toBool()) qDebug() << "VpnConnection: Saved routes cleared";
+                        else qWarning() << "VpnConnection: Failed to clear saved routes";
+                        w->deleteLater();
+                    });
+                }
             } break;
             default:
                 break;
@@ -162,7 +194,13 @@ void VpnConnection::addSitesRoutes(const QString &gw, Settings::RouteMode mode)
                         m_settings->addVpnSite(mode, site, ip);
                     }
                     IpcClient::withInterface([](QSharedPointer<IpcInterfaceReplica> iface) {
-                        iface->flushDns();
+                        auto reply = iface->flushDns();
+                        auto *w = new QRemoteObjectPendingCallWatcher(reply);
+                        QObject::connect(w, &QRemoteObjectPendingCallWatcher::finished, [w]() {
+                            if (!w->returnValue().toBool())
+                                qWarning() << "VpnConnection::addSitesRoutes: Failed to flush DNS";
+                            w->deleteLater();
+                        });
                     });
                     break;
                 }


### PR DESCRIPTION
## Summary

- **Fix UI freezes**: removed blocking `QEventLoop` (1 sec freeze on reload) in `apiSettingsController`, replaced synchronous `waitForFinished()` IPC calls with async `QRemoteObjectPendingCallWatcher` in `vpnconnection.cpp` — every connection state change no longer blocks the main thread while still logging errors
- **Optimize QML rendering**: reduced `ConnectButton` DropShadow samples from 25 to 9, disabled layer rendering during rotation animation, removed 7 unnecessary `Behavior on color/opacity` animations across `BasicButtonType`, `LabelWithButtonType`, `PageHome`
- **Add live speed indicator**: download/upload speed displayed above the connect button when connected, with proper `bytesChanged` reporting for WireGuard/AWG protocols on desktop (was missing entirely)

## Changes

### C++ (performance)
| File | Change |
|------|--------|
| `apiSettingsController.cpp` | Remove `QEventLoop` + 1s `QTimer::singleShot` blocking delay |
| `vpnconnection.cpp` | Replace blocking `waitForFinished()` with async `QRemoteObjectPendingCallWatcher` |
| `connectionController.h/cpp` | Add `downloadSpeed`/`uploadSpeed` Q_PROPERTY with `QElapsedTimer`-based calculation |
| `wireguardprotocol.h/cpp` | Add missing `setBytesChanged()` call + 1s periodic `checkStatus()` timer |

### QML (rendering)
| File | Change |
|------|--------|
| `ConnectButton.qml` | DropShadow samples 25→9, disable layer during connection animation |
| `BasicButtonType.qml` | Remove 2x `Behavior on color` animations |
| `LabelWithButtonType.qml` | Remove 5x `Behavior on color/opacity` animations |
| `PageHome.qml` | Remove `Behavior on opacity`, add speed indicator widget |
| `PageDeinstalling.qml` | Stop timer when progress >= 0.95 |
| `PageSetupWizardInstalling.qml` | Stop timer when progress >= 0.95 |
| `ServersListView.qml` | Cache model properties in delegate `readonly property` |

## Test plan

- [ ] Verify no UI freeze when toggling VPN connection (Connected/Disconnected)
- [ ] Verify IPC errors are logged asynchronously (check debug output)
- [ ] Verify speed indicator appears above connect button when connected
- [ ] Verify speed updates every ~1 second on WireGuard/AWG protocols
- [ ] Verify speed indicator hides smoothly on disconnect
- [ ] Verify ConnectButton animation still renders correctly during connection
- [ ] Verify button hover states still work without `Behavior on color` animations
- [ ] Verify progress bars still animate in install/deinstall pages