### PR TITLE
fix: bounds checks in config parsing, resource cleanup

### DIFF
--- a/client/configurators/ssh_configurator.cpp
+++ b/client/configurators/ssh_configurator.cpp
@@ -90,6 +90,7 @@ void SshConfigurator::openSshTerminal(const ServerCredentials &credentials)
     #endif
 
     p->startDetached();
+    delete p;
 #endif
 }
 

--- a/client/protocols/openvpnprotocol.cpp
+++ b/client/protocols/openvpnprotocol.cpp
@@ -156,7 +156,10 @@ void OpenVpnProtocol::updateRouteGateway(QString line)
             m_routeGateway = params.at(3);
         }
     } else {
-        line = line.split("ROUTE_GATEWAY", Qt::SkipEmptyParts).at(1);
+        auto parts = line.split("ROUTE_GATEWAY", Qt::SkipEmptyParts);
+        if (parts.size() < 2)
+            return;
+        line = parts.at(1);
         if (!line.contains("/"))
             return;
         m_routeGateway = line.split("/", Qt::SkipEmptyParts).first();
@@ -325,6 +328,8 @@ void OpenVpnProtocol::onReadyReadDataFromManagementServer()
 
             beg += sizeof(">BYTECOUNT:") - 1;
             QList<QByteArray> count = data.mid(beg, end - beg + 1).split(',');
+            if (count.size() < 2)
+                continue;
 
             quint64 r = static_cast<quint64>(count.at(0).trimmed().toULongLong());
             quint64 s = static_cast<quint64>(count.at(1).trimmed().toULongLong());
@@ -342,9 +347,10 @@ void OpenVpnProtocol::updateVpnGateway(const QString &line)
     QStringList params = line.split(",");
     for (const QString &l : params) {
         if (l.contains("ifconfig")) {
-            if (l.split(" ").size() == 3) {
-                m_vpnLocalAddress = l.split(" ").at(1);
-                m_vpnGateway = l.split(" ").at(2);
+            QStringList ifconfigParts = l.split(" ");
+            if (ifconfigParts.size() == 3) {
+                m_vpnLocalAddress = ifconfigParts.at(1);
+                m_vpnGateway = ifconfigParts.at(2);
 #ifdef Q_OS_WIN
                 QThread::msleep(300);
                 IpcClient::withInterface([&](QSharedPointer<IpcInterfaceReplica> iface) {

--- a/client/vpnconnection.cpp
+++ b/client/vpnconnection.cpp
@@ -309,7 +309,7 @@ void VpnConnection::appendSplitTunnelingConfig()
             for (auto &line : nativeConfigLines) {
                 if (line.contains("AllowedIPs")) {
                     auto allowedIpsString = line.split(" = ");
-                    if (allowedIpsString.size() < 1) {
+                    if (allowedIpsString.size() < 2) {
                         break;
                     }
                     QJsonArray allowedIpsJsonArray = QJsonArray::fromStringList(allowedIpsString.at(1).split(", "));
@@ -326,7 +326,7 @@ void VpnConnection::appendSplitTunnelingConfig()
             for (auto &line : nativeConfigLines) {
                 if (line.contains("PersistentKeepalive")) {
                     auto persistentKeepaliveString = line.split(" = ");
-                    if (persistentKeepaliveString.size() < 1) {
+                    if (persistentKeepaliveString.size() < 2) {
                         break;
                     }
                     configData.insert(config_key::persistent_keep_alive, persistentKeepaliveString.at(1));


### PR DESCRIPTION
Ran into a couple of crashes while testing with non-standard WG configs and dug into the root cause.

**vpnconnection.cpp** — `appendSplitTunnelingConfig()` parses `AllowedIPs` and `PersistentKeepalive` from native WireGuard configs by splitting on `" = "`. The bounds check was `size() < 1` but the code accesses `.at(1)`, so it would crash on malformed lines like `AllowedIPs` without a value. Fixed to `size() < 2`.

**openvpnprotocol.cpp** — `updateRouteGateway()` calls `.split("ROUTE_GATEWAY").at(1)` without checking the split result first. Also added a guard for the `BYTECOUNT` parser in case the comma-separated pair is incomplete. Bonus: `updateVpnGateway()` was calling `l.split(" ")` three times on the same string — now splits once and reuses the list.

**ssh_configurator.cpp** — `openSshTerminal()` allocates a `QProcess` on the heap, calls `startDetached()`, but never deletes it. Added `delete p` after detach. (The function is marked as dead code in a comment but is still compiled.)

Tested on Windows, builds clean.