### PR TITLE
feat: add 1x1 Android home screen widget for quick VPN toggle

### DIFF
--- a/client/android/AndroidManifest.xml
+++ b/client/android/AndroidManifest.xml
@@ -207,6 +207,27 @@
                 android:value="true" />
         </service>
 
+        <!-- Home screen widget -->
+        <receiver
+            android:name=".AmneziaWidgetProvider"
+            android:exported="true">
+
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="org.amnezia.vpn.WIDGET_TOGGLE" />
+            </intent-filter>
+
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/widget_vpn_toggle_info" />
+        </receiver>
+
+        <service
+            android:name=".AmneziaWidgetService"
+            android:exported="false" />
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="org.amnezia.vpn.qtprovider"

--- a/client/android/res/drawable/widget_circle_connected.xml
+++ b/client/android/res/drawable/widget_circle_connected.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Border ring -->
+    <item>
+        <shape android:shape="oval">
+            <stroke android:width="2dp" android:color="#FF1A1A2E" />
+            <solid android:color="@android:color/transparent" />
+            <size android:width="64dp" android:height="64dp" />
+        </shape>
+    </item>
+    <!-- Inner filled circle -->
+    <item android:left="6dp" android:top="6dp" android:right="6dp" android:bottom="6dp">
+        <shape android:shape="oval">
+            <solid android:color="#FF1A1A2E" />
+            <size android:width="48dp" android:height="48dp" />
+        </shape>
+    </item>
+</layer-list>

--- a/client/android/res/drawable/widget_circle_connecting.xml
+++ b/client/android/res/drawable/widget_circle_connecting.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Border ring -->
+    <item>
+        <shape android:shape="oval">
+            <stroke android:width="2dp" android:color="#FF5C6BC0" />
+            <solid android:color="@android:color/transparent" />
+            <size android:width="64dp" android:height="64dp" />
+        </shape>
+    </item>
+    <!-- Inner filled circle -->
+    <item android:left="6dp" android:top="6dp" android:right="6dp" android:bottom="6dp">
+        <shape android:shape="oval">
+            <solid android:color="#FF5C6BC0" />
+            <size android:width="48dp" android:height="48dp" />
+        </shape>
+    </item>
+</layer-list>

--- a/client/android/res/drawable/widget_circle_disconnected.xml
+++ b/client/android/res/drawable/widget_circle_disconnected.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Border ring -->
+    <item>
+        <shape android:shape="oval">
+            <stroke android:width="2dp" android:color="#FFBDBDBD" />
+            <solid android:color="@android:color/transparent" />
+            <size android:width="64dp" android:height="64dp" />
+        </shape>
+    </item>
+    <!-- Inner filled circle -->
+    <item android:left="6dp" android:top="6dp" android:right="6dp" android:bottom="6dp">
+        <shape android:shape="oval">
+            <solid android:color="#FFBDBDBD" />
+            <size android:width="48dp" android:height="48dp" />
+        </shape>
+    </item>
+</layer-list>

--- a/client/android/res/drawable/widget_circle_disconnecting.xml
+++ b/client/android/res/drawable/widget_circle_disconnecting.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Border ring -->
+    <item>
+        <shape android:shape="oval">
+            <stroke android:width="2dp" android:color="#FF78909C" />
+            <solid android:color="@android:color/transparent" />
+            <size android:width="64dp" android:height="64dp" />
+        </shape>
+    </item>
+    <!-- Inner filled circle -->
+    <item android:left="6dp" android:top="6dp" android:right="6dp" android:bottom="6dp">
+        <shape android:shape="oval">
+            <solid android:color="#FF78909C" />
+            <size android:width="48dp" android:height="48dp" />
+        </shape>
+    </item>
+</layer-list>

--- a/client/android/res/drawable/widget_pulse_ring.xml
+++ b/client/android/res/drawable/widget_pulse_ring.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <stroke
+        android:width="2dp"
+        android:color="#FF5C6BC0" />
+    <solid android:color="@android:color/transparent" />
+    <size
+        android:width="64dp"
+        android:height="64dp" />
+</shape>

--- a/client/android/res/layout/widget_vpn_toggle.xml
+++ b/client/android/res/layout/widget_vpn_toggle.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:padding="2dp">
+
+    <!-- Pulse ring (visible during connecting/disconnecting) -->
+    <ImageView
+        android:id="@+id/widget_pulse_ring"
+        android:layout_width="64dp"
+        android:layout_height="64dp"
+        android:layout_gravity="center"
+        android:src="@drawable/widget_pulse_ring"
+        android:visibility="gone"
+        android:contentDescription="@null" />
+
+    <!-- Main circle button -->
+    <ImageView
+        android:id="@+id/widget_circle"
+        android:layout_width="64dp"
+        android:layout_height="64dp"
+        android:layout_gravity="center"
+        android:src="@drawable/widget_circle_disconnected"
+        android:contentDescription="@string/widget_toggle_vpn" />
+
+    <!-- Amnezia icon overlay -->
+    <ImageView
+        android:id="@+id/widget_icon"
+        android:layout_width="44dp"
+        android:layout_height="44dp"
+        android:layout_gravity="center"
+        android:src="@drawable/ic_amnezia_round"
+        android:tint="#FFFFFFFF"
+        android:contentDescription="@null" />
+
+</FrameLayout>

--- a/client/android/res/values-ru/strings.xml
+++ b/client/android/res/values-ru/strings.xml
@@ -25,4 +25,7 @@
     <string name="openNotificationSettings">Открыть настройки уведомлений</string>
 
     <string name="tvNoFileBrowser">Пожалуйста, установите приложение для просмотра файлов</string>
+
+    <string name="widget_toggle_vpn">Переключить VPN</string>
+    <string name="widget_description">Виджет быстрого переключения VPN</string>
 </resources>

--- a/client/android/res/values/strings.xml
+++ b/client/android/res/values/strings.xml
@@ -25,4 +25,7 @@
     <string name="openNotificationSettings">Open notification settings</string>
 
     <string name="tvNoFileBrowser">Please install a file management utility to browse files</string>
+
+    <string name="widget_toggle_vpn">Toggle VPN</string>
+    <string name="widget_description">One-tap VPN toggle widget</string>
 </resources>

--- a/client/android/res/xml/widget_vpn_toggle_info.xml
+++ b/client/android/res/xml/widget_vpn_toggle_info.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="40dp"
+    android:minHeight="40dp"
+    android:targetCellWidth="1"
+    android:targetCellHeight="1"
+    android:updatePeriodMillis="0"
+    android:initialLayout="@layout/widget_vpn_toggle"
+    android:resizeMode="none"
+    android:widgetCategory="home_screen"
+    android:description="@string/widget_description"
+    android:previewLayout="@layout/widget_vpn_toggle" />

--- a/client/android/src/org/amnezia/vpn/AmneziaWidgetProvider.kt
+++ b/client/android/src/org/amnezia/vpn/AmneziaWidgetProvider.kt
@@ -6,10 +6,7 @@ import android.appwidget.AppWidgetProvider
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
-import android.content.ServiceConnection
 import android.net.VpnService
-import android.os.IBinder
-import android.os.Messenger
 import android.view.View
 import android.widget.RemoteViews
 import androidx.core.content.ContextCompat
@@ -64,38 +61,44 @@ class AmneziaWidgetProvider : AppWidgetProvider() {
     }
 
     private fun handleToggle(context: Context) {
-        // Use global scope so the coroutine survives beyond broadcast receiver lifecycle
+        val pendingResult = goAsync()
         CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
-            val vpnState = VpnStateStore.getVpnState()
-            val vpnProto = vpnState.vpnProto
-            val isVpnConfigExists = vpnState.serverName != null
+            try {
+                val vpnState = VpnStateStore.getVpnState()
+                val vpnProto = vpnState.vpnProto
+                val isVpnConfigExists = vpnState.serverName != null
 
-            if (!isVpnConfigExists || vpnProto == null) {
-                Log.d(TAG, "No VPN config, launching main activity")
-                Intent(context, AmneziaActivity::class.java).apply {
-                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                }.also {
-                    context.startActivity(it)
-                }
-                return@launch
-            }
-
-            when (vpnState.protocolState) {
-                DISCONNECTED, UNKNOWN -> {
-                    Log.d(TAG, "Starting VPN")
-                    VpnStateStore.store { it.copy(protocolState = CONNECTING) }
-                    startVpn(context, vpnProto)
+                if (!isVpnConfigExists || vpnProto == null) {
+                    Log.d(TAG, "No VPN config, launching main activity")
+                    Intent(context, AmneziaActivity::class.java).apply {
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    }.also {
+                        context.startActivity(it)
+                    }
+                    return@launch
                 }
 
-                CONNECTED -> {
-                    Log.d(TAG, "Stopping VPN")
-                    VpnStateStore.store { it.copy(protocolState = DISCONNECTING) }
-                    disconnectVpn(context, vpnProto)
-                }
+                when (vpnState.protocolState) {
+                    DISCONNECTED, UNKNOWN -> {
+                        Log.d(TAG, "Starting VPN")
+                        VpnStateStore.store { it.copy(protocolState = CONNECTING) }
+                        startVpn(context, vpnProto)
+                    }
 
-                CONNECTING, DISCONNECTING, RECONNECTING -> {
-                    Log.d(TAG, "VPN is in transitional state: ${vpnState.protocolState}, ignoring toggle")
+                    CONNECTED -> {
+                        Log.d(TAG, "Stopping VPN")
+                        VpnStateStore.store { it.copy(protocolState = DISCONNECTING) }
+                        // Delegate disconnect to the widget service (it has a longer lifecycle
+                        // than this BroadcastReceiver and can reliably bind to the VPN service)
+                        AmneziaWidgetService.sendDisconnect(context, vpnProto)
+                    }
+
+                    CONNECTING, DISCONNECTING, RECONNECTING -> {
+                        Log.d(TAG, "VPN is in transitional state: ${vpnState.protocolState}, ignoring toggle")
+                    }
                 }
+            } finally {
+                pendingResult.finish()
             }
         }
     }
@@ -119,47 +122,6 @@ class AmneziaWidgetProvider : AppWidgetProvider() {
             )
         } catch (e: SecurityException) {
             Log.e(TAG, "Failed to start ${vpnProto.serviceClass.simpleName}: $e")
-        }
-    }
-
-    /**
-     * Disconnect by binding directly to the VPN service and sending DISCONNECT.
-     * Uses a one-shot ServiceConnection that unbinds itself after sending.
-     */
-    private fun disconnectVpn(context: Context, vpnProto: VpnProto) {
-        val connection = object : ServiceConnection {
-            override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
-                Log.d(TAG, "Bound to VPN service for disconnect: ${name?.flattenToString()}")
-                try {
-                    val messenger = IpcMessenger(
-                        Messenger(service),
-                        "WidgetDisconnect"
-                    )
-                    messenger.send(Action.DISCONNECT)
-                } catch (e: Exception) {
-                    Log.e(TAG, "Failed to send disconnect: $e")
-                }
-                // Unbind after sending
-                try {
-                    context.unbindService(this)
-                } catch (e: Exception) {
-                    Log.e(TAG, "Failed to unbind after disconnect: $e")
-                }
-            }
-
-            override fun onServiceDisconnected(name: ComponentName?) {
-                Log.w(TAG, "VPN service disconnected: ${name?.flattenToString()}")
-            }
-        }
-
-        try {
-            context.bindService(
-                Intent(context, vpnProto.serviceClass),
-                connection,
-                Context.BIND_AUTO_CREATE
-            )
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to bind for disconnect: $e")
         }
     }
 

--- a/client/android/src/org/amnezia/vpn/AmneziaWidgetProvider.kt
+++ b/client/android/src/org/amnezia/vpn/AmneziaWidgetProvider.kt
@@ -6,16 +6,17 @@ import android.appwidget.AppWidgetProvider
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.content.ServiceConnection
 import android.net.VpnService
-import android.os.Build
+import android.os.IBinder
+import android.os.Messenger
 import android.view.View
 import android.widget.RemoteViews
 import androidx.core.content.ContextCompat
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import org.amnezia.vpn.protocol.ProtocolState
 import org.amnezia.vpn.protocol.ProtocolState.CONNECTED
 import org.amnezia.vpn.protocol.ProtocolState.CONNECTING
 import org.amnezia.vpn.protocol.ProtocolState.DISCONNECTED
@@ -38,6 +39,8 @@ class AmneziaWidgetProvider : AppWidgetProvider() {
         for (appWidgetId in appWidgetIds) {
             updateWidget(context, appWidgetManager, appWidgetId)
         }
+        // Ensure widget service is running (recovers from OS kills)
+        AmneziaWidgetService.start(context)
     }
 
     override fun onReceive(context: Context, intent: Intent) {
@@ -61,42 +64,38 @@ class AmneziaWidgetProvider : AppWidgetProvider() {
     }
 
     private fun handleToggle(context: Context) {
-        val scope = CoroutineScope(SupervisorJob())
-        scope.launch {
-            try {
-                val vpnState = VpnStateStore.getVpnState()
-                val vpnProto = vpnState.vpnProto
-                val isVpnConfigExists = vpnState.serverName != null
+        // Use global scope so the coroutine survives beyond broadcast receiver lifecycle
+        CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
+            val vpnState = VpnStateStore.getVpnState()
+            val vpnProto = vpnState.vpnProto
+            val isVpnConfigExists = vpnState.serverName != null
 
-                if (!isVpnConfigExists || vpnProto == null) {
-                    Log.d(TAG, "No VPN config, launching main activity")
-                    Intent(context, AmneziaActivity::class.java).apply {
-                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                    }.also {
-                        context.startActivity(it)
-                    }
-                    return@launch
+            if (!isVpnConfigExists || vpnProto == null) {
+                Log.d(TAG, "No VPN config, launching main activity")
+                Intent(context, AmneziaActivity::class.java).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }.also {
+                    context.startActivity(it)
+                }
+                return@launch
+            }
+
+            when (vpnState.protocolState) {
+                DISCONNECTED, UNKNOWN -> {
+                    Log.d(TAG, "Starting VPN")
+                    VpnStateStore.store { it.copy(protocolState = CONNECTING) }
+                    startVpn(context, vpnProto)
                 }
 
-                when (vpnState.protocolState) {
-                    DISCONNECTED, UNKNOWN -> {
-                        Log.d(TAG, "Starting VPN")
-                        VpnStateStore.store { it.copy(protocolState = CONNECTING) }
-                        startVpn(context, vpnProto)
-                    }
-
-                    CONNECTED -> {
-                        Log.d(TAG, "Stopping VPN")
-                        VpnStateStore.store { it.copy(protocolState = DISCONNECTING) }
-                        AmneziaWidgetService.sendDisconnect(context, vpnProto)
-                    }
-
-                    CONNECTING, DISCONNECTING, RECONNECTING -> {
-                        Log.d(TAG, "VPN is in transitional state: ${vpnState.protocolState}, ignoring toggle")
-                    }
+                CONNECTED -> {
+                    Log.d(TAG, "Stopping VPN")
+                    VpnStateStore.store { it.copy(protocolState = DISCONNECTING) }
+                    disconnectVpn(context, vpnProto)
                 }
-            } finally {
-                scope.cancel()
+
+                CONNECTING, DISCONNECTING, RECONNECTING -> {
+                    Log.d(TAG, "VPN is in transitional state: ${vpnState.protocolState}, ignoring toggle")
+                }
             }
         }
     }
@@ -123,6 +122,47 @@ class AmneziaWidgetProvider : AppWidgetProvider() {
         }
     }
 
+    /**
+     * Disconnect by binding directly to the VPN service and sending DISCONNECT.
+     * Uses a one-shot ServiceConnection that unbinds itself after sending.
+     */
+    private fun disconnectVpn(context: Context, vpnProto: VpnProto) {
+        val connection = object : ServiceConnection {
+            override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
+                Log.d(TAG, "Bound to VPN service for disconnect: ${name?.flattenToString()}")
+                try {
+                    val messenger = IpcMessenger(
+                        Messenger(service),
+                        "WidgetDisconnect"
+                    )
+                    messenger.send(Action.DISCONNECT)
+                } catch (e: Exception) {
+                    Log.e(TAG, "Failed to send disconnect: $e")
+                }
+                // Unbind after sending
+                try {
+                    context.unbindService(this)
+                } catch (e: Exception) {
+                    Log.e(TAG, "Failed to unbind after disconnect: $e")
+                }
+            }
+
+            override fun onServiceDisconnected(name: ComponentName?) {
+                Log.w(TAG, "VPN service disconnected: ${name?.flattenToString()}")
+            }
+        }
+
+        try {
+            context.bindService(
+                Intent(context, vpnProto.serviceClass),
+                connection,
+                Context.BIND_AUTO_CREATE
+            )
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to bind for disconnect: $e")
+        }
+    }
+
     companion object {
         fun updateAllWidgets(context: Context, vpnState: VpnState) {
             val appWidgetManager = AppWidgetManager.getInstance(context)
@@ -139,14 +179,9 @@ class AmneziaWidgetProvider : AppWidgetProvider() {
             appWidgetManager: AppWidgetManager,
             appWidgetId: Int
         ) {
-            val scope = CoroutineScope(SupervisorJob())
-            scope.launch {
-                try {
-                    val vpnState = VpnStateStore.getVpnState()
-                    updateWidgetWithState(context, appWidgetManager, appWidgetId, vpnState)
-                } finally {
-                    scope.cancel()
-                }
+            CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
+                val vpnState = VpnStateStore.getVpnState()
+                updateWidgetWithState(context, appWidgetManager, appWidgetId, vpnState)
             }
         }
 

--- a/client/android/src/org/amnezia/vpn/AmneziaWidgetProvider.kt
+++ b/client/android/src/org/amnezia/vpn/AmneziaWidgetProvider.kt
@@ -1,0 +1,204 @@
+package org.amnezia.vpn
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.net.VpnService
+import android.os.Build
+import android.view.View
+import android.widget.RemoteViews
+import androidx.core.content.ContextCompat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import org.amnezia.vpn.protocol.ProtocolState
+import org.amnezia.vpn.protocol.ProtocolState.CONNECTED
+import org.amnezia.vpn.protocol.ProtocolState.CONNECTING
+import org.amnezia.vpn.protocol.ProtocolState.DISCONNECTED
+import org.amnezia.vpn.protocol.ProtocolState.DISCONNECTING
+import org.amnezia.vpn.protocol.ProtocolState.RECONNECTING
+import org.amnezia.vpn.protocol.ProtocolState.UNKNOWN
+import org.amnezia.vpn.util.Log
+
+private const val TAG = "AmneziaWidgetProvider"
+const val ACTION_WIDGET_TOGGLE = "org.amnezia.vpn.WIDGET_TOGGLE"
+
+class AmneziaWidgetProvider : AppWidgetProvider() {
+
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray
+    ) {
+        Log.d(TAG, "onUpdate: ${appWidgetIds.contentToString()}")
+        for (appWidgetId in appWidgetIds) {
+            updateWidget(context, appWidgetManager, appWidgetId)
+        }
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        super.onReceive(context, intent)
+        Log.d(TAG, "onReceive: ${intent.action}")
+        when (intent.action) {
+            ACTION_WIDGET_TOGGLE -> handleToggle(context)
+        }
+    }
+
+    override fun onEnabled(context: Context) {
+        super.onEnabled(context)
+        Log.d(TAG, "Widget enabled, starting state listener service")
+        AmneziaWidgetService.start(context)
+    }
+
+    override fun onDisabled(context: Context) {
+        super.onDisabled(context)
+        Log.d(TAG, "Widget disabled, stopping state listener service")
+        AmneziaWidgetService.stop(context)
+    }
+
+    private fun handleToggle(context: Context) {
+        val scope = CoroutineScope(SupervisorJob())
+        scope.launch {
+            try {
+                val vpnState = VpnStateStore.getVpnState()
+                val vpnProto = vpnState.vpnProto
+                val isVpnConfigExists = vpnState.serverName != null
+
+                if (!isVpnConfigExists || vpnProto == null) {
+                    Log.d(TAG, "No VPN config, launching main activity")
+                    Intent(context, AmneziaActivity::class.java).apply {
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    }.also {
+                        context.startActivity(it)
+                    }
+                    return@launch
+                }
+
+                when (vpnState.protocolState) {
+                    DISCONNECTED, UNKNOWN -> {
+                        Log.d(TAG, "Starting VPN")
+                        VpnStateStore.store { it.copy(protocolState = CONNECTING) }
+                        startVpn(context, vpnProto)
+                    }
+
+                    CONNECTED -> {
+                        Log.d(TAG, "Stopping VPN")
+                        VpnStateStore.store { it.copy(protocolState = DISCONNECTING) }
+                        AmneziaWidgetService.sendDisconnect(context, vpnProto)
+                    }
+
+                    CONNECTING, DISCONNECTING, RECONNECTING -> {
+                        Log.d(TAG, "VPN is in transitional state: ${vpnState.protocolState}, ignoring toggle")
+                    }
+                }
+            } finally {
+                scope.cancel()
+            }
+        }
+    }
+
+    private fun startVpn(context: Context, vpnProto: VpnProto) {
+        if (VpnService.prepare(context) != null) {
+            Log.d(TAG, "VPN permission not granted, launching permission request")
+            Intent(context, VpnRequestActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                putExtra(EXTRA_PROTOCOL, vpnProto)
+            }.also {
+                context.startActivity(it)
+            }
+            return
+        }
+
+        try {
+            ContextCompat.startForegroundService(
+                context,
+                Intent(context, vpnProto.serviceClass)
+            )
+        } catch (e: SecurityException) {
+            Log.e(TAG, "Failed to start ${vpnProto.serviceClass.simpleName}: $e")
+        }
+    }
+
+    companion object {
+        fun updateAllWidgets(context: Context, vpnState: VpnState) {
+            val appWidgetManager = AppWidgetManager.getInstance(context)
+            val widgetIds = appWidgetManager.getAppWidgetIds(
+                ComponentName(context, AmneziaWidgetProvider::class.java)
+            )
+            for (widgetId in widgetIds) {
+                updateWidgetWithState(context, appWidgetManager, widgetId, vpnState)
+            }
+        }
+
+        private fun updateWidget(
+            context: Context,
+            appWidgetManager: AppWidgetManager,
+            appWidgetId: Int
+        ) {
+            val scope = CoroutineScope(SupervisorJob())
+            scope.launch {
+                try {
+                    val vpnState = VpnStateStore.getVpnState()
+                    updateWidgetWithState(context, appWidgetManager, appWidgetId, vpnState)
+                } finally {
+                    scope.cancel()
+                }
+            }
+        }
+
+        private fun updateWidgetWithState(
+            context: Context,
+            appWidgetManager: AppWidgetManager,
+            appWidgetId: Int,
+            vpnState: VpnState
+        ) {
+            val views = RemoteViews(context.packageName, R.layout.widget_vpn_toggle)
+
+            // Set circle drawable based on state
+            val (circleDrawable, pulseVisible, iconTint) = when (vpnState.protocolState) {
+                CONNECTED -> Triple(
+                    R.drawable.widget_circle_connected,
+                    View.GONE,
+                    0xFFFFFFFF.toInt()
+                )
+                DISCONNECTED, UNKNOWN -> Triple(
+                    R.drawable.widget_circle_disconnected,
+                    View.GONE,
+                    0xFF616161.toInt()
+                )
+                CONNECTING, RECONNECTING -> Triple(
+                    R.drawable.widget_circle_connecting,
+                    View.VISIBLE,
+                    0xFFFFFFFF.toInt()
+                )
+                DISCONNECTING -> Triple(
+                    R.drawable.widget_circle_disconnecting,
+                    View.VISIBLE,
+                    0xFFFFFFFF.toInt()
+                )
+            }
+
+            views.setImageViewResource(R.id.widget_circle, circleDrawable)
+            views.setViewVisibility(R.id.widget_pulse_ring, pulseVisible)
+            views.setInt(R.id.widget_icon, "setColorFilter", iconTint)
+
+            // Set click action
+            val toggleIntent = Intent(context, AmneziaWidgetProvider::class.java).apply {
+                action = ACTION_WIDGET_TOGGLE
+            }
+            val pendingIntent = PendingIntent.getBroadcast(
+                context,
+                0,
+                toggleIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+            views.setOnClickPendingIntent(R.id.widget_root, pendingIntent)
+
+            appWidgetManager.updateAppWidget(appWidgetId, views)
+        }
+    }
+}

--- a/client/android/src/org/amnezia/vpn/AmneziaWidgetService.kt
+++ b/client/android/src/org/amnezia/vpn/AmneziaWidgetService.kt
@@ -1,0 +1,175 @@
+package org.amnezia.vpn
+
+import android.app.Service
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.IBinder
+import android.os.Messenger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import org.amnezia.vpn.protocol.ProtocolState.CONNECTED
+import org.amnezia.vpn.protocol.ProtocolState.CONNECTING
+import org.amnezia.vpn.protocol.ProtocolState.DISCONNECTED
+import org.amnezia.vpn.protocol.ProtocolState.RECONNECTING
+import org.amnezia.vpn.util.Log
+
+private const val TAG = "AmneziaWidgetService"
+private const val ACTION_SEND_DISCONNECT = "org.amnezia.vpn.WIDGET_SEND_DISCONNECT"
+private const val EXTRA_VPN_PROTO = "VPN_PROTO"
+
+class AmneziaWidgetService : Service() {
+
+    private lateinit var scope: CoroutineScope
+    private var stateListeningJob: Job? = null
+    private var vpnServiceMessenger: IpcMessenger? = null
+    private var isInBoundState = false
+
+    private val serviceConnection: ServiceConnection = object : ServiceConnection {
+        override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
+            Log.d(TAG, "VPN service connected: ${name?.flattenToString()}")
+            vpnServiceMessenger?.set(Messenger(service))
+        }
+
+        override fun onServiceDisconnected(name: ComponentName?) {
+            Log.w(TAG, "VPN service disconnected: ${name?.flattenToString()}")
+            vpnServiceMessenger?.reset()
+        }
+
+        override fun onBindingDied(name: ComponentName?) {
+            Log.w(TAG, "Binding died: ${name?.flattenToString()}")
+            doUnbindService()
+        }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        Log.d(TAG, "Widget service created")
+        scope = CoroutineScope(SupervisorJob())
+        vpnServiceMessenger = IpcMessenger(
+            "WidgetVpnService",
+            onDeadObjectException = ::doUnbindService
+        )
+        startStateListening()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ACTION_SEND_DISCONNECT -> {
+                val proto = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+                    intent.getSerializableExtra(EXTRA_VPN_PROTO, VpnProto::class.java)
+                } else {
+                    @Suppress("DEPRECATION")
+                    intent.getSerializableExtra(EXTRA_VPN_PROTO) as? VpnProto
+                }
+                if (proto != null) {
+                    handleDisconnect(proto)
+                }
+            }
+        }
+        return START_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onDestroy() {
+        Log.d(TAG, "Widget service destroyed")
+        stateListeningJob?.cancel()
+        doUnbindService()
+        scope.cancel()
+        super.onDestroy()
+    }
+
+    private fun startStateListening() {
+        stateListeningJob = scope.launch {
+            VpnStateStore.dataFlow().collectLatest { vpnState ->
+                Log.d(TAG, "VPN state changed: $vpnState")
+                AmneziaWidgetProvider.updateAllWidgets(applicationContext, vpnState)
+
+                // Bind/unbind to VPN service based on state
+                val proto = vpnState.vpnProto
+                when (vpnState.protocolState) {
+                    CONNECTED, CONNECTING, RECONNECTING -> {
+                        if (proto != null && !isInBoundState) {
+                            doBindService(proto)
+                        }
+                    }
+                    else -> {
+                        if (isInBoundState) {
+                            doUnbindService()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun handleDisconnect(vpnProto: VpnProto) {
+        if (!isInBoundState) {
+            doBindService(vpnProto)
+            // Post disconnect after bind
+            scope.launch {
+                // Small delay to let bind complete
+                kotlinx.coroutines.delay(500)
+                vpnServiceMessenger?.send(Action.DISCONNECT)
+            }
+        } else {
+            vpnServiceMessenger?.send(Action.DISCONNECT)
+        }
+    }
+
+    private fun doBindService(vpnProto: VpnProto) {
+        Log.d(TAG, "Binding to VPN service: ${vpnProto.serviceClass.simpleName}")
+        try {
+            bindService(
+                Intent(this, vpnProto.serviceClass),
+                serviceConnection,
+                BIND_ABOVE_CLIENT
+            )
+            isInBoundState = true
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to bind to VPN service: $e")
+        }
+    }
+
+    private fun doUnbindService() {
+        if (isInBoundState) {
+            Log.d(TAG, "Unbinding from VPN service")
+            try {
+                unbindService(serviceConnection)
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to unbind: $e")
+            }
+            isInBoundState = false
+            vpnServiceMessenger?.reset()
+        }
+    }
+
+    companion object {
+        fun start(context: Context) {
+            Intent(context, AmneziaWidgetService::class.java).also {
+                context.startService(it)
+            }
+        }
+
+        fun stop(context: Context) {
+            Intent(context, AmneziaWidgetService::class.java).also {
+                context.stopService(it)
+            }
+        }
+
+        fun sendDisconnect(context: Context, vpnProto: VpnProto) {
+            Intent(context, AmneziaWidgetService::class.java).apply {
+                action = ACTION_SEND_DISCONNECT
+                putExtra(EXTRA_VPN_PROTO, vpnProto)
+            }.also {
+                context.startService(it)
+            }
+        }
+    }
+}

--- a/client/android/src/org/amnezia/vpn/AmneziaWidgetService.kt
+++ b/client/android/src/org/amnezia/vpn/AmneziaWidgetService.kt
@@ -1,9 +1,12 @@
 package org.amnezia.vpn
 
 import android.app.Service
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.content.ServiceConnection
 import android.os.IBinder
+import android.os.Messenger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
@@ -13,18 +16,22 @@ import kotlinx.coroutines.launch
 import org.amnezia.vpn.util.Log
 
 private const val TAG = "AmneziaWidgetService"
+private const val ACTION_SEND_DISCONNECT = "org.amnezia.vpn.WIDGET_SEND_DISCONNECT"
+private const val EXTRA_VPN_PROTO = "VPN_PROTO"
 
 /**
- * Lightweight background service that listens to VpnStateStore changes
- * and pushes updates to all widget instances via RemoteViews.
- *
- * Started when the first widget is added, restarted on every onUpdate()
- * to recover from OS kills, stopped when the last widget is removed.
+ * Background service that:
+ * 1. Listens to VpnStateStore changes and pushes widget UI updates
+ * 2. Handles VPN disconnect requests from the widget (needs Service lifecycle
+ *    to reliably bind to the VPN service — BroadcastReceiver is too short-lived)
  */
 class AmneziaWidgetService : Service() {
 
     private lateinit var scope: CoroutineScope
     private var stateListeningJob: Job? = null
+
+    // Disconnect binding state
+    private var disconnectConnection: ServiceConnection? = null
 
     override fun onCreate() {
         super.onCreate()
@@ -38,6 +45,20 @@ class AmneziaWidgetService : Service() {
         if (stateListeningJob == null || stateListeningJob?.isActive != true) {
             startStateListening()
         }
+
+        when (intent?.action) {
+            ACTION_SEND_DISCONNECT -> {
+                val proto = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+                    intent.getSerializableExtra(EXTRA_VPN_PROTO, VpnProto::class.java)
+                } else {
+                    @Suppress("DEPRECATION")
+                    intent.getSerializableExtra(EXTRA_VPN_PROTO) as? VpnProto
+                }
+                if (proto != null) {
+                    handleDisconnect(proto)
+                }
+            }
+        }
         return START_STICKY
     }
 
@@ -46,6 +67,7 @@ class AmneziaWidgetService : Service() {
     override fun onDestroy() {
         Log.d(TAG, "Widget service destroyed")
         stateListeningJob?.cancel()
+        cleanupDisconnectBinding()
         scope.cancel()
         super.onDestroy()
     }
@@ -56,6 +78,68 @@ class AmneziaWidgetService : Service() {
                 Log.d(TAG, "VPN state changed: $vpnState")
                 AmneziaWidgetProvider.updateAllWidgets(applicationContext, vpnState)
             }
+        }
+    }
+
+    /**
+     * Bind to VPN service and send DISCONNECT in the onServiceConnected callback.
+     * This is reliable because:
+     * - We're a Service (long lifecycle), not a BroadcastReceiver
+     * - We send the message in onServiceConnected (guaranteed the connection is ready)
+     * - We unbind immediately after sending
+     */
+    private fun handleDisconnect(vpnProto: VpnProto) {
+        // Clean up any previous disconnect binding
+        cleanupDisconnectBinding()
+
+        val connection = object : ServiceConnection {
+            override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
+                Log.d(TAG, "Bound to VPN service for disconnect: ${name?.flattenToString()}")
+                try {
+                    val messenger = IpcMessenger(
+                        Messenger(service),
+                        "WidgetDisconnect"
+                    )
+                    messenger.send(Action.DISCONNECT)
+                    Log.d(TAG, "Disconnect message sent")
+                } catch (e: Exception) {
+                    Log.e(TAG, "Failed to send disconnect: $e")
+                }
+                // Unbind after sending
+                cleanupDisconnectBinding()
+            }
+
+            override fun onServiceDisconnected(name: ComponentName?) {
+                Log.w(TAG, "VPN service disconnected unexpectedly: ${name?.flattenToString()}")
+            }
+        }
+
+        disconnectConnection = connection
+
+        try {
+            val bound = bindService(
+                Intent(this, vpnProto.serviceClass),
+                connection,
+                BIND_AUTO_CREATE
+            )
+            if (!bound) {
+                Log.e(TAG, "Failed to bind to VPN service for disconnect")
+                disconnectConnection = null
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Exception binding for disconnect: $e")
+            disconnectConnection = null
+        }
+    }
+
+    private fun cleanupDisconnectBinding() {
+        disconnectConnection?.let { conn ->
+            try {
+                unbindService(conn)
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to unbind disconnect connection: $e")
+            }
+            disconnectConnection = null
         }
     }
 
@@ -70,6 +154,15 @@ class AmneziaWidgetService : Service() {
 
         fun stop(context: Context) {
             context.stopService(Intent(context, AmneziaWidgetService::class.java))
+        }
+
+        fun sendDisconnect(context: Context, vpnProto: VpnProto) {
+            Intent(context, AmneziaWidgetService::class.java).apply {
+                action = ACTION_SEND_DISCONNECT
+                putExtra(EXTRA_VPN_PROTO, vpnProto)
+            }.also {
+                context.startService(it)
+            }
         }
     }
 }

--- a/client/android/src/org/amnezia/vpn/AmneziaWidgetService.kt
+++ b/client/android/src/org/amnezia/vpn/AmneziaWidgetService.kt
@@ -1,76 +1,42 @@
 package org.amnezia.vpn
 
 import android.app.Service
-import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
-import android.content.ServiceConnection
 import android.os.IBinder
-import android.os.Messenger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import org.amnezia.vpn.protocol.ProtocolState.CONNECTED
-import org.amnezia.vpn.protocol.ProtocolState.CONNECTING
-import org.amnezia.vpn.protocol.ProtocolState.DISCONNECTED
-import org.amnezia.vpn.protocol.ProtocolState.RECONNECTING
 import org.amnezia.vpn.util.Log
 
 private const val TAG = "AmneziaWidgetService"
-private const val ACTION_SEND_DISCONNECT = "org.amnezia.vpn.WIDGET_SEND_DISCONNECT"
-private const val EXTRA_VPN_PROTO = "VPN_PROTO"
 
+/**
+ * Lightweight background service that listens to VpnStateStore changes
+ * and pushes updates to all widget instances via RemoteViews.
+ *
+ * Started when the first widget is added, restarted on every onUpdate()
+ * to recover from OS kills, stopped when the last widget is removed.
+ */
 class AmneziaWidgetService : Service() {
 
     private lateinit var scope: CoroutineScope
     private var stateListeningJob: Job? = null
-    private var vpnServiceMessenger: IpcMessenger? = null
-    private var isInBoundState = false
-
-    private val serviceConnection: ServiceConnection = object : ServiceConnection {
-        override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
-            Log.d(TAG, "VPN service connected: ${name?.flattenToString()}")
-            vpnServiceMessenger?.set(Messenger(service))
-        }
-
-        override fun onServiceDisconnected(name: ComponentName?) {
-            Log.w(TAG, "VPN service disconnected: ${name?.flattenToString()}")
-            vpnServiceMessenger?.reset()
-        }
-
-        override fun onBindingDied(name: ComponentName?) {
-            Log.w(TAG, "Binding died: ${name?.flattenToString()}")
-            doUnbindService()
-        }
-    }
 
     override fun onCreate() {
         super.onCreate()
         Log.d(TAG, "Widget service created")
         scope = CoroutineScope(SupervisorJob())
-        vpnServiceMessenger = IpcMessenger(
-            "WidgetVpnService",
-            onDeadObjectException = ::doUnbindService
-        )
         startStateListening()
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        when (intent?.action) {
-            ACTION_SEND_DISCONNECT -> {
-                val proto = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
-                    intent.getSerializableExtra(EXTRA_VPN_PROTO, VpnProto::class.java)
-                } else {
-                    @Suppress("DEPRECATION")
-                    intent.getSerializableExtra(EXTRA_VPN_PROTO) as? VpnProto
-                }
-                if (proto != null) {
-                    handleDisconnect(proto)
-                }
-            }
+        // Re-ensure state listening is active (in case of restart)
+        if (stateListeningJob == null || stateListeningJob?.isActive != true) {
+            startStateListening()
         }
         return START_STICKY
     }
@@ -80,7 +46,6 @@ class AmneziaWidgetService : Service() {
     override fun onDestroy() {
         Log.d(TAG, "Widget service destroyed")
         stateListeningJob?.cancel()
-        doUnbindService()
         scope.cancel()
         super.onDestroy()
     }
@@ -90,86 +55,21 @@ class AmneziaWidgetService : Service() {
             VpnStateStore.dataFlow().collectLatest { vpnState ->
                 Log.d(TAG, "VPN state changed: $vpnState")
                 AmneziaWidgetProvider.updateAllWidgets(applicationContext, vpnState)
-
-                // Bind/unbind to VPN service based on state
-                val proto = vpnState.vpnProto
-                when (vpnState.protocolState) {
-                    CONNECTED, CONNECTING, RECONNECTING -> {
-                        if (proto != null && !isInBoundState) {
-                            doBindService(proto)
-                        }
-                    }
-                    else -> {
-                        if (isInBoundState) {
-                            doUnbindService()
-                        }
-                    }
-                }
             }
-        }
-    }
-
-    private fun handleDisconnect(vpnProto: VpnProto) {
-        if (!isInBoundState) {
-            doBindService(vpnProto)
-            // Post disconnect after bind
-            scope.launch {
-                // Small delay to let bind complete
-                kotlinx.coroutines.delay(500)
-                vpnServiceMessenger?.send(Action.DISCONNECT)
-            }
-        } else {
-            vpnServiceMessenger?.send(Action.DISCONNECT)
-        }
-    }
-
-    private fun doBindService(vpnProto: VpnProto) {
-        Log.d(TAG, "Binding to VPN service: ${vpnProto.serviceClass.simpleName}")
-        try {
-            bindService(
-                Intent(this, vpnProto.serviceClass),
-                serviceConnection,
-                BIND_ABOVE_CLIENT
-            )
-            isInBoundState = true
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to bind to VPN service: $e")
-        }
-    }
-
-    private fun doUnbindService() {
-        if (isInBoundState) {
-            Log.d(TAG, "Unbinding from VPN service")
-            try {
-                unbindService(serviceConnection)
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to unbind: $e")
-            }
-            isInBoundState = false
-            vpnServiceMessenger?.reset()
         }
     }
 
     companion object {
         fun start(context: Context) {
-            Intent(context, AmneziaWidgetService::class.java).also {
-                context.startService(it)
+            try {
+                context.startService(Intent(context, AmneziaWidgetService::class.java))
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to start widget service: $e")
             }
         }
 
         fun stop(context: Context) {
-            Intent(context, AmneziaWidgetService::class.java).also {
-                context.stopService(it)
-            }
-        }
-
-        fun sendDisconnect(context: Context, vpnProto: VpnProto) {
-            Intent(context, AmneziaWidgetService::class.java).apply {
-                action = ACTION_SEND_DISCONNECT
-                putExtra(EXTRA_VPN_PROTO, vpnProto)
-            }.also {
-                context.startService(it)
-            }
+            context.stopService(Intent(context, AmneziaWidgetService::class.java))
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds a **1x1 home screen widget** for Android that lets users toggle VPN on/off with a single tap — no need to open the app
- Circle icon with a border ring changes color based on VPN state: **gray** (disconnected), **dark** (connected), **indigo** (connecting/reconnecting), **blue-gray** (disconnecting)
- Pulse ring overlay appears during transitional states (connecting/disconnecting)
- If no VPN config exists, tapping the widget opens the main app

## Implementation

- `AmneziaWidgetProvider` — `AppWidgetProvider` that handles tap-to-toggle logic and updates `RemoteViews`
- `AmneziaWidgetService` — background service that listens to `VpnStateStore` DataStore flow and pushes real-time state changes to all widget instances; also handles disconnect via IPC to the VPN service
- Reuses existing patterns from `AmneziaTileService`: `VpnStateStore`, `IpcMessenger`, `VpnRequestActivity`, `Action.CONNECT`/`DISCONNECT`
- Registered in `AndroidManifest.xml` with `APPWIDGET_UPDATE` intent filter and widget metadata

## Files changed

| File | Change |
|------|--------|
| `AmneziaWidgetProvider.kt` | New — widget broadcast receiver |
| `AmneziaWidgetService.kt` | New — state listener service |
| `widget_vpn_toggle.xml` (layout) | New — widget layout |
| `widget_vpn_toggle_info.xml` (xml) | New — appwidget-provider metadata |
| `widget_circle_*.xml` (4 drawables) | New — circle + border ring for each state |
| `widget_pulse_ring.xml` | New — ring overlay for transitional states |
| `AndroidManifest.xml` | Modified — registered receiver + service |
| `strings.xml` (en + ru) | Modified — added widget strings |

## Test plan

- [x] Add widget to home screen from widget picker
- [x] Tap widget when disconnected — VPN should connect, circle turns dark
- [x] Tap widget when connected — VPN should disconnect, circle turns gray
- [x] Verify pulse ring appears during connecting/disconnecting
- [x] Tap widget with no VPN config — main app should open
- [x] Verify widget updates when VPN state changes from within the app
- [x] Test on Android 8+ (API 26+)

## Screenshots

Tested on physical device — widget appears as a circle with the Amnezia logo that changes color on tap.