### PR TITLE
Require SOCKS5 auth on local Xray inbound (fixes #2452)

### DIFF
--- a/client/android/xray/src/main/kotlin/Xray.kt
+++ b/client/android/xray/src/main/kotlin/Xray.kt
@@ -99,6 +99,13 @@ class Xray : Protocol() {
 
             val socksConfig = xrayJsonConfig.getJSONArray("inbounds")[0] as JSONObject
             socksConfig.getInt("port").let { setSocksPort(it) }
+            socksConfig.optJSONObject("settings")
+                ?.optJSONArray("accounts")
+                ?.optJSONObject(0)
+                ?.let {
+                    setSocksUser(it.optString("user"))
+                    setSocksPass(it.optString("pass"))
+                }
 
             configSplitTunneling(config)
             configAppSplitTunneling(config)
@@ -162,9 +169,12 @@ class Xray : Protocol() {
     }
 
     private fun runTun2Socks(config: XrayConfig, fd: Int) {
+        val auth = if (config.socksUser.isNotEmpty() && config.socksPass.isNotEmpty())
+                       "${config.socksUser}:${config.socksPass}@"
+                   else ""
         val tun2SocksConfig = Tun2SocksConfig().apply {
             mtu = config.mtu.toLong()
-            proxy = "socks5://127.0.0.1:${config.socksPort}"
+            proxy = "socks5://${auth}127.0.0.1:${config.socksPort}"
             device = "fd://$fd"
             logLevel = "warn"
         }

--- a/client/android/xray/src/main/kotlin/XrayConfig.kt
+++ b/client/android/xray/src/main/kotlin/XrayConfig.kt
@@ -9,17 +9,23 @@ private const val XRAY_DEFAULT_MAX_MEMORY: Long = 50 shl 20 // 50 MB
 class XrayConfig protected constructor(
     protocolConfigBuilder: ProtocolConfig.Builder,
     val socksPort: Int,
+    val socksUser: String,
+    val socksPass: String,
     val maxMemory: Long,
 ) : ProtocolConfig(protocolConfigBuilder) {
 
     protected constructor(builder: Builder) : this(
         builder,
         builder.socksPort,
+        builder.socksUser,
+        builder.socksPass,
         builder.maxMemory
     )
 
     class Builder : ProtocolConfig.Builder(false) {
         internal var socksPort: Int = 0
+        internal var socksUser: String = ""
+        internal var socksPass: String = ""
             private set
 
         internal var maxMemory: Long = XRAY_DEFAULT_MAX_MEMORY
@@ -29,6 +35,10 @@ class XrayConfig protected constructor(
 
         fun setSocksPort(port: Int) = apply { socksPort = port }
 
+
+        fun setSocksUser(user: String) = apply { socksUser = user }
+
+        fun setSocksPass(pass: String) = apply { socksPass = pass }
         fun setMaxMemory(maxMemory: Long) = apply { this.maxMemory = maxMemory }
 
         override fun build(): XrayConfig = configBuild().run { XrayConfig(this@Builder) }

--- a/client/core/serialization/inbound.cpp
+++ b/client/core/serialization/inbound.cpp
@@ -1,9 +1,12 @@
-#include <QString>
+#include <QJsonArray>
 #include <QJsonObject>
 #include <QList>
+#include <QRandomGenerator>
+#include <QString>
+
 #include "3rd/QJsonStruct/QJsonIO.hpp"
-#include "transfer.h"
 #include "serialization.h"
+#include "transfer.h"
 
 namespace amnezia::serialization::inbounds
 {
@@ -14,25 +17,78 @@ namespace amnezia::serialization::inbounds
 //                     "port": 10808,
 //                     "protocol": "socks",
 //                     "settings": {
-//                         "udp": true
+//                         "udp": true,
+//                         "auth": "password",
+//                         "accounts": [ { "user": "<random>", "pass": "<random>" } ]
 //                     }
 //                 }
 //],
+//
+// The local SOCKS5 inbound is an in-process IPC channel between the
+// Xray core and the tun2socks component. On Android the loopback
+// interface is shared across UIDs, so without authentication any
+// third-party app with INTERNET permission can use it as an open
+// proxy and bypass per-app split tunneling (see #2452).
+//
+// We require SOCKS5 username/password authentication. Credentials
+// are generated once per process lifetime via QRandomGenerator::system()
+// and are never persisted to disk or logs. The tun2socks consumer
+// must read them via GetInboundCredentials() and feed them into its
+// own upstream SOCKS5 client config.
 
 const static QString listen = "127.0.0.1";
 const static int port = 10808;
 const static QString protocol = "socks";
 
+namespace
+{
+    QString RandomToken(int length = 24)
+    {
+        static const char alphabet[] =
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+            "abcdefghijklmnopqrstuvwxyz"
+            "0123456789";
+        QString out;
+        out.reserve(length);
+        auto *rng = QRandomGenerator::system();
+        for (int i = 0; i < length; ++i) {
+            out.append(QLatin1Char(alphabet[rng->bounded(int(sizeof(alphabet) - 1))]));
+        }
+        return out;
+    }
+
+    const InboundCredentials &Credentials()
+    {
+        static const InboundCredentials c{ listen, port, RandomToken(), RandomToken() };
+        return c;
+    }
+}
+
+InboundCredentials GetInboundCredentials()
+{
+    return Credentials();
+}
+
 QJsonObject GenerateInboundEntry()
 {
+    const auto &c = Credentials();
+
+    QJsonObject account;
+    account.insert("user", c.user);
+    account.insert("pass", c.pass);
+
+    QJsonArray accounts;
+    accounts.append(account);
+
     QJsonObject root;
     QJsonIO::SetValue(root, listen, "listen");
     QJsonIO::SetValue(root, port, "port");
     QJsonIO::SetValue(root, protocol, "protocol");
     QJsonIO::SetValue(root, true, "settings", "udp");
+    QJsonIO::SetValue(root, QString("password"), "settings", "auth");
+    QJsonIO::SetValue(root, accounts, "settings", "accounts");
     return root;
 }
 
 
 } // namespace amnezia::serialization::inbounds
-

--- a/client/core/serialization/serialization.h
+++ b/client/core/serialization/serialization.h
@@ -60,7 +60,24 @@ namespace amnezia::serialization
 
     namespace inbounds
     {
+        // Credentials of the local SOCKS5 inbound, needed by the tun2socks
+        // consumer so it can authenticate against the Xray core. The
+        // underlying user/pass are generated once per process via a CSPRNG
+        // and are only held in memory.
+        struct InboundCredentials
+        {
+            QString listen;
+            int port;
+            QString user;
+            QString pass;
+        };
+
         QJsonObject GenerateInboundEntry();
+
+        // Returns the credentials used by GenerateInboundEntry(). Must be
+        // called from the same process that started Xray, since credentials
+        // are generated per-process and not persisted.
+        InboundCredentials GetInboundCredentials();
     }
 }
 

--- a/client/platforms/ios/PacketTunnelProvider+Xray.swift
+++ b/client/platforms/ios/PacketTunnelProvider+Xray.swift
@@ -132,9 +132,20 @@ extension PacketTunnelProvider {
             let port = 10808
             let address = "::1"
 
+            var socksUser: String? = nil
+            var socksPass: String? = nil
+
             if var inboundsArray = jsonDict["inbounds"] as? [[String: Any]], !inboundsArray.isEmpty {
                 inboundsArray[0]["port"] = port
                 inboundsArray[0]["listen"] = address
+
+                if let settings = inboundsArray[0]["settings"] as? [String: Any],
+                   let accounts = settings["accounts"] as? [[String: Any]],
+                   let first = accounts.first {
+                    socksUser = first["user"] as? String
+                    socksPass = first["pass"] as? String
+                }
+
                 jsonDict["inbounds"] = inboundsArray
             }
 
@@ -159,6 +170,8 @@ extension PacketTunnelProvider {
                     self?.setupAndRunTun2socks(configData: updatedData,
                                                address: address,
                                                port: port,
+                                               username: socksUser,
+                                               password: socksPass,
                                                completionHandler: completionHandler)
                 }
             }
@@ -214,7 +227,19 @@ extension PacketTunnelProvider {
     private func setupAndRunTun2socks(configData: Data,
                                       address: String,
                                       port: Int,
+                                      username: String?,
+                                      password: String?,
                                       completionHandler: @escaping (Error?) -> Void) {
+        let authLines: String
+        if let username, let password {
+            authLines = """
+              username: '\(username)'
+              password: '\(password)'
+            """
+        } else {
+            authLines = ""
+        }
+
         let config = """
         tunnel:
           mtu: 9000
@@ -222,6 +247,7 @@ extension PacketTunnelProvider {
           port: \(port)
           address: \(address)
           udp: 'udp'
+        \(authLines)
         misc:
           task-stack-size: 20480
           connect-timeout: 5000

--- a/client/protocols/xrayprotocol.cpp
+++ b/client/protocols/xrayprotocol.cpp
@@ -1,5 +1,5 @@
 #include "xrayprotocol.h"
-
+#include "core/serialization/serialization.h"
 #include "core/ipcclient.h"
 #include "ipc.h"
 #include "utilities.h"
@@ -122,7 +122,11 @@ ErrorCode XrayProtocol::startTun2Socks()
     }
 
     m_tun2socksProcess->setProgram(PermittedProcess::Tun2Socks);
-    m_tun2socksProcess->setArguments({"-device", QString("tun://%1").arg(tunName), "-proxy", "socks5://127.0.0.1:10808" });
+    const auto creds = amnezia::serialization::inbounds::GetInboundCredentials();
+    const QString proxyUrl = QString("socks5://%1:%2@%3:%4")
+                             .arg(creds.user, creds.pass, creds.listen)
+                             .arg(creds.port);
+    m_tun2socksProcess->setArguments({"-device", QString("tun://%1").arg(tunName), "-proxy", proxyUrl});
 
     connect(m_tun2socksProcess.data(), &IpcProcessInterfaceReplica::readyReadStandardOutput, this, [this]() {
         auto readAllStandardOutput = m_tun2socksProcess->readAllStandardOutput();


### PR DESCRIPTION
## Summary

Closes #2452.

The local SOCKS5 listener that bridges `tun2socks` and the Xray core was
unauthenticated and bound to `127.0.0.1:10808`. On Android the loopback
interface is shared across UIDs, so any third-party app with `INTERNET`
permission could connect to it and use it as an open proxy, bypassing
per-app split tunneling and sending traffic through the VPN tunnel even
when the user had explicitly excluded the app.

This PR requires SOCKS5 username/password authentication on that
inbound. Credentials are generated per process via
`QRandomGenerator::system()`, kept only in memory, and re-rolled on
every process start. The tun2socks consumer on each platform reads the
credentials and authenticates, so the VPN keeps working end-to-end
while external apps can no longer use the proxy.

## Changes

**Serialization (`client/core/serialization/`)**
- `inbound.cpp`: `GenerateInboundEntry()` now emits
  `settings.auth = "password"` and `settings.accounts = [{user, pass}]`
  with random 24-char tokens generated by `QRandomGenerator::system()`.
  Adds `GetInboundCredentials()` returning the same pair for in-process
  consumers via a Meyers singleton.
- `serialization.h`: declares `InboundCredentials` and
  `GetInboundCredentials()` next to the existing `GenerateInboundEntry()`.

**Desktop (`client/protocols/xrayprotocol.cpp`)**
- The tun2socks process is now launched with
  `socks5://user:pass@127.0.0.1:10808` instead of the unauthenticated
  URL. The credentials are read from `GetInboundCredentials()` so they
  always match what `GenerateInboundEntry()` put into the Xray config.

**Android (`client/android/xray/src/main/kotlin/`)**
- `XrayConfig.kt`: adds `socksUser` / `socksPass` fields, builder
  setters and constructor wiring, mirroring the existing `socksPort`.
- `Xray.kt`: parses
  `inbounds[0].settings.accounts[0]` from the Xray JSON config and
  populates the new fields. `runTun2Socks()` builds a
  `socks5://user:pass@127.0.0.1:port` URL for `Tun2SocksConfig.proxy`.
  Uses `optJSONObject` / `optJSONArray` so older configs without an
  `accounts` block degrade gracefully (no auth → behaves as before).

**iOS (`client/platforms/ios/PacketTunnelProvider+Xray.swift`)**
- Reads the same `inbounds[0].settings.accounts[0]` from the JSON
  config and threads `username` / `password` into
  `setupAndRunTun2socks(...)`. The hev-socks5-tunnel YAML config now
  includes `username:` / `password:` lines under `socks5:` when
  credentials are present.

## Security properties

- Credentials are generated by a CSPRNG (`QRandomGenerator::system()`,
  which maps to `/dev/urandom` on Linux/Android, `SecRandomCopyBytes`
  on Apple, `BCryptGenRandom` on Windows).
- They live only in process memory, are never written to disk, logs,
  or notifications, and are never serialized into shareable Xray
  config exports.
- They are re-rolled on every process start, so a VPN reconnect after
  an app kill yields a fresh pair.
- After the patch, an external app connecting to `127.0.0.1:10808`
  receives a SOCKS5 handshake that requires method `0x02`
  (username/password) and cannot proceed without the secret. The
  per-app split-tunneling bypass from #2452 is closed.

## What this PR does *not* do

It does not hide the fact that *something* is listening on
`127.0.0.1:10808`. An attacker app can still probe the port and infer
"AmneziaVPN with Xray is active". Fully addressing the
detectability concern from the second half of #2452 would require
moving the IPC off loopback TCP entirely (e.g. to a Unix domain
socket inside the app's private files dir), which in turn requires
adding Unix socket support upstream in `hev-socks5-tunnel`. That
should be tracked as a follow-up; this PR is the minimal fix that
closes the bypass without new dependencies.

## Testing

Locally on Linux desktop with Qt 6.6.2:
- Full client builds cleanly (`235/235`, both `AmneziaVPN` and
  `AmneziaVPN-service` link successfully).
- A small standalone test calling `GenerateInboundEntry()` and
  `GetInboundCredentials()` confirms that the JSON contains
  `auth: "password"` and a populated `accounts` array, that the
  credentials returned by `GetInboundCredentials()` match the ones
  inside the JSON, and that they differ between process invocations.

The Android, iOS, Windows and macOS changes are mechanical and rely
on this repository's CI for build verification. Reviewers familiar
with each platform should sanity-check the wiring; I'm happy to
iterate on anything that looks off.