### PR TITLE
fix(openvpn): break Disconnect → infinite reconnect loop in stop()

### DIFF
--- a/client/protocols/openvpnprotocol.cpp
+++ b/client/protocols/openvpnprotocol.cpp
@@ -41,18 +41,34 @@ QString OpenVpnProtocol::defaultConfigPath()
 void OpenVpnProtocol::stop()
 {
     qDebug() << "OpenVpnProtocol::stop()";
+
+    // Capture the previous state BEFORE setConnectionState() mutates it.
+    // VpnProtocol::setConnectionState() synchronously assigns m_connectionState,
+    // so checking m_connectionState after the assignment to Disconnecting will
+    // never match Connected/Connecting/Reconnecting/Preparing — the entire
+    // shutdown block was effectively dead code in the original implementation.
+    const Vpn::ConnectionState prevState = m_connectionState;
     setConnectionState(Vpn::ConnectionState::Disconnecting);
 
-    // TODO: need refactoring
-    // sendTermSignal() will even return true while server connected ???
-    if ((m_connectionState == Vpn::ConnectionState::Preparing) || (m_connectionState == Vpn::ConnectionState::Connecting)
-        || (m_connectionState == Vpn::ConnectionState::Connected)
-        || (m_connectionState == Vpn::ConnectionState::Reconnecting)) {
-        if (!sendTermSignal()) {
-            killOpenVpnProcess();
-        }
-        QThread::msleep(10);
+    if (prevState == Vpn::ConnectionState::Preparing || prevState == Vpn::ConnectionState::Connecting
+        || prevState == Vpn::ConnectionState::Connected || prevState == Vpn::ConnectionState::Reconnecting) {
+        // Try graceful shutdown via management interface first.
+        // sendTermSignal() returns true as soon as bytes are written to the
+        // management socket, NOT when openvpn actually processes SIGTERM, so
+        // we cannot rely on its return value to decide whether to fall back
+        // to killing the process.
+        sendTermSignal();
+        // Give openvpn enough time to read and process the SIGTERM command
+        // before we tear down the management socket. Otherwise it interprets
+        // the closed management socket as a connection-reset and enters a
+        // SIGUSR1[soft,connection-reset] reconnect loop ("Restart pause, 5
+        // second(s)") that the UI cannot escape.
+        QThread::msleep(200);
         m_managementServer.stop();
+        // Always force-kill afterwards. If SIGTERM was processed in time the
+        // process is already gone and this is a no-op; if it wasn't, this
+        // breaks the reconnect loop.
+        killOpenVpnProcess();
     }
 
 #if defined(Q_OS_WIN) || defined(Q_OS_LINUX) || defined(Q_OS_MACOS)


### PR DESCRIPTION
## Summary

When the user clicks **Disconnect**, the desktop client gets stuck alternating between *Disconnected* and *Reconnecting…* forever; the only way out is to manually kill `openvpn.exe`. Reproduced on AmneziaVPN **4.8.14.5** + `amnezia-openvpn-cloak` container on Windows 10 22H2.

Two compounding bugs in [\`OpenVpnProtocol::stop()\`](https://github.com/amnezia-vpn/amnezia-client/blob/dev/client/protocols/openvpnprotocol.cpp#L41):

\`\`\`cpp
void OpenVpnProtocol::stop()
{
    qDebug() << \"OpenVpnProtocol::stop()\";
    setConnectionState(Vpn::ConnectionState::Disconnecting);

    // TODO: need refactoring
    // sendTermSignal() will even return true while server connected ???
    if ((m_connectionState == Connected) || ...) {
        if (!sendTermSignal()) { killOpenVpnProcess(); }
        QThread::msleep(10);
        m_managementServer.stop();
    }
    ...
}
\`\`\`

### Bug 1 — the shutdown if-block is unreachable

[\`VpnProtocol::setConnectionState()\`](https://github.com/amnezia-vpn/amnezia-client/blob/dev/client/protocols/vpnprotocol.cpp#L90) synchronously assigns \`m_connectionState\`, so by the time the \`if\` on the next line checks \`m_connectionState\` it is already \`Disconnecting\` and never matches \`Connected\` / \`Connecting\` / \`Reconnecting\` / \`Preparing\`. Neither \`sendTermSignal()\` nor \`killOpenVpnProcess()\` is ever called from \`stop()\`. The author already left a \`// TODO: need refactoring\` next to it.

### Bug 2 — the 10 ms sleep is too short and \`sendTermSignal()\`'s return value is misleading

\`sendTermSignal()\` is just \`m_managementServer.writeCommand(\"signal SIGTERM\")\` — it returns \`true\` as soon as bytes are written to the management socket, NOT when openvpn actually processes the command. 10 ms isn't enough for openvpn to read and act on it before \`m_managementServer.stop()\` tears the socket down. openvpn then sees the closed management socket as a connection-reset and emits:

\`\`\`
SIGUSR1[soft,connection-reset] received, process restarting
MANAGEMENT: >STATE: RECONNECTING,connection-reset
Restart pause, 5 second(s)
\`\`\`

The UI sees the \`RECONNECTING\` state and gets stuck. (In the unpatched code this happens via \`OpenVpnOverCloakProtocol::stop()\` / the \`~OpenVpnProtocol\` destructor path that does close the management server, since the \`if\`-block in \`OpenVpnProtocol::stop()\` is unreachable.)

## Fix

* Capture \`prevState\` BEFORE \`setConnectionState()\` mutates \`m_connectionState\`, so the kill path actually runs when \`stop()\` is called from a live state.
* Always send SIGTERM via the management interface (drop the misleading \`if (!sendTermSignal())\` short-circuit).
* Sleep **200 ms** so openvpn can actually receive and process SIGTERM before the management socket is closed.
* Always call \`killOpenVpnProcess()\` afterwards as a hard fallback. If SIGTERM was processed in time the process is already gone and this is a no-op; if it wasn't, this breaks the soft-restart loop.

## Verification

Tested on Windows 10 22H2 with the \`amnezia-openvpn-cloak\` server container, by building this branch via a stripped-down windows-only GitHub Actions workflow on \`windows-latest\` and replacing \`AmneziaVPN.exe\` + \`AmneziaVPN-service.exe\` in the install directory. Several connect → disconnect → connect cycles with timestamps from \`AmneziaVPN.log\`:

| stop() | → Disconnected | gap |
|---|---|---|
| 09:14:39.585 | 09:14:39.824 | **239 ms** |
| 09:14:43.307 | 09:14:43.511 | **204 ms** |
| 09:15:00.791 | 09:15:01.013 | **222 ms** |

The ~200 ms gap proves the new shutdown block is actually executed (the original block was effectively a no-op and the same sequence completed in 4 ms).

After the patch the log contains **no occurrences** of any of:

- \`SIGUSR1[soft,connection-reset] received\`
- \`Connection reset, restarting [-1]\`
- \`Restart pause, 5 second(s)\`
- \`STATE: RECONNECTING,connection-reset\`
- \`Connection state: 'Переподключение...'\`

Connect → Connected → Disconnect → Disconnected works cleanly, repeatedly, without leaving \`openvpn.exe\` orphaned.

## Test plan

- [x] Reproduce the bug on a clean install of 4.8.14.5
- [x] Build patched binaries from this branch
- [x] Replace \`AmneziaVPN.exe\` + \`AmneziaVPN-service.exe\` and re-test
- [x] Verify multiple connect/disconnect cycles in a row
- [x] Verify no orphaned \`openvpn.exe\` processes after Disconnect
- [x] Verify log no longer contains \`SIGUSR1[soft,connection-reset]\` after stop()