### PR TITLE
fix(windows): unblock WireGuard connect with large split-tunnel lists

### DIFF
--- a/client/daemon/daemon.cpp
+++ b/client/daemon/daemon.cpp
@@ -132,8 +132,13 @@ bool Daemon::activate(const InterfaceConfig& config) {
   }
 
   // Configure routing for excluded addresses.
-  for (const QString& i : config.m_excludedAddresses) {
-    addExclusionRoute(IPAddress(i));
+  {
+    QList<IPAddress> excludedPrefixes;
+    excludedPrefixes.reserve(config.m_excludedAddresses.size());
+    for (const QString& i : config.m_excludedAddresses) {
+      excludedPrefixes.append(IPAddress(i));
+    }
+    addExclusionRoutes(excludedPrefixes);
   }
 
   // Add the peer to this interface.
@@ -147,11 +152,9 @@ bool Daemon::activate(const InterfaceConfig& config) {
   }
 
   // set routing
-  for (const IPAddress& ip : config.m_allowedIPAddressRanges) {
-    if (!wgutils()->updateRoutePrefix(ip)) {
-      logger.debug() << "Routing configuration failed for" << ip.toString();
-      return false;
-    }
+  if (!wgutils()->updateRoutePrefixes(config.m_allowedIPAddressRanges)) {
+    logger.debug() << "Routing configuration failed for one or more prefixes";
+    return false;
   }
 
   bool status = run(Up, config);
@@ -229,6 +232,30 @@ bool Daemon::delExclusionRoute(const IPAddress& prefix) {
   }
   m_excludedAddrSet.remove(prefix);
   return wgutils()->deleteExclusionRoute(prefix);
+}
+
+bool Daemon::addExclusionRoutes(const QList<IPAddress>& prefixes) {
+  if (prefixes.isEmpty()) {
+    return true;
+  }
+
+  QList<IPAddress> freshPrefixes;
+  freshPrefixes.reserve(prefixes.size());
+  for (const IPAddress& prefix : prefixes) {
+    auto it = m_excludedAddrSet.find(prefix);
+    if (it != m_excludedAddrSet.end()) {
+      it.value()++;
+      continue;
+    }
+    freshPrefixes.append(prefix);
+    m_excludedAddrSet[prefix] = 1;
+  }
+
+  if (freshPrefixes.isEmpty()) {
+    return true;
+  }
+
+  return wgutils()->addExclusionRoutes(freshPrefixes);
 }
 
 // static
@@ -516,8 +543,13 @@ bool Daemon::switchServer(const InterfaceConfig& config) {
       m_connections.value(config.m_hopType).m_config;
 
   // Configure routing for new excluded addresses.
-  for (const QString& i : config.m_excludedAddresses) {
-    addExclusionRoute(IPAddress(i));
+  {
+    QList<IPAddress> excludedPrefixes;
+    excludedPrefixes.reserve(config.m_excludedAddresses.size());
+    for (const QString& i : config.m_excludedAddresses) {
+      excludedPrefixes.append(IPAddress(i));
+    }
+    addExclusionRoutes(excludedPrefixes);
   }
 
   // Activate the new peer and its routes.
@@ -525,11 +557,8 @@ bool Daemon::switchServer(const InterfaceConfig& config) {
     logger.error() << "Server switch failed to update the wireguard interface";
     return false;
   }
-  for (const IPAddress& ip : config.m_allowedIPAddressRanges) {
-    if (!wgutils()->updateRoutePrefix(ip)) {
-      logger.error() << "Server switch failed to update the routing table";
-      break;
-    }
+  if (!wgutils()->updateRoutePrefixes(config.m_allowedIPAddressRanges)) {
+    logger.error() << "Server switch failed to update the routing table";
   }
 
   // Remove routing entries for the old peer.

--- a/client/daemon/daemon.h
+++ b/client/daemon/daemon.h
@@ -59,6 +59,7 @@ class Daemon : public QObject {
   bool maybeUpdateResolvers(const InterfaceConfig& config);
   bool addExclusionRoute(const IPAddress& address);
   bool delExclusionRoute(const IPAddress& address);
+  bool addExclusionRoutes(const QList<IPAddress>& prefixes);
 
  protected:
   virtual bool run(Op op, const InterfaceConfig& config) {

--- a/client/daemon/wireguardutils.h
+++ b/client/daemon/wireguardutils.h
@@ -49,6 +49,26 @@ class WireguardUtils : public QObject {
   virtual bool addExclusionRoute(const IPAddress& prefix) = 0;
   virtual bool deleteExclusionRoute(const IPAddress& prefix) = 0;
 
+  virtual bool updateRoutePrefixes(const QList<IPAddress>& prefixes) {
+    bool ok = true;
+    for (const IPAddress& prefix : prefixes) {
+      if (!updateRoutePrefix(prefix)) {
+        ok = false;
+      }
+    }
+    return ok;
+  }
+
+  virtual bool addExclusionRoutes(const QList<IPAddress>& prefixes) {
+    bool ok = true;
+    for (const IPAddress& prefix : prefixes) {
+      if (!addExclusionRoute(prefix)) {
+        ok = false;
+      }
+    }
+    return ok;
+  }
+
   virtual bool excludeLocalNetworks(const QList<IPAddress>& addresses) = 0;
 };
 

--- a/client/platforms/windows/daemon/windowsroutemonitor.cpp
+++ b/client/platforms/windows/daemon/windowsroutemonitor.cpp
@@ -432,6 +432,103 @@ bool WindowsRouteMonitor::addExclusionRoute(const IPAddress& prefix) {
   return true;
 }
 
+int WindowsRouteMonitor::addExclusionRoutes(const QList<IPAddress>& prefixes) {
+  if (prefixes.isEmpty()) {
+    return 0;
+  }
+
+  // Group by address family so the routing-table snapshot and
+  // updateCapturedRoutes() run once per family instead of once per prefix
+  QVector<QPair<IPAddress, MIB_IPFORWARD_ROW2*>> pendingV4;
+  QVector<QPair<IPAddress, MIB_IPFORWARD_ROW2*>> pendingV6;
+  pendingV4.reserve(prefixes.size());
+  pendingV6.reserve(prefixes.size());
+
+  for (const IPAddress& prefix : prefixes) {
+    const QHostAddress addr = prefix.address();
+    if (addr.isLoopback() || addr.isBroadcast() || addr.isLinkLocal() ||
+        addr.isMulticast()) {
+      continue;
+    }
+    if (m_exclusionRoutes.contains(prefix)) {
+      continue;
+    }
+
+    MIB_IPFORWARD_ROW2* data = new MIB_IPFORWARD_ROW2;
+    InitializeIpForwardEntry(data);
+    if (addr.protocol() == QAbstractSocket::IPv6Protocol) {
+      Q_IPV6ADDR buf = addr.toIPv6Address();
+      memcpy(&data->DestinationPrefix.Prefix.Ipv6.sin6_addr, &buf, sizeof(buf));
+      data->DestinationPrefix.Prefix.Ipv6.sin6_family = AF_INET6;
+    } else {
+      quint32 buf = addr.toIPv4Address();
+      data->DestinationPrefix.Prefix.Ipv4.sin_addr.s_addr = htonl(buf);
+      data->DestinationPrefix.Prefix.Ipv4.sin_family = AF_INET;
+    }
+    data->DestinationPrefix.PrefixLength = prefix.prefixLength();
+    data->NextHop.si_family = data->DestinationPrefix.Prefix.si_family;
+
+    data->ValidLifetime = 0xffffffff;
+    data->PreferredLifetime = 0xffffffff;
+    data->Metric = EXCLUSION_ROUTE_METRIC;
+    data->Protocol = MIB_IPPROTO_NETMGMT;
+    data->Loopback = false;
+    data->AutoconfigureAddress = false;
+    data->Publish = false;
+    data->Immortal = false;
+    data->Age = 0;
+
+    if (data->DestinationPrefix.Prefix.si_family == AF_INET6) {
+      pendingV6.append(qMakePair(prefix, data));
+    } else {
+      pendingV4.append(qMakePair(prefix, data));
+    }
+    // Register up-front so the single updateCapturedRoutes() pass below
+    // sees the full exclusion set via isRouteExcluded().
+    m_exclusionRoutes[prefix] = data;
+  }
+
+  int added = 0;
+
+  auto processFamily =
+      [&](int family,
+          const QVector<QPair<IPAddress, MIB_IPFORWARD_ROW2*>>& pending) {
+        if (pending.isEmpty()) {
+          return;
+        }
+
+        logger.debug() << "Batch exclusion install:" << pending.size()
+                       << (family == AF_INET6 ? "IPv6" : "IPv4") << "routes";
+
+        PMIB_IPFORWARD_TABLE2 table = nullptr;
+        DWORD result = GetIpForwardTable2(family, &table);
+        if (result != NO_ERROR) {
+          logger.error() << "Failed to fetch routing table:" << result;
+          for (const auto& item : pending) {
+            MIB_IPFORWARD_ROW2* row = m_exclusionRoutes.take(item.first);
+            if (row != nullptr) {
+              delete row;
+            }
+          }
+          return;
+        }
+
+        updateInterfaceMetrics(family);
+        for (const auto& item : pending) {
+          updateExclusionRoute(item.second, table);
+          ++added;
+        }
+        updateCapturedRoutes(family, table);
+
+        FreeMibTable(table);
+      };
+
+  processFamily(AF_INET, pendingV4);
+  processFamily(AF_INET6, pendingV6);
+
+  return added;
+}
+
 bool WindowsRouteMonitor::deleteExclusionRoute(const IPAddress& prefix) {
   logger.debug() << "Deleting exclusion route for"
                  << prefix.address().toString();

--- a/client/platforms/windows/daemon/windowsroutemonitor.cpp
+++ b/client/platforms/windows/daemon/windowsroutemonitor.cpp
@@ -19,8 +19,12 @@ Logger logger("WindowsRouteMonitor");
 // way to other routing entries.
 constexpr const ULONG EXCLUSION_ROUTE_METRIC = 0x5e72;
 
+// Coalesce bursts of NotifyRouteChange2 callbacks into a single rescan so that
+// exclusion install / tunnel bring-up does not starve the daemon event loop.
+constexpr int ROUTE_CHANGE_DEBOUNCE_MSEC = 50;
+
 // Called by the kernel on route changes - perform some basic filtering and
-// invoke the routeChanged slot to do the real work.
+// schedule a coalesced rescan on the Qt thread.
 static void routeChangeCallback(PVOID context, PMIB_IPFORWARD_ROW2 row,
                                 MIB_NOTIFICATION_TYPE type) {
   WindowsRouteMonitor* monitor = (WindowsRouteMonitor*)context;
@@ -35,8 +39,8 @@ static void routeChangeCallback(PVOID context, PMIB_IPFORWARD_ROW2 row,
     return;
   }
 
-  // Invoke the route changed signal to do the real work in Qt.
-  QMetaObject::invokeMethod(monitor, "routeChanged", Qt::QueuedConnection);
+  QMetaObject::invokeMethod(monitor, "scheduleRouteChanged",
+                            Qt::QueuedConnection);
 }
 
 // Perform prefix matching comparison on IP addresses in host order.
@@ -62,6 +66,11 @@ WindowsRouteMonitor::WindowsRouteMonitor(quint64 luid, QObject* parent)
     : QObject(parent), m_luid(luid) {
   MZ_COUNT_CTOR(WindowsRouteMonitor);
   logger.debug() << "WindowsRouteMonitor created.";
+
+  m_routeChangedDebounce.setSingleShot(true);
+  m_routeChangedDebounce.setInterval(ROUTE_CHANGE_DEBOUNCE_MSEC);
+  connect(&m_routeChangedDebounce, &QTimer::timeout, this,
+          &WindowsRouteMonitor::routeChanged);
 
   NotifyRouteChange2(AF_INET, routeChangeCallback, this, FALSE, &m_routeHandle);
 }
@@ -303,6 +312,9 @@ void WindowsRouteMonitor::updateCapturedRoutes(int family, void* ptable) {
       data->Age++;
       continue;
     }
+    if (m_captureBlacklist.contains(prefix)) {
+      continue;
+    }
     logger.debug() << "Capturing route to" << prefix.toString();
 
     // Clone the route and direct it into the VPN tunnel.
@@ -328,6 +340,11 @@ void WindowsRouteMonitor::updateCapturedRoutes(int family, void* ptable) {
     if (result != NO_ERROR) {
       logger.error() << "Failed to update route:" << result;
       delete data;
+      // Pin prefixes owned by someone else (e.g. Wintun's subnet-broadcast
+      // /32 entries) so we don't retry them on every notification.
+      if (result == ERROR_OBJECT_ALREADY_EXISTS) {
+        m_captureBlacklist.insert(prefix);
+      }
     } else {
       m_clonedRoutes.insert(prefix, data);
       data->Age++;
@@ -573,7 +590,14 @@ void WindowsRouteMonitor::setDetaultRouteCapture(bool enable) {
   // Flush any captured routes when disabling the feature.
   if (!m_defaultRouteCapture) {
     flushRouteTable(m_clonedRoutes);
+    m_captureBlacklist.clear();
     return;
+  }
+}
+
+void WindowsRouteMonitor::scheduleRouteChanged() {
+  if (!m_routeChangedDebounce.isActive()) {
+    m_routeChangedDebounce.start();
   }
 }
 

--- a/client/platforms/windows/daemon/windowsroutemonitor.h
+++ b/client/platforms/windows/daemon/windowsroutemonitor.h
@@ -27,6 +27,7 @@ class WindowsRouteMonitor final : public QObject {
   void setDetaultRouteCapture(bool enable);
 
   bool addExclusionRoute(const IPAddress& prefix);
+  int addExclusionRoutes(const QList<IPAddress>& prefixes);
   bool deleteExclusionRoute(const IPAddress& prefix);
   void flushExclusionRoutes() { return flushRouteTable(m_exclusionRoutes); };
 

--- a/client/platforms/windows/daemon/windowsroutemonitor.h
+++ b/client/platforms/windows/daemon/windowsroutemonitor.h
@@ -14,6 +14,8 @@
 #include <QHash>
 #include <QMap>
 #include <QObject>
+#include <QSet>
+#include <QTimer>
 
 #include "ipaddress.h"
 
@@ -35,6 +37,7 @@ class WindowsRouteMonitor final : public QObject {
 
  public slots:
   void routeChanged();
+  void scheduleRouteChanged();
 
  private:
   bool isRouteExcluded(const IP_ADDRESS_PREFIX* dest) const;
@@ -55,9 +58,12 @@ class WindowsRouteMonitor final : public QObject {
   // Default route cloning
   bool m_defaultRouteCapture = false;
   QHash<IPAddress, MIB_IPFORWARD_ROW2*> m_clonedRoutes;
+  QSet<IPAddress> m_captureBlacklist;
 
   const quint64 m_luid = 0;
   HANDLE m_routeHandle = INVALID_HANDLE_VALUE;
+
+  QTimer m_routeChangedDebounce;
 };
 
 #endif /* WINDOWSROUTEMONITOR_H */

--- a/client/platforms/windows/daemon/wireguardutilswindows.cpp
+++ b/client/platforms/windows/daemon/wireguardutilswindows.cpp
@@ -8,6 +8,7 @@
 #include <iphlpapi.h>
 #include <windows.h>
 #include <winsock2.h>
+#include <winsvc.h>
 #include <ws2ipdef.h>
 
 #include <QFileInfo>
@@ -17,9 +18,132 @@
 #include "windowsfirewall.h"
 
 #pragma comment(lib, "iphlpapi.lib")
+#pragma comment(lib, "advapi32.lib")
 
 namespace {
 Logger logger("WireguardUtilsWindows");
+
+// Suspend wcmSvc for bulk route installs to avoid per-route stalls, matching
+constexpr int kWcmSuspendThreshold = 500;
+
+LONG (NTAPI* g_NtSuspendProcess)(HANDLE ProcessHandle) = nullptr;
+LONG (NTAPI* g_NtResumeProcess)(HANDLE ProcessHandle) = nullptr;
+
+#ifndef WG_STATUS_SUCCESS
+#define WG_STATUS_SUCCESS ((NTSTATUS)0x00000000L)
+#endif
+
+bool ensureNtFunctions() {
+  static bool initialized = false;
+  static bool ok = false;
+  if (initialized) {
+    return ok;
+  }
+  initialized = true;
+
+  HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
+  if (!ntdll) {
+    return false;
+  }
+  g_NtSuspendProcess = reinterpret_cast<decltype(g_NtSuspendProcess)>(
+      GetProcAddress(ntdll, "NtSuspendProcess"));
+  g_NtResumeProcess = reinterpret_cast<decltype(g_NtResumeProcess)>(
+      GetProcAddress(ntdll, "NtResumeProcess"));
+  ok = (g_NtSuspendProcess != nullptr) && (g_NtResumeProcess != nullptr);
+  return ok;
+}
+
+bool ensureDebugPrivilege() {
+  static bool tried = false;
+  static bool ok = false;
+  if (tried) {
+    return ok;
+  }
+  tried = true;
+
+  HANDLE token = nullptr;
+  if (!OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES, &token)) {
+    return false;
+  }
+  TOKEN_PRIVILEGES priv = {};
+  if (!LookupPrivilegeValueW(nullptr, SE_DEBUG_NAME,
+                             &priv.Privileges[0].Luid)) {
+    CloseHandle(token);
+    return false;
+  }
+  priv.PrivilegeCount = 1;
+  priv.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
+  ok = AdjustTokenPrivileges(token, FALSE, &priv, sizeof(priv), nullptr,
+                             nullptr) != 0;
+  CloseHandle(token);
+  return ok;
+}
+
+DWORD getServicePid(LPCWSTR serviceName) {
+  SC_HANDLE scm = OpenSCManagerW(nullptr, nullptr, SC_MANAGER_CONNECT);
+  if (!scm) {
+    return 0;
+  }
+  SC_HANDLE svc = OpenServiceW(scm, serviceName, SERVICE_QUERY_STATUS);
+  if (!svc) {
+    CloseServiceHandle(scm);
+    return 0;
+  }
+  SERVICE_STATUS_PROCESS ssp = {};
+  DWORD bytesNeeded = 0;
+  QueryServiceStatusEx(svc, SC_STATUS_PROCESS_INFO,
+                       reinterpret_cast<LPBYTE>(&ssp), sizeof(ssp),
+                       &bytesNeeded);
+  CloseServiceHandle(svc);
+  CloseServiceHandle(scm);
+  return ssp.dwProcessId;
+}
+
+class WcmSuspender {
+ public:
+  explicit WcmSuspender(int pendingRoutes) {
+    if (pendingRoutes < kWcmSuspendThreshold) {
+      return;
+    }
+    if (!ensureNtFunctions()) {
+      return;
+    }
+    ensureDebugPrivilege();
+
+    DWORD pid = getServicePid(L"wcmSvc");
+    if (pid == 0) {
+      return;
+    }
+    m_handle = OpenProcess(PROCESS_SUSPEND_RESUME, FALSE, pid);
+    if (!m_handle) {
+      return;
+    }
+    if (g_NtSuspendProcess(m_handle) == WG_STATUS_SUCCESS) {
+      m_suspended = true;
+      logger.debug() << "wcmSvc suspended for bulk route install"
+                     << "(pending:" << pendingRoutes << ")";
+    } else {
+      CloseHandle(m_handle);
+      m_handle = nullptr;
+    }
+  }
+  ~WcmSuspender() {
+    if (m_handle) {
+      if (m_suspended) {
+        g_NtResumeProcess(m_handle);
+        logger.debug() << "wcmSvc resumed";
+      }
+      CloseHandle(m_handle);
+    }
+  }
+  WcmSuspender(const WcmSuspender&) = delete;
+  WcmSuspender& operator=(const WcmSuspender&) = delete;
+
+ private:
+  HANDLE m_handle = nullptr;
+  bool m_suspended = false;
+};
+
 };  // namespace
 
 std::unique_ptr<WireguardUtilsWindows> WireguardUtilsWindows::create(
@@ -306,8 +430,57 @@ bool WireguardUtilsWindows::deleteRoutePrefix(const IPAddress& prefix) {
   return result == NO_ERROR;
 }
 
+bool WireguardUtilsWindows::updateRoutePrefixes(
+    const QList<IPAddress>& prefixes) {
+  if (prefixes.isEmpty()) {
+    return true;
+  }
+
+  if (m_routeMonitor) {
+    for (const IPAddress& prefix : prefixes) {
+      if (prefix.prefixLength() == 0) {
+        m_routeMonitor->setDetaultRouteCapture(true);
+        break;
+      }
+    }
+  }
+
+  WcmSuspender suspender(prefixes.size());
+
+  bool ok = true;
+  for (const IPAddress& prefix : prefixes) {
+    MIB_IPFORWARD_ROW2 entry;
+    buildMibForwardRow(prefix, &entry);
+    DWORD result = CreateIpForwardEntry2(&entry);
+    if (result == ERROR_OBJECT_ALREADY_EXISTS) {
+      continue;
+    }
+    // IPv6 might be disabled on the host.
+    if (prefix.address().protocol() == QAbstractSocket::IPv6Protocol &&
+        result == ERROR_NOT_FOUND) {
+      continue;
+    }
+    if (result != NO_ERROR) {
+      logger.error() << "Failed to create route to" << prefix.toString()
+                     << "result:" << result;
+      ok = false;
+    }
+  }
+  return ok;
+}
+
 bool WireguardUtilsWindows::addExclusionRoute(const IPAddress& prefix) {
   return m_routeMonitor->addExclusionRoute(prefix);
+}
+
+bool WireguardUtilsWindows::addExclusionRoutes(
+    const QList<IPAddress>& prefixes) {
+  if (!m_routeMonitor || prefixes.isEmpty()) {
+    return true;
+  }
+  WcmSuspender suspender(prefixes.size());
+  m_routeMonitor->addExclusionRoutes(prefixes);
+  return true;
 }
 
 bool WireguardUtilsWindows::deleteExclusionRoute(const IPAddress& prefix) {

--- a/client/platforms/windows/daemon/wireguardutilswindows.h
+++ b/client/platforms/windows/daemon/wireguardutilswindows.h
@@ -41,6 +41,9 @@ class WireguardUtilsWindows final : public WireguardUtils {
   bool updateRoutePrefix(const IPAddress& prefix) override;
   bool deleteRoutePrefix(const IPAddress& prefix) override;
 
+  bool updateRoutePrefixes(const QList<IPAddress>& prefixes) override;
+  bool addExclusionRoutes(const QList<IPAddress>& prefixes) override;
+
   bool addExclusionRoute(const IPAddress& prefix) override;
   bool deleteExclusionRoute(const IPAddress& prefix) override;
 


### PR DESCRIPTION
Fixes #2248.

Currently, when connecting to a WireGuard server on Windows with a large split-tunnel list (e.g. the 11k-CIDR RU list from #2248), the client spends 5–20 minutes on "Connecting" before it finally reports "Connected". The same profile connects in 1–3 seconds on macOS, Android and iOS. Even after the first connect succeeds, reconnecting in the same session hangs on "Connecting" indefinitely.

This happens because `Daemon::activate` installs exclusion routes one at a time: every `CreateIpForwardEntry2` call wakes `wcmSvc` (which `router_win.cpp` already works around for OpenVPN/Shadowsocks but not for WireGuard), and `WindowsRouteMonitor::addExclusionRoute` re-fetches the full routing table and re-runs `updateCapturedRoutes` for every prefix. On top of that, `NotifyRouteChange2` fires a callback per row during interface bring-up; each callback queues a `routeChanged` slot that rescans everything, and Wintun's subnet-broadcast `/32` entries (which `QHostAddress::isBroadcast()` does not recognize) keep failing with `ERROR_OBJECT_ALREADY_EXISTS` and get retried on every rescan - the daemon event loop fills up and `Daemon::checkHandshake()` never gets a slot, so the `connected` signal never reaches the GUI.

This PR adds batch entry points to `WireguardUtils` so `WindowsRouteMonitor` can install all exclusion prefixes against one routing-table snapshot per address family and suspend `wcmSvc` for the whole batch (matching `router_win.cpp`), debounces `NotifyRouteChange2` callbacks through a 50 ms single-shot timer so bursts collapse into one rescan, and pins prefixes that return `ERROR_OBJECT_ALREADY_EXISTS` so they stop being retried. Other platforms fall back to the existing per-prefix path and are untouched.