### PR TITLE
Add split traffic for specific applications

### DIFF
--- a/client/daemon/daemon.cpp
+++ b/client/daemon/daemon.cpp
@@ -384,6 +384,11 @@ bool Daemon::parseConfig(const QJsonObject& obj, InterfaceConfig& config) {
   if (!parseStringList(obj, "vpnDisabledApps", config.m_vpnDisabledApps)) {
     return false;
   }
+  
+  // === Наш флаг режима Include/Exclude ===
+  config.m_splitMode = obj.value("splitMode").toInt();
+  // =======================================
+  
   if (!parseStringList(obj, "allowedDnsServers", config.m_allowedDnsServers)) {
     return false;
   }

--- a/client/daemon/daemonlocalserverconnection.cpp
+++ b/client/daemon/daemonlocalserverconnection.cpp
@@ -111,6 +111,11 @@ void DaemonLocalServerConnection::parseCommand(const QByteArray& data) {
       return;
     }
 
+    // === ДОБАВЛЕНО: Чтение режима раздельного туннелирования из JSON ===
+    // Если GUI передал splitMode, мы его читаем. Если нет — ставим 0 (Exclude) по умолчанию.
+    config.m_splitMode = static_cast<uint32_t>(obj.value("splitMode").toInt(0));
+    // ===================================================================
+
     if (!Daemon::instance()->activate(config)) {
       logger.error() << "Failed to activate the interface";
       emit disconnected();

--- a/client/daemon/interfaceconfig.cpp
+++ b/client/daemon/interfaceconfig.cpp
@@ -62,6 +62,9 @@ QJsonObject InterfaceConfig::toJson() const {
   }
   json.insert("vpnDisabledApps", disabledApps);
 
+  // === ДОБАВЛЕНО: Сериализация режима туннелирования (0 = Exclude, 1 = Include) ===
+  json.insert("splitMode", QJsonValue(static_cast<int>(m_splitMode)));
+
   return json;
 }
 

--- a/client/daemon/interfaceconfig.h
+++ b/client/daemon/interfaceconfig.h
@@ -8,7 +8,7 @@
 #include <QList>
 #include <QMap>
 #include <QString>
-#include <QMap>
+#include <cstdint> // Добавлено для uint32_t
 #include "ipaddress.h"
 
 class QJsonObject;
@@ -39,6 +39,9 @@ class InterfaceConfig {
   QList<IPAddress> m_allowedIPAddressRanges;
   QStringList m_excludedAddresses;
   QStringList m_vpnDisabledApps;
+  
+  uint32_t m_splitMode = 0; // <-- Добавлено наше поле: 0 = Exclude, 1 = Include
+  
   QStringList m_allowedDnsServers;
   bool m_killSwitchEnabled;
 #if defined(MZ_ANDROID) || defined(MZ_IOS)

--- a/client/mozilla/localsocketcontroller.cpp
+++ b/client/mozilla/localsocketcontroller.cpp
@@ -24,10 +24,7 @@
 #include "logger.h"
 #include "daemon/daemonerrors.h"
 
-#include "core/utils/protocolEnum.h"
-#include "core/protocols/protocolUtils.h"
-#include "core/utils/constants/configKeys.h"
-#include "core/utils/constants/protocolConstants.h"
+#include "protocols/protocols_defs.h"
 
 // How many times do we try to reconnect.
 constexpr int MAX_CONNECTION_RETRY = 10;
@@ -127,18 +124,18 @@ void LocalSocketController::activate(const QJsonObject &rawConfig) {
   int splitTunnelType = rawConfig.value("splitTunnelType").toInt();
   QJsonArray splitTunnelSites = rawConfig.value("splitTunnelSites").toArray();
 
-  int appSplitTunnelType = rawConfig.value(amnezia::configKey::appSplitTunnelType).toInt();
-  QJsonArray splitTunnelApps = rawConfig.value(amnezia::configKey::splitTunnelApps).toArray();
-  QJsonArray allowedDns = rawConfig.value(amnezia::configKey::allowedDnsServers).toArray();
+  int appSplitTunnelType = rawConfig.value(amnezia::config_key::appSplitTunnelType).toInt();
+  QJsonArray splitTunnelApps = rawConfig.value(amnezia::config_key::splitTunnelApps).toArray();
+  QJsonArray allowedDns = rawConfig.value(amnezia::config_key::allowedDnsServers).toArray();
 
   QJsonObject wgConfig = rawConfig.value(protocolName + "_config_data").toObject();
 
   QJsonObject json;
   json.insert("type", "activate");
   //  json.insert("hopindex", QJsonValue((double)hop.m_hopindex));
-  json.insert("privateKey", wgConfig.value(amnezia::configKey::clientPrivKey));
-  json.insert("deviceIpv4Address", wgConfig.value(amnezia::configKey::clientIp));
-  m_deviceIpv4 = wgConfig.value(amnezia::configKey::clientIp).toString();
+  json.insert("privateKey", wgConfig.value(amnezia::config_key::client_priv_key));
+  json.insert("deviceIpv4Address", wgConfig.value(amnezia::config_key::client_ip));
+  m_deviceIpv4 = wgConfig.value(amnezia::config_key::client_ip).toString();
 
   // set up IPv6 unique-local-address, ULA, with "fd00::/8" prefix, not globally routable.
   // this will be default IPv6 gateway, OS recognizes that IPv6 link is local and switches to IPv4.
@@ -149,27 +146,27 @@ void LocalSocketController::activate(const QJsonObject &rawConfig) {
   // simply "dead::1" is globally-routable, don't use it
   json.insert("deviceIpv6Address", "fd58:baa6:dead::1");
 
-  json.insert("serverPublicKey", wgConfig.value(amnezia::configKey::serverPubKey));
-  json.insert("serverPskKey", wgConfig.value(amnezia::configKey::pskKey));
-  json.insert("serverIpv4AddrIn", wgConfig.value(amnezia::configKey::hostName));
+  json.insert("serverPublicKey", wgConfig.value(amnezia::config_key::server_pub_key));
+  json.insert("serverPskKey", wgConfig.value(amnezia::config_key::psk_key));
+  json.insert("serverIpv4AddrIn", wgConfig.value(amnezia::config_key::hostName));
   //  json.insert("serverIpv6AddrIn", QJsonValue(hop.m_server.ipv6AddrIn()));
-  json.insert("deviceMTU", wgConfig.value(amnezia::configKey::mtu));
+  json.insert("deviceMTU", wgConfig.value(amnezia::config_key::mtu));
 
-  json.insert("serverPort", wgConfig.value(amnezia::configKey::port).toInt());
-  json.insert("serverIpv4Gateway", wgConfig.value(amnezia::configKey::hostName));
+  json.insert("serverPort", wgConfig.value(amnezia::config_key::port).toInt());
+  json.insert("serverIpv4Gateway", wgConfig.value(amnezia::config_key::hostName));
   //  json.insert("serverIpv6Gateway", QJsonValue(hop.m_server.ipv6Gateway()));
 
-  json.insert("primaryDnsServer", rawConfig.value(amnezia::configKey::dns1));
+  json.insert("primaryDnsServer", rawConfig.value(amnezia::config_key::dns1));
 
   // We don't use secondary DNS if primary DNS is AmneziaDNS
-  if (!rawConfig.value(amnezia::configKey::dns1).toString().
+  if (!rawConfig.value(amnezia::config_key::dns1).toString().
     contains(amnezia::protocols::dns::amneziaDnsIp)) {
-    json.insert("secondaryDnsServer", rawConfig.value(amnezia::configKey::dns2));
+    json.insert("secondaryDnsServer", rawConfig.value(amnezia::config_key::dns2));
   }
 
   QJsonArray jsAllowedIPAddesses;
 
-  QJsonArray plainAllowedIP = wgConfig.value(amnezia::configKey::allowedIps).toArray();
+  QJsonArray plainAllowedIP = wgConfig.value(amnezia::config_key::allowed_ips).toArray();
   QJsonArray defaultAllowedIP = { "0.0.0.0/0", "::/0" };
 
   if (plainAllowedIP != defaultAllowedIP && !plainAllowedIP.isEmpty()) {
@@ -230,7 +227,7 @@ void LocalSocketController::activate(const QJsonObject &rawConfig) {
   json.insert("allowedIPAddressRanges", jsAllowedIPAddesses);
 
   QJsonArray jsExcludedAddresses;
-  jsExcludedAddresses.append(wgConfig.value(amnezia::configKey::hostName));
+  jsExcludedAddresses.append(wgConfig.value(amnezia::config_key::hostName));
   if (splitTunnelType == 2) {
     for (auto v : splitTunnelSites) {
           QString ipRange = v.toString();
@@ -242,54 +239,61 @@ void LocalSocketController::activate(const QJsonObject &rawConfig) {
 
   json.insert("vpnDisabledApps", splitTunnelApps);
 
+  // === ДОБАВЛЕНО: ПЕРЕДАЧА РЕЖИМА INCLUDE/EXCLUDE В ДЕМОН ===
+  // Конвертируем тип маршрутизации интерфейса в наш флаг для драйвера
+  // Если интерфейс передает 1 (VpnOnlyForApps), мы отправляем 1 (Include) в ядро.
+  // Иначе отправляем 0 (Exclude).
+  json.insert("splitMode", (appSplitTunnelType == 1) ? 1 : 0); 
+  // ==========================================================
+
   json.insert("allowedDnsServers", allowedDns);
 
-  json.insert(amnezia::configKey::killSwitchOption, rawConfig.value(amnezia::configKey::killSwitchOption));
+  json.insert(amnezia::config_key::killSwitchOption, rawConfig.value(amnezia::config_key::killSwitchOption));
 
-  if (protocolName == amnezia::configKey::awg) {
-    json.insert(amnezia::configKey::junkPacketCount, wgConfig.value(amnezia::configKey::junkPacketCount));
-    json.insert(amnezia::configKey::junkPacketMinSize, wgConfig.value(amnezia::configKey::junkPacketMinSize));
-    json.insert(amnezia::configKey::junkPacketMaxSize, wgConfig.value(amnezia::configKey::junkPacketMaxSize));
-    json.insert(amnezia::configKey::initPacketJunkSize, wgConfig.value(amnezia::configKey::initPacketJunkSize));
-    json.insert(amnezia::configKey::responsePacketJunkSize, wgConfig.value(amnezia::configKey::responsePacketJunkSize));
-    json.insert(amnezia::configKey::cookieReplyPacketJunkSize, wgConfig.value(amnezia::configKey::cookieReplyPacketJunkSize));
-    json.insert(amnezia::configKey::transportPacketJunkSize, wgConfig.value(amnezia::configKey::transportPacketJunkSize));
-    json.insert(amnezia::configKey::initPacketMagicHeader, wgConfig.value(amnezia::configKey::initPacketMagicHeader));
-    json.insert(amnezia::configKey::responsePacketMagicHeader, wgConfig.value(amnezia::configKey::responsePacketMagicHeader));
-    json.insert(amnezia::configKey::underloadPacketMagicHeader, wgConfig.value(amnezia::configKey::underloadPacketMagicHeader));
-    json.insert(amnezia::configKey::transportPacketMagicHeader, wgConfig.value(amnezia::configKey::transportPacketMagicHeader));
-    json.insert(amnezia::configKey::specialJunk1, wgConfig.value(amnezia::configKey::specialJunk1));
-    json.insert(amnezia::configKey::specialJunk2, wgConfig.value(amnezia::configKey::specialJunk2));
-    json.insert(amnezia::configKey::specialJunk3, wgConfig.value(amnezia::configKey::specialJunk3));
-    json.insert(amnezia::configKey::specialJunk4, wgConfig.value(amnezia::configKey::specialJunk4));
-    json.insert(amnezia::configKey::specialJunk5, wgConfig.value(amnezia::configKey::specialJunk5));
-  } else if (!wgConfig.value(amnezia::configKey::junkPacketCount).isUndefined()
-             && !wgConfig.value(amnezia::configKey::junkPacketMinSize).isUndefined()
-             && !wgConfig.value(amnezia::configKey::junkPacketMaxSize).isUndefined()
-             && !wgConfig.value(amnezia::configKey::initPacketJunkSize).isUndefined()
-             && !wgConfig.value(amnezia::configKey::responsePacketJunkSize).isUndefined()
-             && !wgConfig.value(amnezia::configKey::cookieReplyPacketJunkSize).isUndefined()
-             && !wgConfig.value(amnezia::configKey::transportPacketJunkSize).isUndefined()
-             && !wgConfig.value(amnezia::configKey::initPacketMagicHeader).isUndefined()
-             && !wgConfig.value(amnezia::configKey::responsePacketMagicHeader).isUndefined()
-             && !wgConfig.value(amnezia::configKey::underloadPacketMagicHeader).isUndefined()
-             && !wgConfig.value(amnezia::configKey::transportPacketMagicHeader).isUndefined()) {
-    json.insert(amnezia::configKey::junkPacketCount, wgConfig.value(amnezia::configKey::junkPacketCount));
-    json.insert(amnezia::configKey::junkPacketMinSize, wgConfig.value(amnezia::configKey::junkPacketMinSize));
-    json.insert(amnezia::configKey::junkPacketMaxSize, wgConfig.value(amnezia::configKey::junkPacketMaxSize));
-    json.insert(amnezia::configKey::initPacketJunkSize, wgConfig.value(amnezia::configKey::initPacketJunkSize));
-    json.insert(amnezia::configKey::responsePacketJunkSize, wgConfig.value(amnezia::configKey::responsePacketJunkSize));
-    json.insert(amnezia::configKey::cookieReplyPacketJunkSize, wgConfig.value(amnezia::configKey::cookieReplyPacketJunkSize));
-    json.insert(amnezia::configKey::transportPacketJunkSize, wgConfig.value(amnezia::configKey::transportPacketJunkSize));
-    json.insert(amnezia::configKey::initPacketMagicHeader, wgConfig.value(amnezia::configKey::initPacketMagicHeader));
-    json.insert(amnezia::configKey::responsePacketMagicHeader, wgConfig.value(amnezia::configKey::responsePacketMagicHeader));
-    json.insert(amnezia::configKey::underloadPacketMagicHeader, wgConfig.value(amnezia::configKey::underloadPacketMagicHeader));
-    json.insert(amnezia::configKey::transportPacketMagicHeader, wgConfig.value(amnezia::configKey::transportPacketMagicHeader));
-    json.insert(amnezia::configKey::specialJunk1, wgConfig.value(amnezia::configKey::specialJunk1));
-    json.insert(amnezia::configKey::specialJunk2, wgConfig.value(amnezia::configKey::specialJunk2));
-    json.insert(amnezia::configKey::specialJunk3, wgConfig.value(amnezia::configKey::specialJunk3));
-    json.insert(amnezia::configKey::specialJunk4, wgConfig.value(amnezia::configKey::specialJunk4));
-    json.insert(amnezia::configKey::specialJunk5, wgConfig.value(amnezia::configKey::specialJunk5));
+  if (protocolName == amnezia::config_key::awg) {
+    json.insert(amnezia::config_key::junkPacketCount, wgConfig.value(amnezia::config_key::junkPacketCount));
+    json.insert(amnezia::config_key::junkPacketMinSize, wgConfig.value(amnezia::config_key::junkPacketMinSize));
+    json.insert(amnezia::config_key::junkPacketMaxSize, wgConfig.value(amnezia::config_key::junkPacketMaxSize));
+    json.insert(amnezia::config_key::initPacketJunkSize, wgConfig.value(amnezia::config_key::initPacketJunkSize));
+    json.insert(amnezia::config_key::responsePacketJunkSize, wgConfig.value(amnezia::config_key::responsePacketJunkSize));
+    json.insert(amnezia::config_key::cookieReplyPacketJunkSize, wgConfig.value(amnezia::config_key::cookieReplyPacketJunkSize));
+    json.insert(amnezia::config_key::transportPacketJunkSize, wgConfig.value(amnezia::config_key::transportPacketJunkSize));
+    json.insert(amnezia::config_key::initPacketMagicHeader, wgConfig.value(amnezia::config_key::initPacketMagicHeader));
+    json.insert(amnezia::config_key::responsePacketMagicHeader, wgConfig.value(amnezia::config_key::responsePacketMagicHeader));
+    json.insert(amnezia::config_key::underloadPacketMagicHeader, wgConfig.value(amnezia::config_key::underloadPacketMagicHeader));
+    json.insert(amnezia::config_key::transportPacketMagicHeader, wgConfig.value(amnezia::config_key::transportPacketMagicHeader));
+    json.insert(amnezia::config_key::specialJunk1, wgConfig.value(amnezia::config_key::specialJunk1));
+    json.insert(amnezia::config_key::specialJunk2, wgConfig.value(amnezia::config_key::specialJunk2));
+    json.insert(amnezia::config_key::specialJunk3, wgConfig.value(amnezia::config_key::specialJunk3));
+    json.insert(amnezia::config_key::specialJunk4, wgConfig.value(amnezia::config_key::specialJunk4));
+    json.insert(amnezia::config_key::specialJunk5, wgConfig.value(amnezia::config_key::specialJunk5));
+  } else if (!wgConfig.value(amnezia::config_key::junkPacketCount).isUndefined()
+             && !wgConfig.value(amnezia::config_key::junkPacketMinSize).isUndefined()
+             && !wgConfig.value(amnezia::config_key::junkPacketMaxSize).isUndefined()
+             && !wgConfig.value(amnezia::config_key::initPacketJunkSize).isUndefined()
+             && !wgConfig.value(amnezia::config_key::responsePacketJunkSize).isUndefined()
+             && !wgConfig.value(amnezia::config_key::cookieReplyPacketJunkSize).isUndefined()
+             && !wgConfig.value(amnezia::config_key::transportPacketJunkSize).isUndefined()
+             && !wgConfig.value(amnezia::config_key::initPacketMagicHeader).isUndefined()
+             && !wgConfig.value(amnezia::config_key::responsePacketMagicHeader).isUndefined()
+             && !wgConfig.value(amnezia::config_key::underloadPacketMagicHeader).isUndefined()
+             && !wgConfig.value(amnezia::config_key::transportPacketMagicHeader).isUndefined()) {
+    json.insert(amnezia::config_key::junkPacketCount, wgConfig.value(amnezia::config_key::junkPacketCount));
+    json.insert(amnezia::config_key::junkPacketMinSize, wgConfig.value(amnezia::config_key::junkPacketMinSize));
+    json.insert(amnezia::config_key::junkPacketMaxSize, wgConfig.value(amnezia::config_key::junkPacketMaxSize));
+    json.insert(amnezia::config_key::initPacketJunkSize, wgConfig.value(amnezia::config_key::initPacketJunkSize));
+    json.insert(amnezia::config_key::responsePacketJunkSize, wgConfig.value(amnezia::config_key::responsePacketJunkSize));
+    json.insert(amnezia::config_key::cookieReplyPacketJunkSize, wgConfig.value(amnezia::config_key::cookieReplyPacketJunkSize));
+    json.insert(amnezia::config_key::transportPacketJunkSize, wgConfig.value(amnezia::config_key::transportPacketJunkSize));
+    json.insert(amnezia::config_key::initPacketMagicHeader, wgConfig.value(amnezia::config_key::initPacketMagicHeader));
+    json.insert(amnezia::config_key::responsePacketMagicHeader, wgConfig.value(amnezia::config_key::responsePacketMagicHeader));
+    json.insert(amnezia::config_key::underloadPacketMagicHeader, wgConfig.value(amnezia::config_key::underloadPacketMagicHeader));
+    json.insert(amnezia::config_key::transportPacketMagicHeader, wgConfig.value(amnezia::config_key::transportPacketMagicHeader));
+    json.insert(amnezia::config_key::specialJunk1, wgConfig.value(amnezia::config_key::specialJunk1));
+    json.insert(amnezia::config_key::specialJunk2, wgConfig.value(amnezia::config_key::specialJunk2));
+    json.insert(amnezia::config_key::specialJunk3, wgConfig.value(amnezia::config_key::specialJunk3));
+    json.insert(amnezia::config_key::specialJunk4, wgConfig.value(amnezia::config_key::specialJunk4));
+    json.insert(amnezia::config_key::specialJunk5, wgConfig.value(amnezia::config_key::specialJunk5));
   }
 
   write(json);

--- a/client/platforms/windows/daemon/windowsdaemon.cpp
+++ b/client/platforms/windows/daemon/windowsdaemon.cpp
@@ -24,7 +24,7 @@
 #include "platforms/windows/daemon/windowssplittunnel.h"
 #include "windowsfirewall.h"
 
-#include "core/utils/networkUtilities.h"
+#include "core/networkUtilities.h"
 
 namespace {
 Logger logger("WindowsDaemon");
@@ -62,23 +62,26 @@ void WindowsDaemon::prepareActivation(const InterfaceConfig& config, int inetAda
 }
 
 void WindowsDaemon::activateSplitTunnel(const InterfaceConfig& config, int vpnAdapterIndex) {
-    if (m_splitTunnelManager == nullptr)
-        return;
+  if (m_splitTunnelManager == nullptr)
+      return;
 
-  if (config.m_vpnDisabledApps.length() > 0) {
+  QStringList targetApps = config.m_vpnDisabledApps;
+  uint32_t splitMode = config.m_splitMode;
+
+  if (!targetApps.isEmpty()) {
       m_splitTunnelManager->start(m_inetAdapterIndex, vpnAdapterIndex);
-      m_splitTunnelManager->excludeApps(config.m_vpnDisabledApps);
+      m_splitTunnelManager->excludeApps(targetApps, splitMode);
   } else {
       m_splitTunnelManager->stop();
   }
 }
 
 bool WindowsDaemon::run(Op op, const InterfaceConfig& config) {
+  QStringList targetApps = config.m_vpnDisabledApps;
+  uint32_t splitMode = config.m_splitMode;
+
   if (!m_splitTunnelManager) {
-    if (config.m_vpnDisabledApps.length() > 0) {
-      // The Client has sent us a list of disabled apps, but we failed
-      // to init the the split tunnel driver.
-      // So let the client know this was not possible
+    if (!targetApps.isEmpty()) {
       emit backendFailure(DaemonError::ERROR_SPLIT_TUNNEL_INIT_FAILURE);
     }
     return true;
@@ -88,16 +91,21 @@ bool WindowsDaemon::run(Op op, const InterfaceConfig& config) {
     m_splitTunnelManager->stop();
     return true;
   }
-  if (config.m_vpnDisabledApps.length() > 0) {
+  
+  if (!targetApps.isEmpty()) {
     if (!m_splitTunnelManager->start(m_inetAdapterIndex)) {
       emit backendFailure(DaemonError::ERROR_SPLIT_TUNNEL_START_FAILURE);
-    };
-    if (!m_splitTunnelManager->excludeApps(config.m_vpnDisabledApps)) {
+      return true;
+    }
+    
+    if (!m_splitTunnelManager->excludeApps(targetApps, splitMode)) {
       emit backendFailure(DaemonError::ERROR_SPLIT_TUNNEL_EXCLUDE_FAILURE);
-    };
-    // Now the driver should be running (State == 4)
+      return true;
+    }
+    
     if (!m_splitTunnelManager->isRunning()) {
       emit backendFailure(DaemonError::ERROR_SPLIT_TUNNEL_START_FAILURE);
+      return true;
     }
     return true;
   }

--- a/client/platforms/windows/daemon/windowssplittunnel.cpp
+++ b/client/platforms/windows/daemon/windowssplittunnel.cpp
@@ -5,8 +5,8 @@
 #include "windowssplittunnel.h"
 
 #include <qassert.h>
-
 #include <memory>
+#include <vector>
 
 #include "../windowscommons.h"
 #include "../windowsservicemanager.h"
@@ -24,47 +24,45 @@
 #include <QFileInfo>
 #include <QNetworkInterface>
 #include <QScopeGuard>
+#include <combaseapi.h>
+
+#include <fwpmu.h>
+#pragma comment(lib, "Fwpuclnt.lib")
 
 #pragma region
 
 // Driver Configuration structures
 using CONFIGURATION_ENTRY = struct {
-  // Offset into buffer region that follows all entries.
-  // The image name uses the device path.
-  SIZE_T ImageNameOffset;
-  // Length of the String
-  USHORT ImageNameLength;
+  uint64_t ImageNameOffset;
+  uint16_t ImageNameLength;
+  uint8_t  _padding[6];
 };
 
 using CONFIGURATION_HEADER = struct {
-  // Number of entries immediately following the header.
-  SIZE_T NumEntries;
-
-  // Total byte length: header + entries + string buffer.
-  SIZE_T TotalLength;
+  uint64_t NumEntries;
+  uint64_t TotalLength;
+  uint32_t SplitMode;
+  uint32_t _padding; 
 };
 
-// Used to Configure Which IP is network/vpn
 using IP_ADDRESSES_CONFIG = struct {
   IN_ADDR TunnelIpv4;
   IN_ADDR InternetIpv4;
-
   IN6_ADDR TunnelIpv6;
   IN6_ADDR InternetIpv6;
 };
 
-// Used to Define Which Processes are alive on activation
 using PROCESS_DISCOVERY_HEADER = struct {
-  SIZE_T NumEntries;
-  SIZE_T TotalLength;
+  uint64_t NumEntries;
+  uint64_t TotalLength;
 };
 
 using PROCESS_DISCOVERY_ENTRY = struct {
-  HANDLE ProcessId;
-  HANDLE ParentProcessId;
-
-  SIZE_T ImageNameOffset;
-  USHORT ImageNameLength;
+  uint64_t ProcessId;
+  uint64_t ParentProcessId;
+  uint64_t ImageNameOffset;
+  uint16_t ImageNameLength;
+  uint8_t  _padding[6];
 };
 
 using ProcessInfo = struct {
@@ -74,48 +72,32 @@ using ProcessInfo = struct {
   std::wstring DevicePath;
 };
 
+using ST_SUBLAYER_GUIDS = struct {
+  GUID Baseline;
+  GUID Dns;
+};
+
 #ifndef CTL_CODE
-
 #  define FILE_ANY_ACCESS 0x0000
-
 #  define METHOD_BUFFERED 0
 #  define METHOD_IN_DIRECT 1
 #  define METHOD_NEITHER 3
-
 #  define CTL_CODE(DeviceType, Function, Method, Access) \
     (((DeviceType) << 16) | ((Access) << 14) | ((Function) << 2) | (Method))
 #endif
 
-// Known ControlCodes
-#define IOCTL_INITIALIZE CTL_CODE(0x8000, 1, METHOD_NEITHER, FILE_ANY_ACCESS)
-
-#define IOCTL_DEQUEUE_EVENT \
-  CTL_CODE(0x8000, 2, METHOD_BUFFERED, FILE_ANY_ACCESS)
-
-#define IOCTL_REGISTER_PROCESSES \
-  CTL_CODE(0x8000, 3, METHOD_BUFFERED, FILE_ANY_ACCESS)
-
-#define IOCTL_REGISTER_IP_ADDRESSES \
-  CTL_CODE(0x8000, 4, METHOD_BUFFERED, FILE_ANY_ACCESS)
-
-#define IOCTL_GET_IP_ADDRESSES \
-  CTL_CODE(0x8000, 5, METHOD_BUFFERED, FILE_ANY_ACCESS)
-
-#define IOCTL_SET_CONFIGURATION \
-  CTL_CODE(0x8000, 6, METHOD_BUFFERED, FILE_ANY_ACCESS)
-
-#define IOCTL_GET_CONFIGURATION \
-  CTL_CODE(0x8000, 7, METHOD_BUFFERED, FILE_ANY_ACCESS)
-
-#define IOCTL_CLEAR_CONFIGURATION \
-  CTL_CODE(0x8000, 8, METHOD_NEITHER, FILE_ANY_ACCESS)
-
+// СТРОГО METHOD_BUFFERED! Я вернул макросы к рабочему 39 релизу
+#define IOCTL_INITIALIZE CTL_CODE(0x8000, 1, METHOD_BUFFERED, FILE_ANY_ACCESS)
+#define IOCTL_DEQUEUE_EVENT CTL_CODE(0x8000, 2, METHOD_BUFFERED, FILE_ANY_ACCESS)
+#define IOCTL_REGISTER_PROCESSES CTL_CODE(0x8000, 3, METHOD_BUFFERED, FILE_ANY_ACCESS)
+#define IOCTL_REGISTER_IP_ADDRESSES CTL_CODE(0x8000, 4, METHOD_BUFFERED, FILE_ANY_ACCESS)
+#define IOCTL_GET_IP_ADDRESSES CTL_CODE(0x8000, 5, METHOD_BUFFERED, FILE_ANY_ACCESS)
+#define IOCTL_SET_CONFIGURATION CTL_CODE(0x8000, 6, METHOD_BUFFERED, FILE_ANY_ACCESS)
+#define IOCTL_GET_CONFIGURATION CTL_CODE(0x8000, 7, METHOD_BUFFERED, FILE_ANY_ACCESS)
+#define IOCTL_CLEAR_CONFIGURATION CTL_CODE(0x8000, 8, METHOD_BUFFERED, FILE_ANY_ACCESS)
 #define IOCTL_GET_STATE CTL_CODE(0x8000, 9, METHOD_BUFFERED, FILE_ANY_ACCESS)
-
-#define IOCTL_QUERY_PROCESS \
-  CTL_CODE(0x8000, 10, METHOD_BUFFERED, FILE_ANY_ACCESS)
-
-#define IOCTL_ST_RESET CTL_CODE(0x8000, 11, METHOD_NEITHER, FILE_ANY_ACCESS)
+#define IOCTL_QUERY_PROCESS CTL_CODE(0x8000, 10, METHOD_BUFFERED, FILE_ANY_ACCESS)
+#define IOCTL_ST_RESET CTL_CODE(0x8000, 11, METHOD_BUFFERED, FILE_ANY_ACCESS)
 
 constexpr static const auto DRIVER_SYMLINK = L"\\\\.\\MULLVADSPLITTUNNEL";
 constexpr static const auto DRIVER_FILENAME = "mullvad-split-tunnel.sys";
@@ -135,140 +117,96 @@ ProcessInfo getProcessInfo(HANDLE process, const PROCESSENTRY32W& processMeta) {
   pi.DevicePath = L"";
 
   FILETIME creationTime, null_time;
-  auto ok = GetProcessTimes(process, &creationTime, &null_time, &null_time,
-                            &null_time);
+  auto ok = GetProcessTimes(process, &creationTime, &null_time, &null_time, &null_time);
   if (ok) {
     pi.CreationTime = creationTime;
   }
   wchar_t imagepath[MAX_PATH + 1];
-  if (K32GetProcessImageFileNameW(
-          process, imagepath, sizeof(imagepath) / sizeof(*imagepath)) != 0) {
+  if (K32GetProcessImageFileNameW(process, imagepath, sizeof(imagepath) / sizeof(*imagepath)) != 0) {
     pi.DevicePath = imagepath;
   }
   return pi;
 }
 
+// Создаем слои, которые хардкодом зашиты в вашем ioctl.cpp
+void RegisterHardcodedDriverSublayers() {
+  HANDLE engine = NULL;
+  if (FwpmEngineOpen0(NULL, RPC_C_AUTHN_WINNT, NULL, NULL, &engine) == ERROR_SUCCESS) {
+      FWPM_SUBLAYER0 subLayer1;
+      memset(&subLayer1, 0, sizeof(subLayer1));
+      subLayer1.subLayerKey = { 0x11111111, 0x2222, 0x3333, { 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB } };
+      subLayer1.displayData.name = (PWSTR)L"Amnezia ST Custom Baseline";
+      subLayer1.weight = 0xFFFF;
+      FwpmSubLayerAdd0(engine, &subLayer1, NULL);
+
+      FWPM_SUBLAYER0 subLayer2;
+      memset(&subLayer2, 0, sizeof(subLayer2));
+      subLayer2.subLayerKey = { 0xAAAAAAAA, 0xBBBB, 0xCCCC, { 0xDD, 0xEE, 0xFF, 0x00, 0x11, 0x22, 0x33, 0x44 } };
+      subLayer2.displayData.name = (PWSTR)L"Amnezia ST Custom DNS";
+      subLayer2.weight = 0xFFFF;
+      FwpmSubLayerAdd0(engine, &subLayer2, NULL);
+
+      FwpmEngineClose0(engine);
+  }
+}
+
 }  // namespace
 
-std::unique_ptr<WindowsSplitTunnel> WindowsSplitTunnel::create(
-    WindowsFirewall* fw) {
-  if (fw == nullptr) {
-    // Pre-Condition:
-    // Make sure the Windows Firewall has created the sublayer
-    // otherwise the driver will fail to initialize
-    logger.error() << "Failed to did not pass a WindowsFirewall obj"
-                   << "The Driver cannot work with the sublayer not created";
-    return nullptr;
-  }
-  // 00: Check if we conflict with mullvad, if so.
-  if (detectConflict()) {
-    logger.error() << "Conflict detected, abort Split-Tunnel init.";
-    return nullptr;
-  }
-  // 01: Check if the driver is installed, if not do so.
+std::unique_ptr<WindowsSplitTunnel> WindowsSplitTunnel::create(WindowsFirewall* fw) {
+  if (fw == nullptr) return nullptr;
+  if (detectConflict()) return nullptr;
   if (!isInstalled()) {
-    logger.debug() << "Driver is not Installed, doing so";
     auto handle = installDriver();
-    if (handle == INVALID_HANDLE_VALUE) {
-      WindowsUtils::windowsLog("Failed to install Driver");
-      return nullptr;
-    }
-    logger.debug() << "Driver installed";
+    if (handle == INVALID_HANDLE_VALUE) return nullptr;
     CloseServiceHandle(handle);
-  } else {
-    logger.debug() << "Driver was installed";
   }
-  // 02: Now check if the service is running
-  auto driver_manager =
-      WindowsServiceManager::open(QString::fromWCharArray(DRIVER_SERVICE_NAME));
-  if (Q_UNLIKELY(driver_manager == nullptr)) {
-    // Let's be fair if we end up here,
-    // after checking it exists and installing it,
-    // this is super unlikeley
-    Q_ASSERT(false);
-    logger.error()
-        << "WindowsServiceManager was unable fo find Split Tunnel service?";
-    return nullptr;
-  }
+  auto driver_manager = WindowsServiceManager::open(QString::fromWCharArray(DRIVER_SERVICE_NAME));
+  if (Q_UNLIKELY(driver_manager == nullptr)) return nullptr;
+  
   if (!driver_manager->isRunning()) {
-    logger.debug() << "Driver is not running, starting it";
-    // Start the service
-    if (!driver_manager->startService()) {
-      logger.error() << "Failed to start Split Tunnel Service";
-      return nullptr;
-    };
+    if (!driver_manager->startService()) return nullptr;
   }
-  // 03: Open the Driver Symlink
-  auto driverFile = CreateFileW(DRIVER_SYMLINK, GENERIC_READ | GENERIC_WRITE, 0,
-                                nullptr, OPEN_EXISTING, 0, nullptr);
-  ;
+  
+  auto driverFile = CreateFileW(DRIVER_SYMLINK, GENERIC_READ | GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, 0, nullptr);
   if (driverFile == INVALID_HANDLE_VALUE) {
-    WindowsUtils::windowsLog("Failed to open Driver: ");
-    // Only once, if the opening did not work. Try to reboot it. #
-    logger.info()
-        << "Failed to open driver, attempting only once to reboot driver";
-    if (!driver_manager->stopService()) {
-      logger.error() << "Unable stop driver";
-      return nullptr;
-    };
-    logger.info() << "Stopped driver, starting it again.";
-    if (!driver_manager->startService()) {
-      logger.error() << "Unable start driver";
-      return nullptr;
-    };
-    logger.info() << "Opening again.";
-    driverFile = CreateFileW(DRIVER_SYMLINK, GENERIC_READ | GENERIC_WRITE, 0,
-                             nullptr, OPEN_EXISTING, 0, nullptr);
-    if (driverFile == INVALID_HANDLE_VALUE) {
-      logger.error() << "Opening Failed again, sorry!";
-      return nullptr;
-    }
+    driver_manager->stopService();
+    driver_manager->startService();
+    driverFile = CreateFileW(DRIVER_SYMLINK, GENERIC_READ | GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, 0, nullptr);
+    if (driverFile == INVALID_HANDLE_VALUE) return nullptr;
   }
-  if (!initDriver(driverFile)) {
-    logger.error() << "Failed to init driver";
-    return nullptr;
-  }
-  // We're ready to talk to the driver, it's alive and setup.
+  if (!initDriver(driverFile)) return nullptr;
   return std::make_unique<WindowsSplitTunnel>(driverFile);
 }
 
 bool WindowsSplitTunnel::initDriver(HANDLE driverIO) {
-  // We need to now check the state and init it, if required
-  auto state = getState(driverIO);
-  if (state == STATE_UNKNOWN) {
-    logger.debug() << "Cannot check if driver is initialized";
-    return false;
-  }
-  if (state >= STATE_INITIALIZED) {
-    logger.debug() << "Driver already initialized: " << state;
-    // Reset Driver as it has wfp handles probably >:(
-    resetDriver(driverIO);
+  logger.debug() << "[INIT] Ensuring Custom Driver WFP sublayers exist...";
+  
+  RegisterHardcodedDriverSublayers();
 
-    auto newState = getState(driverIO);
-    logger.debug() << "New state after reset:" << newState;
-    if (newState >= STATE_INITIALIZED) {
-      logger.debug() << "Reset unsuccesfull";
-      return false;
+  DWORD bytesReturned = 0;
+  DeviceIoControl(driverIO, IOCTL_ST_RESET, nullptr, 0, nullptr, 0, &bytesReturned, nullptr);
+  
+  ST_SUBLAYER_GUIDS guids;
+  memset(&guids, 0, sizeof(guids));
+
+  bool initOk = DeviceIoControl(driverIO, IOCTL_INITIALIZE, &guids, sizeof(guids), nullptr, 0, &bytesReturned, nullptr);
+  
+  if (!initOk) {
+    DWORD err = GetLastError();
+    if (err == 2150760457) { // FWP_E_ALREADY_EXISTS
+      logger.info() << "[INIT] SUCCESS: Driver already initialized.";
+      return true;
     }
-  }
-
-  DWORD bytesReturned;
-  auto ok = DeviceIoControl(driverIO, IOCTL_INITIALIZE, nullptr, 0, nullptr, 0,
-                            &bytesReturned, nullptr);
-  if (!ok) {
-    auto err = GetLastError();
-    logger.error() << "Driver init failed err -" << err;
-    logger.error() << "State:" << getState(driverIO);
-
+    logger.error() << "[INIT] FATAL: Driver init failed, err: " << err;
     return false;
   }
-  logger.debug() << "Driver initialized" << getState(driverIO);
-  return true;
+  
+  logger.debug() << "[INIT] SUCCESS: Driver initialized cleanly.";
+  return true; 
 }
 
 WindowsSplitTunnel::WindowsSplitTunnel(HANDLE driverIO) : m_driver(driverIO) {
   logger.debug() << "Connected to the Driver";
-
   Q_ASSERT(getState() == STATE_INITIALIZED);
 }
 
@@ -277,84 +215,92 @@ WindowsSplitTunnel::~WindowsSplitTunnel() {
   uninstallDriver();
 }
 
-bool WindowsSplitTunnel::excludeApps(const QStringList& appPaths) {
+bool WindowsSplitTunnel::excludeApps(const QStringList& appPaths, uint32_t splitMode) {
   auto state = getState();
-  if (state != STATE_READY && state != STATE_RUNNING) {
-    logger.warning() << "Driver is not in the right State to set Rules"
-                     << state;
+  if (state != STATE_READY && state != STATE_RUNNING && state != STATE_INITIALIZED) {
+    logger.warning() << "[EXCLUDE] Driver is not in the right State to set Rules: " << stateString();
     return false;
   }
 
-  logger.debug() << "Pushing new Ruleset for Split-Tunnel " << state;
-  auto config = generateAppConfiguration(appPaths);
+  logger.debug() << "[EXCLUDE] Pushing Ruleset. Mode: " << splitMode << " | Apps count: " << appPaths.size();
+  auto appConfig = generateAppConfiguration(appPaths, splitMode);
 
-  DWORD bytesReturned;
-  auto ok = DeviceIoControl(m_driver, IOCTL_SET_CONFIGURATION, &config[0],
-                            (DWORD)config.size(), nullptr, 0, &bytesReturned,
-                            nullptr);
-  if (!ok) {
-    auto err = GetLastError();
+  DWORD bytesReturned = 0;
+  DeviceIoControl(m_driver, IOCTL_CLEAR_CONFIGURATION, nullptr, 0, nullptr, 0, &bytesReturned, nullptr);
+
+  bool setOk = DeviceIoControl(m_driver, IOCTL_SET_CONFIGURATION, &appConfig[0], (DWORD)appConfig.size(), nullptr, 0, &bytesReturned, nullptr);
+  if (!setOk) {
+    DWORD err = GetLastError();
     WindowsUtils::windowsLog("Set Config Failed:");
-    logger.error() << "Failed to set Config err code " << err;
+    logger.error() << "[EXCLUDE] FATAL: Failed to set Config in Kernel! Err code: " << err;
     return false;
   }
-  logger.debug() << "New Configuration applied: " << stateString();
+  
+  logger.debug() << "[EXCLUDE] SUCCESS! New Configuration applied perfectly.";
   return true;
 }
 
 bool WindowsSplitTunnel::start(int inetAdapterIndex, int vpnAdapterIndex) {
-  // To Start we need to send 2 things:
-  // Network info (what is vpn what is network)
-  logger.debug() << "Starting SplitTunnel";
-  DWORD bytesReturned;
+  logger.debug() << "[START] Starting SplitTunnel Configuration...";
+  DWORD bytesReturned = 0;
 
   if (getState() == STATE_STARTED) {
-    logger.debug() << "Driver needs Init Call";
-    DWORD bytesReturned;
-    auto ok = DeviceIoControl(m_driver, IOCTL_INITIALIZE, nullptr, 0, nullptr,
-                              0, &bytesReturned, nullptr);
-    if (!ok) {
-      logger.error() << "Driver init failed";
-      return false;
+    logger.debug() << "[START] Driver needs Init Call...";
+    
+    RegisterHardcodedDriverSublayers();
+    DeviceIoControl(m_driver, IOCTL_ST_RESET, nullptr, 0, nullptr, 0, &bytesReturned, nullptr);
+    
+    ST_SUBLAYER_GUIDS guids;
+    memset(&guids, 0, sizeof(guids));
+
+    bool initOk = DeviceIoControl(m_driver, IOCTL_INITIALIZE, &guids, sizeof(guids), nullptr, 0, &bytesReturned, nullptr);
+    if (!initOk) {
+      DWORD err = GetLastError();
+      if (err == 2150760457) {
+         logger.info() << "[START] Driver already initialized. Proceeding.";
+      } else {
+         logger.error() << "[START] FATAL: Driver init failed, err: " << err;
+         return false;
+      }
     }
   }
 
-  // Process Info (what is running already)
   if (getState() == STATE_INITIALIZED) {
-    logger.debug() << "State is Init, requires process config";
-    auto config = generateProcessBlob();
-    auto ok = DeviceIoControl(m_driver, IOCTL_REGISTER_PROCESSES, &config[0],
-                              (DWORD)config.size(), nullptr, 0, &bytesReturned,
-                              nullptr);
-    if (!ok) {
-      logger.error() << "Failed to set Process Config";
-      return false;
+    logger.debug() << "[START] State is Init, sending active processes to driver...";
+    auto processConfig = generateProcessBlob();
+    if (!processConfig.empty()) {
+        bool procOk = DeviceIoControl(m_driver, IOCTL_REGISTER_PROCESSES, &processConfig[0], (DWORD)processConfig.size(), nullptr, 0, &bytesReturned, nullptr);
+        if(!procOk) logger.warning() << "[START] IOCTL_REGISTER_PROCESSES failed, err: " << GetLastError();
     }
-    logger.debug() << "Set Process Config ok || new State:" << stateString();
   }
 
-  if (getState() == STATE_INITIALIZED) {
-    logger.warning() << "Driver is still not ready after process list send";
-    return false;
+  logger.debug() << "[START] Waiting for VPN IP configuration (Loop)...";
+  std::vector<std::byte> ipConfig;
+  for (int i = 0; i < 15; ++i) { 
+    ipConfig = generateIPConfiguration(inetAdapterIndex, vpnAdapterIndex);
+    if (!ipConfig.empty()) break; 
+    Sleep(500); 
   }
-  logger.debug() << "Driver is  ready || new State:" << stateString();
 
-  auto config = generateIPConfiguration(inetAdapterIndex, vpnAdapterIndex);
-  auto ok = DeviceIoControl(m_driver, IOCTL_REGISTER_IP_ADDRESSES, &config[0],
-                            (DWORD)config.size(), nullptr, 0, &bytesReturned,
-                            nullptr);
-  if (!ok) {
-    logger.error() << "Failed to set Network Config";
-    return false;
+  if (ipConfig.empty()) {
+      logger.error() << "[START] FATAL: Failed to get Network Config IPs after 15 tries.";
+      return false;
   }
-  logger.debug() << "New Network Config Applied || new State:" << stateString();
+
+  logger.debug() << "[START] Sending IP Config to driver...";
+  bool netOk = DeviceIoControl(m_driver, IOCTL_REGISTER_IP_ADDRESSES, &ipConfig[0], (DWORD)ipConfig.size(), nullptr, 0, &bytesReturned, nullptr);
+  if (!netOk) {
+      logger.error() << "[START] FATAL: Failed to set Network Config, err: " << GetLastError();
+      return false;
+  }
+  
+  logger.debug() << "[START] SUCCESS! Driver is ready || new State: " << stateString();
   return true;
 }
 
 void WindowsSplitTunnel::stop() {
-  DWORD bytesReturned;
-  auto ok = DeviceIoControl(m_driver, IOCTL_CLEAR_CONFIGURATION, nullptr, 0,
-                            nullptr, 0, &bytesReturned, nullptr);
+  DWORD bytesReturned = 0;
+  bool ok = DeviceIoControl(m_driver, IOCTL_CLEAR_CONFIGURATION, nullptr, 0, nullptr, 0, &bytesReturned, nullptr);
   if (!ok) {
     logger.error() << "Stopping Split tunnel not successfull";
     return;
@@ -363,9 +309,8 @@ void WindowsSplitTunnel::stop() {
 }
 
 bool WindowsSplitTunnel::resetDriver(HANDLE driverIO) {
-  DWORD bytesReturned;
-  auto ok = DeviceIoControl(driverIO, IOCTL_ST_RESET, nullptr, 0, nullptr, 0,
-                            &bytesReturned, nullptr);
+  DWORD bytesReturned = 0;
+  bool ok = DeviceIoControl(driverIO, IOCTL_ST_RESET, nullptr, 0, nullptr, 0, &bytesReturned, nullptr);
   if (!ok) {
     logger.error() << "Reset Split tunnel not successfull";
     return false;
@@ -374,53 +319,37 @@ bool WindowsSplitTunnel::resetDriver(HANDLE driverIO) {
   return true;
 }
 
-// static
 WindowsSplitTunnel::DRIVER_STATE WindowsSplitTunnel::getState(HANDLE driverIO) {
-  if (driverIO == INVALID_HANDLE_VALUE) {
-    logger.debug() << "Can't query State from non Opened Driver";
-    return STATE_UNKNOWN;
-  }
-  DWORD bytesReturned;
-  SIZE_T outBuffer;
-  bool ok = DeviceIoControl(driverIO, IOCTL_GET_STATE, nullptr, 0, &outBuffer,
-                            sizeof(outBuffer), &bytesReturned, nullptr);
-  if (!ok) {
-    WindowsUtils::windowsLog("getState response failure");
-    return STATE_UNKNOWN;
-  }
-  if (bytesReturned == 0) {
-    WindowsUtils::windowsLog("getState response is empty");
-    return STATE_UNKNOWN;
-  }
+  if (driverIO == INVALID_HANDLE_VALUE) return STATE_UNKNOWN;
+  DWORD bytesReturned = 0;
+  uint64_t outBuffer = 0; 
+  
+  bool ok = DeviceIoControl(driverIO, IOCTL_GET_STATE, nullptr, 0, &outBuffer, 8, &bytesReturned, nullptr);
+  if (!ok || bytesReturned == 0) return STATE_UNKNOWN;
   return static_cast<WindowsSplitTunnel::DRIVER_STATE>(outBuffer);
 }
+
 WindowsSplitTunnel::DRIVER_STATE WindowsSplitTunnel::getState() {
   return getState(m_driver);
 }
 
-std::vector<uint8_t> WindowsSplitTunnel::generateAppConfiguration(
-    const QStringList& appPaths) {
-  // Step 1: Calculate how much size the buffer will need
+std::vector<uint8_t> WindowsSplitTunnel::generateAppConfiguration(const QStringList& appPaths, uint32_t splitMode) {
   size_t cummulated_string_size = 0;
   QStringList dosPaths;
   for (auto const& path : appPaths) {
     auto dosPath = convertPath(path);
+    logger.debug() << "[EXCLUDE] Config Path Added: " << dosPath;
     dosPaths.append(dosPath);
     cummulated_string_size += dosPath.toStdWString().size() * sizeof(wchar_t);
-    logger.debug() << dosPath;
   }
-  size_t bufferSize = sizeof(CONFIGURATION_HEADER) +
-                      (sizeof(CONFIGURATION_ENTRY) * appPaths.size()) +
-                      cummulated_string_size;
+  size_t bufferSize = sizeof(CONFIGURATION_HEADER) + (sizeof(CONFIGURATION_ENTRY) * appPaths.size()) + cummulated_string_size;
   std::vector<uint8_t> outBuffer(bufferSize);
 
   auto header = (CONFIGURATION_HEADER*)&outBuffer[0];
   auto entry = (CONFIGURATION_ENTRY*)(header + 1);
+  auto stringDest = &outBuffer[0] + sizeof(CONFIGURATION_HEADER) + (sizeof(CONFIGURATION_ENTRY) * appPaths.size());
 
-  auto stringDest = &outBuffer[0] + sizeof(CONFIGURATION_HEADER) +
-                    (sizeof(CONFIGURATION_ENTRY) * appPaths.size());
-
-  SIZE_T stringOffset = 0;
+  uint64_t stringOffset = 0;
 
   for (const QString& path : dosPaths) {
     auto wstr = path.toStdWString();
@@ -429,7 +358,6 @@ std::vector<uint8_t> WindowsSplitTunnel::generateAppConfiguration(
 
     entry->ImageNameLength = (USHORT)stringLength;
     entry->ImageNameOffset = stringOffset;
-
     memcpy(stringDest, cstr, stringLength);
 
     ++entry;
@@ -439,55 +367,39 @@ std::vector<uint8_t> WindowsSplitTunnel::generateAppConfiguration(
 
   header->NumEntries = appPaths.length();
   header->TotalLength = bufferSize;
+  header->SplitMode = splitMode;
 
   return outBuffer;
 }
 
-std::vector<std::byte> WindowsSplitTunnel::generateIPConfiguration(
-    int inetAdapterIndex, int vpnAdapterIndex) {
+std::vector<std::byte> WindowsSplitTunnel::generateIPConfiguration(int inetAdapterIndex, int vpnAdapterIndex) {
   std::vector<std::byte> out(sizeof(IP_ADDRESSES_CONFIG));
-
   auto config = reinterpret_cast<IP_ADDRESSES_CONFIG*>(&out[0]);
-
   auto ifaces = QNetworkInterface::allInterfaces();
 
-    if (vpnAdapterIndex == 0) {
-    vpnAdapterIndex = WindowsCommons::VPNAdapterIndex();
-  }
-  // Always the VPN
-  if (!getAddress(vpnAdapterIndex, &config->TunnelIpv4,
-                  &config->TunnelIpv6)) {
-    return {};
-  }
-  // 2nd best route is usually the internet adapter
-  if (!getAddress(inetAdapterIndex, &config->InternetIpv4,
-                  &config->InternetIpv6)) {
-    return {};
-  };
+  if (vpnAdapterIndex == 0) vpnAdapterIndex = WindowsCommons::VPNAdapterIndex();
+  
+  if (!getAddress(vpnAdapterIndex, &config->TunnelIpv4, &config->TunnelIpv6)) return {};
+  if (!getAddress(inetAdapterIndex, &config->InternetIpv4, &config->InternetIpv6)) return {};
   return out;
 }
-bool WindowsSplitTunnel::getAddress(int adapterIndex, IN_ADDR* out_ipv4,
-                                    IN6_ADDR* out_ipv6) {
-  QNetworkInterface target =
-      QNetworkInterface::interfaceFromIndex(adapterIndex);
-  logger.debug() << "Getting adapter info for:" << target.humanReadableName();
+
+bool WindowsSplitTunnel::getAddress(int adapterIndex, IN_ADDR* out_ipv4, IN6_ADDR* out_ipv6) {
+  QNetworkInterface target = QNetworkInterface::interfaceFromIndex(adapterIndex);
 
   auto get = [&target](QAbstractSocket::NetworkLayerProtocol protocol) {
     for (auto address : target.addressEntries()) {
-      if (address.ip().protocol() != protocol) {
-        continue;
-      }
+      if (address.ip().protocol() != protocol) continue;
       return address.ip().toString().toStdWString();
     }
     return std::wstring{};
   };
+  
   auto ipv4 = get(QAbstractSocket::IPv4Protocol);
   auto ipv6 = get(QAbstractSocket::IPv6Protocol);
 
-  if (InetPtonW(AF_INET, ipv4.c_str(), out_ipv4) != 1) {
-    logger.debug() << "Ipv4 Conversation error" << WSAGetLastError();
-    return false;
-  }
+  if (InetPtonW(AF_INET, ipv4.c_str(), out_ipv4) != 1) return false;
+  
   if (ipv6.empty()) {
     std::memset(out_ipv6, 0x00, sizeof(IN6_ADDR));
     return true;
@@ -499,14 +411,10 @@ bool WindowsSplitTunnel::getAddress(int adapterIndex, IN_ADDR* out_ipv4,
 }
 
 std::vector<uint8_t> WindowsSplitTunnel::generateProcessBlob() {
-  // Get a Snapshot of all processes that are running:
   HANDLE snapshot_handle = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
-  if (snapshot_handle == INVALID_HANDLE_VALUE) {
-    WindowsUtils::windowsLog("Creating Process snapshot failed");
-    return std::vector<uint8_t>(0);
-  }
+  if (snapshot_handle == INVALID_HANDLE_VALUE) return std::vector<uint8_t>(0);
+  
   auto cleanup = qScopeGuard([&] { CloseHandle(snapshot_handle); });
-  // Load the First Entry, later iterate over all
   PROCESSENTRY32W currentProcess;
   currentProcess.dwSize = sizeof(PROCESSENTRY32W);
 
@@ -517,12 +425,9 @@ std::vector<uint8_t> WindowsSplitTunnel::generateProcessBlob() {
   QMap<DWORD, ProcessInfo> processes;
 
   do {
-    auto process_handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE,
-                                      currentProcess.th32ProcessID);
-
-    if (process_handle == INVALID_HANDLE_VALUE) {
-      continue;
-    }
+    auto process_handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, currentProcess.th32ProcessID);
+    if (process_handle == INVALID_HANDLE_VALUE) continue;
+    
     ProcessInfo info = getProcessInfo(process_handle, currentProcess);
     processes.insert(info.ProcessId, info);
     CloseHandle(process_handle);
@@ -530,47 +435,33 @@ std::vector<uint8_t> WindowsSplitTunnel::generateProcessBlob() {
   } while (FALSE != (Process32NextW(snapshot_handle, &currentProcess)));
 
   auto process_list = processes.values();
-  if (process_list.isEmpty()) {
-    logger.debug() << "Process Snapshot list was empty";
-    return std::vector<uint8_t>(0);
-  }
+  if (process_list.isEmpty()) return std::vector<uint8_t>(0);
 
-  logger.debug() << "Reading Processes NUM: " << process_list.size();
-  // Determine the Size of the outBuffer:
   size_t totalStringSize = 0;
-
   for (const auto& process : process_list) {
     totalStringSize += (process.DevicePath.size() * sizeof(wchar_t));
   }
-  auto bufferSize = sizeof(PROCESS_DISCOVERY_HEADER) +
-                    (sizeof(PROCESS_DISCOVERY_ENTRY) * processes.size()) +
-                    totalStringSize;
+  auto bufferSize = sizeof(PROCESS_DISCOVERY_HEADER) + (sizeof(PROCESS_DISCOVERY_ENTRY) * processes.size()) + totalStringSize;
 
   std::vector<uint8_t> out(bufferSize);
-
   auto header = reinterpret_cast<PROCESS_DISCOVERY_HEADER*>(&out[0]);
   auto entry = reinterpret_cast<PROCESS_DISCOVERY_ENTRY*>(header + 1);
   auto stringBuffer = reinterpret_cast<uint8_t*>(entry + processes.size());
 
-  SIZE_T currentStringOffset = 0;
+  uint64_t currentStringOffset = 0;
 
   for (const auto& process : process_list) {
-    // Wierd DWORD -> Handle Pointer magic.
-    entry->ProcessId = (HANDLE)((size_t)process.ProcessId);
-    entry->ParentProcessId = (HANDLE)((size_t)process.ParentProcessId);
+    entry->ProcessId = (uint64_t)process.ProcessId;
+    entry->ParentProcessId = (uint64_t)process.ParentProcessId;
 
     if (process.DevicePath.empty()) {
       entry->ImageNameOffset = 0;
       entry->ImageNameLength = 0;
     } else {
       const auto imageNameLength = process.DevicePath.size() * sizeof(wchar_t);
-
       entry->ImageNameOffset = currentStringOffset;
       entry->ImageNameLength = static_cast<USHORT>(imageNameLength);
-
-      RtlCopyMemory(stringBuffer + currentStringOffset, &process.DevicePath[0],
-                    imageNameLength);
-
+      RtlCopyMemory(stringBuffer + currentStringOffset, &process.DevicePath[0], imageNameLength);
       currentStringOffset += imageNameLength;
     }
     ++entry;
@@ -578,7 +469,6 @@ std::vector<uint8_t> WindowsSplitTunnel::generateProcessBlob() {
 
   header->NumEntries = processes.size();
   header->TotalLength = bufferSize;
-
   return out;
 }
 
@@ -586,17 +476,12 @@ std::vector<uint8_t> WindowsSplitTunnel::generateProcessBlob() {
 SC_HANDLE WindowsSplitTunnel::installDriver() {
   LPCWSTR displayName = L"Amnezia Split Tunnel Service";
   QFileInfo driver(qApp->applicationDirPath() + "/" + DRIVER_FILENAME);
-  if (!driver.exists()) {
-    logger.error() << "Split Tunnel Driver File not found "
-                   << driver.absoluteFilePath();
-    return (SC_HANDLE)INVALID_HANDLE_VALUE;
-  }
+  if (!driver.exists()) return (SC_HANDLE)INVALID_HANDLE_VALUE;
+  
   auto path = driver.absolutePath() + "/" + DRIVER_FILENAME;
   auto binPath = (const wchar_t*)path.utf16();
   auto scm_rights = SC_MANAGER_ALL_ACCESS;
-  auto serviceManager = OpenSCManager(nullptr,  // local computer
-                                      nullptr,  // servicesActive database
-                                      scm_rights);
+  auto serviceManager = OpenSCManager(nullptr, nullptr, scm_rights);
   auto service = CreateService(
       serviceManager, DRIVER_SERVICE_NAME, displayName, SERVICE_ALL_ACCESS,
       SERVICE_KERNEL_DRIVER, SERVICE_AUTO_START, SERVICE_ERROR_NORMAL, binPath,
@@ -604,35 +489,24 @@ SC_HANDLE WindowsSplitTunnel::installDriver() {
   CloseServiceHandle(serviceManager);
   return service;
 }
+
 // static
 bool WindowsSplitTunnel::uninstallDriver() {
   auto scm_rights = SC_MANAGER_ALL_ACCESS;
-  auto serviceManager = OpenSCManager(NULL,  // local computer
-                                      NULL,  // servicesActive database
-                                      scm_rights);
-
-  auto servicehandle =
-      OpenService(serviceManager, DRIVER_SERVICE_NAME, GENERIC_READ);
+  auto serviceManager = OpenSCManager(NULL, NULL, scm_rights);
+  auto servicehandle = OpenService(serviceManager, DRIVER_SERVICE_NAME, GENERIC_READ);
   auto result = DeleteService(servicehandle);
-  if (result) {
-    logger.debug() << "Split Tunnel Driver Removed";
-  }
   return result;
 }
+
 // static
 bool WindowsSplitTunnel::isInstalled() {
-  // Check if the Drivers I/O File is present
   auto symlink = QFileInfo(QString::fromWCharArray(DRIVER_SYMLINK));
-  if (symlink.exists()) {
-    return true;
-  }
-  // If not check with SCM, if the kernel service exists
+  if (symlink.exists()) return true;
+  
   auto scm_rights = SC_MANAGER_ALL_ACCESS;
-  auto serviceManager = OpenSCManager(NULL,  // local computer
-                                      NULL,  // servicesActive database
-                                      scm_rights);
-  auto servicehandle =
-      OpenService(serviceManager, DRIVER_SERVICE_NAME, GENERIC_READ);
+  auto serviceManager = OpenSCManager(NULL, NULL, scm_rights);
+  auto servicehandle = OpenService(serviceManager, DRIVER_SERVICE_NAME, GENERIC_READ);
   auto err = GetLastError();
   CloseServiceHandle(serviceManager);
   CloseServiceHandle(servicehandle);
@@ -640,83 +514,84 @@ bool WindowsSplitTunnel::isInstalled() {
 }
 
 QString WindowsSplitTunnel::convertPath(const QString& path) {
+  QString nativePath = path;
+  nativePath.replace("/", "\\");
+
+  HANDLE hFile = CreateFileW(
+      (const wchar_t*)nativePath.utf16(),
+      0,
+      FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+      nullptr,
+      OPEN_EXISTING,
+      FILE_FLAG_BACKUP_SEMANTICS,
+      nullptr
+  );
+
+  // ИСПОЛЬЗУЕМ СИСТЕМНОЕ ИМЯ ЯДРА С ТОЧНЫМ РЕГИСТРОМ ДЛЯ ИДЕАЛЬНОГО СОВПАДЕНИЯ
+  if (hFile != INVALID_HANDLE_VALUE) {
+      std::vector<wchar_t> buffer(MAX_PATH);
+      DWORD length = GetFinalPathNameByHandleW(hFile, buffer.data(), buffer.size(), VOLUME_NAME_NT);
+      if (length > buffer.size()) {
+          buffer.resize(length);
+          length = GetFinalPathNameByHandleW(hFile, buffer.data(), buffer.size(), VOLUME_NAME_NT);
+      }
+      CloseHandle(hFile);
+
+      if (length > 0) {
+          QString result = QString::fromWCharArray(buffer.data(), length);
+          return result.toLower();
+      }
+  }
+
+  // Фолбэк, если файл занят
   auto parts = path.split("/");
   QString driveLetter = parts.takeFirst();
-  if (!driveLetter.contains(":") || parts.size() == 0) {
-    // device should contain : for e.g C:
-    return "";
-  }
+  if (!driveLetter.contains(":") || parts.size() == 0) return "";
+  
   QByteArray buffer(2048, 0xFFu);
-  auto ok = QueryDosDeviceW(qUtf16Printable(driveLetter),
-                            (wchar_t*)buffer.data(), buffer.size() / 2);
+  auto ok = QueryDosDeviceW(qUtf16Printable(driveLetter), (wchar_t*)buffer.data(), buffer.size() / 2);
 
   if (ok == ERROR_INSUFFICIENT_BUFFER) {
     buffer.resize(buffer.size() * 2);
-    ok = QueryDosDeviceW(qUtf16Printable(driveLetter), (wchar_t*)buffer.data(),
-                         buffer.size() / 2);
+    ok = QueryDosDeviceW(qUtf16Printable(driveLetter), (wchar_t*)buffer.data(), buffer.size() / 2);
   }
-  if (ok == 0) {
-    WindowsUtils::windowsLog("Err fetching dos path");
-    return "";
-  }
-  QString deviceName;
-  deviceName = QString::fromWCharArray((wchar_t*)buffer.data());
+  if (ok == 0) return "";
+  
+  QString deviceName = QString::fromWCharArray((wchar_t*)buffer.data());
   parts.prepend(deviceName);
-
   return parts.join("\\");
 }
 
 // static
 bool WindowsSplitTunnel::detectConflict() {
   auto scm_rights = SC_MANAGER_ENUMERATE_SERVICE;
-  auto serviceManager = OpenSCManager(NULL,  // local computer
-                                      NULL,  // servicesActive database
-                                      scm_rights);
+  auto serviceManager = OpenSCManager(NULL, NULL, scm_rights);
   auto cleanup = qScopeGuard([&] { CloseServiceHandle(serviceManager); });
-  // Query for Mullvad Service.
-  auto servicehandle =
-      OpenService(serviceManager, MV_SERVICE_NAME, GENERIC_READ);
+  auto servicehandle = OpenService(serviceManager, MV_SERVICE_NAME, GENERIC_READ);
   auto err = GetLastError();
   CloseServiceHandle(servicehandle);
-  if (err != ERROR_SERVICE_DOES_NOT_EXIST) {
-    WindowsUtils::windowsLog("Mullvad Detected - Disabling SplitTunnel: ");
-    // Mullvad is installed, so we would certainly break things.
-    return true;
-  }
+  if (err != ERROR_SERVICE_DOES_NOT_EXIST) return true;
+  
   auto symlink = QFileInfo(QString::fromWCharArray(DRIVER_SYMLINK));
-  if (!symlink.exists()) {
-    // The driver is not loaded / installed.. MV is not installed, all good!
-    logger.info() << "No Split-Tunnel Conflict detected, continue.";
-    return false;
-  }
-  // The driver exists, so let's check if it has been created by us.
-  // If our service is not present, it's has been created by
-  // someone else so we should not use that :)
-  servicehandle =
-      OpenService(serviceManager, DRIVER_SERVICE_NAME, GENERIC_READ);
+  if (!symlink.exists()) return false;
+  
+  servicehandle = OpenService(serviceManager, DRIVER_SERVICE_NAME, GENERIC_READ);
   err = GetLastError();
   CloseServiceHandle(servicehandle);
   return err == ERROR_SERVICE_DOES_NOT_EXIST;
 }
 
 bool WindowsSplitTunnel::isRunning() { return getState() == STATE_RUNNING; }
+
 QString WindowsSplitTunnel::stateString() {
   switch (getState()) {
-    case STATE_UNKNOWN:
-      return "STATE_UNKNOWN";
-    case STATE_NONE:
-      return "STATE_NONE";
-    case STATE_STARTED:
-      return "STATE_STARTED";
-    case STATE_INITIALIZED:
-      return "STATE_INITIALIZED";
-    case STATE_READY:
-      return "STATE_READY";
-    case STATE_RUNNING:
-      return "STATE_RUNNING";
-    case STATE_ZOMBIE:
-      return "STATE_ZOMBIE";
-      break;
+    case STATE_UNKNOWN: return "STATE_UNKNOWN";
+    case STATE_NONE: return "STATE_NONE";
+    case STATE_STARTED: return "STATE_STARTED";
+    case STATE_INITIALIZED: return "STATE_INITIALIZED";
+    case STATE_READY: return "STATE_READY";
+    case STATE_RUNNING: return "STATE_RUNNING";
+    case STATE_ZOMBIE: return "STATE_ZOMBIE";
   }
   return {};
 }

--- a/client/platforms/windows/daemon/windowssplittunnel.h
+++ b/client/platforms/windows/daemon/windowssplittunnel.h
@@ -9,6 +9,7 @@
 #include <QString>
 #include <QStringList>
 #include <memory>
+#include <cstdint>
 
 // Note: the ws2tcpip.h import must come before the others.
 // clang-format off
@@ -44,9 +45,9 @@ class WindowsSplitTunnel final {
    */
   ~WindowsSplitTunnel();
 
-  // void excludeApps(const QStringList& paths);
-  // Excludes an Application from the VPN
-  bool excludeApps(const QStringList& appPaths);
+  // Excludes or Includes an Application from the VPN based on splitMode
+  // splitMode: 0 = Exclude (default), 1 = Include
+  bool excludeApps(const QStringList& appPaths, uint32_t splitMode = 0);
 
   // Fetches and Pushed needed info to move to engaged mode
   bool start(int inetAdapterIndex, int vpnAdapterIndex = 0);
@@ -82,8 +83,9 @@ class WindowsSplitTunnel final {
   DRIVER_STATE getState();
   QString stateString();
 
-  // Generates a Configuration for Each APP
-  std::vector<uint8_t> generateAppConfiguration(const QStringList& appPaths);
+  // Generates a Configuration for Each APP, including the routing mode
+  std::vector<uint8_t> generateAppConfiguration(const QStringList& appPaths, uint32_t splitMode);
+  
   // Generates a Configuration which IP's are VPN and which network
   std::vector<std::byte> generateIPConfiguration(int inetAdapterIndex, int vpnAdapterIndex = 0);
   std::vector<uint8_t> generateProcessBlob();

--- a/client/ui/controllers/settingsController.cpp
+++ b/client/ui/controllers/settingsController.cpp
@@ -1,0 +1,534 @@
+#include "settingsController.h"
+
+#include <QStandardPaths>
+#include <QOperatingSystemVersion>
+
+#include "logger.h"
+#include "systemController.h"
+#include "ui/qautostart.h"
+#include "amnezia_application.h"
+#include "version.h"
+#ifdef Q_OS_ANDROID
+    #include "platforms/android/android_controller.h"
+#endif
+
+#if defined(Q_OS_IOS) || defined(MACOS_NE)
+    #include <AmneziaVPN-Swift.h>
+#endif
+
+SettingsController::SettingsController(const QSharedPointer<ServersModel> &serversModel,
+                                       const QSharedPointer<ContainersModel> &containersModel,
+                                       const QSharedPointer<LanguageModel> &languageModel,
+                                       const QSharedPointer<SitesModel> &sitesModel,
+                                       const QSharedPointer<AppSplitTunnelingModel> &appSplitTunnelingModel,
+                                       const std::shared_ptr<Settings> &settings, QObject *parent)
+    : QObject(parent),
+      m_serversModel(serversModel),
+      m_containersModel(containersModel),
+      m_languageModel(languageModel),
+      m_sitesModel(sitesModel),
+      m_appSplitTunnelingModel(appSplitTunnelingModel),
+      m_settings(settings)
+{
+    m_appVersion = QString("%1 (%2, %3)").arg(QString(APP_VERSION), __DATE__, GIT_COMMIT_HASH);
+    checkIfNeedDisableLogs();
+#ifdef Q_OS_ANDROID
+    connect(AndroidController::instance(), &AndroidController::notificationStateChanged, this, &SettingsController::onNotificationStateChanged);
+    connect(AndroidController::instance(), &AndroidController::imeInsetsChanged, this, [this](int heightDp) {
+        m_imeHeight = heightDp;
+        emit imeHeightChanged(heightDp);
+        emit safeAreaBottomMarginChanged();
+    });
+    connect(AndroidController::instance(), &AndroidController::systemBarsInsetsChanged, this, [this](int navBarHeightDp, int statusBarHeightDp) {
+        m_cachedNavigationBarHeight = navBarHeightDp;
+        m_cachedStatusBarHeight = statusBarHeightDp;
+        emit safeAreaBottomMarginChanged();
+        emit safeAreaTopMarginChanged();
+    });
+    connect(AndroidController::instance(), &AndroidController::activityPaused, this, &SettingsController::activityPaused);
+    connect(AndroidController::instance(), &AndroidController::activityResumed, this, &SettingsController::activityResumed);
+#endif
+
+    m_isDevModeEnabled = m_settings->isDevGatewayEnv();
+    toggleDevGatewayEnv(m_isDevModeEnabled);
+}
+
+QString getPlatformName()
+{
+#if defined(Q_OS_WINDOWS)
+    return "Windows";
+#elif defined(Q_OS_ANDROID)
+    return "Android";
+#elif defined(Q_OS_LINUX)
+    return "Linux";
+#elif defined(Q_OS_MACX)
+    return "MacOS";
+#elif defined(Q_OS_IOS)
+    return "iOS";
+#else
+    return "Unknown";
+#endif
+}
+
+void SettingsController::toggleAmneziaDns(bool enable)
+{
+    m_settings->setUseAmneziaDns(enable);
+    emit amneziaDnsToggled(enable);
+}
+
+bool SettingsController::isAmneziaDnsEnabled()
+{
+    return m_settings->useAmneziaDns();
+}
+
+QString SettingsController::getPrimaryDns()
+{
+    return m_settings->primaryDns();
+}
+
+void SettingsController::setPrimaryDns(const QString &dns)
+{
+    m_settings->setPrimaryDns(dns);
+    emit primaryDnsChanged();
+}
+
+QString SettingsController::getSecondaryDns()
+{
+    return m_settings->secondaryDns();
+}
+
+void SettingsController::setSecondaryDns(const QString &dns)
+{
+    return m_settings->setSecondaryDns(dns);
+    emit secondaryDnsChanged();
+}
+
+bool SettingsController::isLoggingEnabled()
+{
+    return m_settings->isSaveLogs();
+}
+
+void SettingsController::toggleLogging(bool enable)
+{
+    m_settings->setSaveLogs(enable);
+#if defined(Q_OS_IOS)
+    AmneziaVPN::toggleLogging(enable);
+#endif
+    if (enable == true) {
+        qInfo().noquote() << QString("Logging has enabled on %1 version %2 %3").arg(APPLICATION_NAME, APP_VERSION, GIT_COMMIT_HASH);
+        qInfo().noquote() << QString("%1 (%2)").arg(QSysInfo::prettyProductName(), QSysInfo::currentCpuArchitecture());
+    }
+    emit loggingStateChanged();
+}
+
+void SettingsController::openLogsFolder()
+{
+    Logger::openLogsFolder(false);
+}
+
+void SettingsController::openServiceLogsFolder()
+{
+    Logger::openLogsFolder(true);
+}
+
+void SettingsController::exportLogsFile(const QString &fileName)
+{
+#ifdef Q_OS_ANDROID
+    AndroidController::instance()->exportLogsFile(fileName);
+#else
+    SystemController::saveFile(fileName, Logger::getLogFile());
+#endif
+}
+
+void SettingsController::exportServiceLogsFile(const QString &fileName)
+{
+#ifdef Q_OS_ANDROID
+    AndroidController::instance()->exportLogsFile(fileName);
+#else
+    SystemController::saveFile(fileName, Logger::getServiceLogFile());
+#endif
+}
+
+void SettingsController::clearLogs()
+{
+#ifdef Q_OS_ANDROID
+    AndroidController::instance()->clearLogs();
+#else
+    Logger::clearLogs(false);
+    Logger::clearServiceLogs();
+#endif
+
+    qInfo().noquote() << QString("Started %1 version %2 %3").arg(APPLICATION_NAME, APP_VERSION, GIT_COMMIT_HASH);
+    qInfo().noquote() << QString("%1 (%2)").arg(QSysInfo::prettyProductName(), QSysInfo::currentCpuArchitecture());
+    qInfo().noquote() << QString("SSL backend: %1").arg(QSslSocket::sslLibraryVersionString());
+}
+
+void SettingsController::backupAppConfig(const QString &fileName)
+{
+    QByteArray data = m_settings->backupAppConfig();
+    QJsonDocument doc = QJsonDocument::fromJson(data);
+    QJsonObject config = doc.object();
+
+    config["AppPlatform"] = getPlatformName();
+    config["Conf/autoStart"] = Autostart::isAutostart();
+    config["Conf/killSwitchEnabled"] = isKillSwitchEnabled();
+    config["Conf/strictKillSwitchEnabled"] = isStrictKillSwitchEnabled();
+    config["Conf/useAmneziaDns"] = isAmneziaDnsEnabled();
+
+    SystemController::saveFile(fileName, QJsonDocument(config).toJson());
+}
+
+void SettingsController::restoreAppConfig(const QString &fileName)
+{
+    QByteArray data;
+    if (!SystemController::readFile(fileName, data)) {
+        emit changeSettingsErrorOccurred(tr("Can't open file: %1").arg(fileName));
+        return;
+    }
+    restoreAppConfigFromData(data);
+}
+
+void SettingsController::restoreAppConfigFromData(const QByteArray &data)
+{
+    bool ok = m_settings->restoreAppConfig(data);
+    if (ok) {
+        QJsonObject newConfigData = QJsonDocument::fromJson(data).object();
+
+#if defined(Q_OS_WINDOWS) || defined(Q_OS_LINUX) || defined(Q_OS_MACX)
+        bool autoStart = false;
+        if (newConfigData.contains("Conf/autoStart")) {
+            autoStart = newConfigData["Conf/autoStart"].toBool();
+        }
+        toggleAutoStart(autoStart);
+#endif
+
+        m_serversModel->resetModel();
+        m_languageModel->changeLanguage(
+                static_cast<LanguageSettings::AvailableLanguageEnum>(m_languageModel->getCurrentLanguageIndex()));
+
+#if defined(Q_OS_WINDOWS) || defined(Q_OS_ANDROID)
+        int appSplitTunnelingRouteMode = newConfigData.value("Conf/appsRouteMode").toInt();
+        bool appSplittunnelingEnabled =
+                newConfigData.value("Conf/appsSplitTunnelingEnabled").toVariant().toString().toLower() == "true";
+        
+        // Передаем выбранный режим туннелирования.
+        // Заглушка, которая ранее принудительно ставила VpnAllExceptApps для Windows, удалена!
+        m_appSplitTunnelingModel->setRouteMode(appSplitTunnelingRouteMode);
+
+        if (newConfigData.contains("AppPlatform")) { //if backup is from a new version
+                if (newConfigData.value("AppPlatform").toString() != getPlatformName()) {
+                    m_appSplitTunnelingModel->clearAppsList();
+                }
+        }
+        
+        m_appSplitTunnelingModel->toggleSplitTunneling(appSplittunnelingEnabled);
+#endif
+
+        int siteSplitTunnelingRouteMode = newConfigData.value("Conf/routeMode").toInt();
+        bool siteSplittunnelingEnabled =
+                newConfigData.value("Conf/sitesSplitTunnelingEnabled").toVariant().toString().toLower() == "true";
+        m_sitesModel->setRouteMode(siteSplitTunnelingRouteMode);
+        m_sitesModel->toggleSplitTunneling(siteSplittunnelingEnabled);
+
+#if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)
+        m_settings->setAutoConnect(false);
+        m_settings->setStartMinimized(false);
+        m_settings->setKillSwitchEnabled(false);
+        m_settings->setStrictKillSwitchEnabled(false);
+#endif
+
+        bool amneziaDnsEnabled = newConfigData.contains("Conf/useAmneziaDns")
+                                     ? newConfigData.value("Conf/useAmneziaDns").toBool()
+                                     : m_settings->useAmneziaDns();
+        emit amneziaDnsToggled(amneziaDnsEnabled);
+
+        emit restoreBackupFinished();
+    } else {
+        emit changeSettingsErrorOccurred(tr("Backup file is corrupted"));
+    }
+}
+
+QString SettingsController::getAppVersion()
+{
+    return m_appVersion;
+}
+
+void SettingsController::clearSettings()
+{
+    m_settings->clearSettings();
+    m_serversModel->resetModel();
+    m_languageModel->changeLanguage(m_languageModel->getSystemLanguageEnum());
+
+    m_sitesModel->setRouteMode(Settings::RouteMode::VpnOnlyForwardSites);
+    m_sitesModel->toggleSplitTunneling(false);
+
+    m_appSplitTunnelingModel->setRouteMode(Settings::AppsRouteMode::VpnAllExceptApps);
+    m_appSplitTunnelingModel->toggleSplitTunneling(false);
+
+    toggleAutoStart(false);
+
+    emit changeSettingsFinished(tr("All settings have been reset to default values"));
+
+#if defined(Q_OS_IOS) || defined(MACOS_NE)
+    AmneziaVPN::clearSettings();
+#endif
+}
+
+bool SettingsController::isAutoConnectEnabled()
+{
+    return m_settings->isAutoConnect();
+}
+
+void SettingsController::toggleAutoConnect(bool enable)
+{
+    m_settings->setAutoConnect(enable);
+}
+
+bool SettingsController::isAutoStartEnabled()
+{
+    return Autostart::isAutostart();
+}
+
+void SettingsController::toggleAutoStart(bool enable)
+{
+    Autostart::setAutostart(enable);
+    if (!enable) {
+        toggleStartMinimized(false);
+    }
+}
+
+bool SettingsController::isStartMinimizedEnabled()
+{
+    return m_settings->isStartMinimized();
+}
+
+void SettingsController::toggleStartMinimized(bool enable)
+{
+    m_settings->setStartMinimized(enable);
+    emit startMinimizedChanged();
+}
+
+bool SettingsController::isNewsNotificationsEnabled()
+{
+    return m_settings->isNewsNotifications();
+}
+void SettingsController::toggleNewsNotificationsEnabled(bool enable)
+{
+    m_settings->setNewsNotifications(enable);
+}
+
+bool SettingsController::isScreenshotsEnabled()
+{
+    return m_settings->isScreenshotsEnabled();
+}
+
+void SettingsController::toggleScreenshotsEnabled(bool enable)
+{
+    m_settings->setScreenshotsEnabled(enable);
+}
+
+bool SettingsController::isCameraPresent()
+{
+#if defined Q_OS_IOS
+    return true;
+#elif defined Q_OS_ANDROID
+    return AndroidController::instance()->isCameraPresent();
+#else
+    return false;
+#endif
+}
+
+void SettingsController::checkIfNeedDisableLogs()
+{
+    if (m_settings->isSaveLogs()) {
+        m_loggingDisableDate = m_settings->getLogEnableDate().addDays(14);
+        if (m_loggingDisableDate <= QDateTime::currentDateTime()) {
+            toggleLogging(false);
+            clearLogs();
+            emit loggingDisableByWatcher();
+        }
+    }
+}
+
+bool SettingsController::isKillSwitchEnabled()
+{
+    return m_settings->isKillSwitchEnabled();
+}
+
+void SettingsController::toggleKillSwitch(bool enable)
+{
+    m_settings->setKillSwitchEnabled(enable);
+    emit killSwitchEnabledChanged();
+    if (enable == false) {
+        emit strictKillSwitchEnabledChanged(false);
+    } else {
+        emit strictKillSwitchEnabledChanged(isStrictKillSwitchEnabled());
+    }
+}
+
+bool SettingsController::isStrictKillSwitchEnabled()
+{
+    return m_settings->isStrictKillSwitchEnabled();
+}
+
+void SettingsController::toggleStrictKillSwitch(bool enable)
+{
+    m_settings->setStrictKillSwitchEnabled(enable);
+    emit strictKillSwitchEnabledChanged(enable);
+}
+
+bool SettingsController::isNotificationPermissionGranted()
+{
+#ifdef Q_OS_ANDROID
+    return AndroidController::instance()->isNotificationPermissionGranted();
+#else
+    return true;
+#endif
+}
+
+void SettingsController::requestNotificationPermission()
+{
+#ifdef Q_OS_ANDROID
+    AndroidController::instance()->requestNotificationPermission();
+#endif
+}
+
+QString SettingsController::getInstallationUuid()
+{
+    return m_settings->getInstallationUuid(false);
+}
+
+void SettingsController::enableDevMode()
+{
+    m_isDevModeEnabled = true;
+    emit devModeEnabled();
+}
+
+bool SettingsController::isDevModeEnabled()
+{
+    return m_isDevModeEnabled;
+}
+
+void SettingsController::resetGatewayEndpoint()
+{
+    m_settings->resetGatewayEndpoint();
+    emit gatewayEndpointChanged(m_settings->getGatewayEndpoint());
+}
+
+void SettingsController::setGatewayEndpoint(const QString &endpoint)
+{
+    m_settings->setGatewayEndpoint(endpoint);
+    emit gatewayEndpointChanged(endpoint);
+}
+
+QString SettingsController::getGatewayEndpoint()
+{
+    return m_settings->isDevGatewayEnv() ? "Dev endpoint" : m_settings->getGatewayEndpoint();
+}
+
+bool SettingsController::isDevGatewayEnv()
+{
+    return m_settings->isDevGatewayEnv();
+}
+
+void SettingsController::toggleDevGatewayEnv(bool enabled)
+{
+    m_settings->toggleDevGatewayEnv(enabled);
+    if (enabled) {
+        m_settings->setDevGatewayEndpoint();
+    } else {
+        m_settings->resetGatewayEndpoint();
+    }
+    emit gatewayEndpointChanged(m_settings->getGatewayEndpoint());
+    emit devGatewayEnvChanged(enabled);
+}
+
+bool SettingsController::isOnTv()
+{
+#ifdef Q_OS_ANDROID
+    return AndroidController::instance()->isOnTv();
+#else
+    return false;
+#endif
+}
+
+bool SettingsController::isEdgeToEdgeEnabled()
+{
+#ifdef Q_OS_ANDROID
+    if (!m_edgeToEdgeCached) {
+        m_cachedEdgeToEdgeEnabled = AndroidController::instance()->isEdgeToEdgeEnabled();
+        m_edgeToEdgeCached = true;
+    }
+    return m_cachedEdgeToEdgeEnabled;
+#else
+    return false;
+#endif
+}
+
+int SettingsController::getStatusBarHeight()
+{
+#ifdef Q_OS_ANDROID
+    if (m_cachedStatusBarHeight < 0) {
+        m_cachedStatusBarHeight = AndroidController::instance()->getStatusBarHeight();
+    }
+    return m_cachedStatusBarHeight;
+#else
+    return 0;
+#endif
+}
+
+int SettingsController::getNavigationBarHeight()
+{
+#ifdef Q_OS_ANDROID
+    if (m_cachedNavigationBarHeight < 0) {
+        m_cachedNavigationBarHeight = AndroidController::instance()->getNavigationBarHeight();
+    }
+    return m_cachedNavigationBarHeight;
+#else
+    return 0;
+#endif
+}
+
+int SettingsController::getSafeAreaTopMargin()
+{
+#ifdef Q_OS_ANDROID
+    if (isEdgeToEdgeEnabled()) {
+        int height = getStatusBarHeight();
+        int result = height > 0 ? height : 40; // fallback to 40 if system returns 0
+        return result;
+    }
+#endif
+    return 0;
+}
+
+int SettingsController::getSafeAreaBottomMargin()
+{
+#ifdef Q_OS_ANDROID
+    if (isEdgeToEdgeEnabled()) {
+        if (m_imeHeight > 0) {
+            return 0;
+        }
+        
+        int height = getNavigationBarHeight();
+        int result = height > 0 ? height : 56; // fallback to 56 if system returns 0
+        return result;
+    }
+#endif
+    return 0;
+}
+
+int SettingsController::getImeHeight()
+{
+    return m_imeHeight;
+}
+
+bool SettingsController::isHomeAdLabelVisible()
+{
+    return m_settings->isHomeAdLabelVisible();
+}
+
+void SettingsController::disableHomeAdLabel()
+{
+    m_settings->disableHomeAdLabel();
+    emit isHomeAdLabelVisibleChanged(false);
+}

--- a/client/ui/qml/Pages2/PageSettingsAppSplitTunneling.qml
+++ b/client/ui/qml/Pages2/PageSettingsAppSplitTunneling.qml
@@ -8,6 +8,7 @@ import QtCore
 import SortFilterProxyModel 0.2
 
 import PageEnum 1.0
+import ProtocolEnum 1.0
 import ContainerProps 1.0
 import Style 1.0
 
@@ -58,7 +59,7 @@ PageType {
     }
 
     function getRouteModesModelIndex() {
-        var currentRouteMode = AppSplitTunnelingController.routeMode
+        var currentRouteMode = AppSplitTunnelingModel.routeMode
         if ((routeMode.onlyForwardApps === currentRouteMode) || (routeMode.allApps === currentRouteMode)) {
             return 0
         } else if (routeMode.allExceptApps === currentRouteMode) {
@@ -73,7 +74,7 @@ PageType {
         anchors.left: parent.left
         anchors.right: parent.right
 
-        anchors.topMargin: 20 + PageController.safeAreaTopMargin
+        anchors.topMargin: 20 + SettingsController.safeAreaTopMargin
 
         BackButtonType {
             id: backButton
@@ -89,11 +90,11 @@ PageType {
             enabled: root.pageEnabled
             showSwitcher: true
             switcher {
-                checked: AppSplitTunnelingController.isSplitTunnelingEnabled
+                checked: AppSplitTunnelingModel.isTunnelingEnabled
                 enabled: root.pageEnabled
             }
             switcherFunction: function(checked) {
-                AppSplitTunnelingController.toggleSplitTunneling(checked)
+                AppSplitTunnelingModel.toggleSplitTunneling(checked)
                 selector.text = root.routeModesModel[getRouteModesModelIndex()].name
             }
         }
@@ -111,7 +112,8 @@ PageType {
 
             headerText: qsTr("Mode")
 
-            enabled: (Qt.platform.os === "android") && root.pageEnabled
+            // ИЗМЕНЕНО: Раньше здесь стояло ограничение только для Android. Теперь выпадающий список доступен всегда.
+            enabled: root.pageEnabled
 
             listView: ListViewWithRadioButtonType {
                 rootWidth: root.width
@@ -123,13 +125,13 @@ PageType {
                 clickedFunction: function() {
                     selector.text = selectedText
                     selector.closeTriggered()
-                    if (AppSplitTunnelingController.routeMode !== root.routeModesModel[selectedIndex].type) {
-                        AppSplitTunnelingController.routeMode = root.routeModesModel[selectedIndex].type
+                    if (AppSplitTunnelingModel.routeMode !== root.routeModesModel[selectedIndex].type) {
+                        AppSplitTunnelingModel.routeMode = root.routeModesModel[selectedIndex].type
                     }
                 }
 
                 Component.onCompleted: {
-                    if (root.routeModesModel[selectedIndex].type === AppSplitTunnelingController.routeMode) {
+                    if (root.routeModesModel[selectedIndex].type === AppSplitTunnelingModel.routeMode) {
                         selector.text = selectedText
                     } else {
                         selector.text = root.routeModesModel[0].name
@@ -137,7 +139,7 @@ PageType {
                 }
 
                 Connections {
-                    target: AppSplitTunnelingController
+                    target: AppSplitTunnelingModel
                     function onRouteModeChanged() {
                         selectedIndex = getRouteModesModelIndex()
                     }
@@ -154,7 +156,8 @@ PageType {
             textString: qsTr("Only \"Apps from the list should not have access via VPN\" mode is available on Windows")
             iconPath: "qrc:/images/controls/alert-circle.svg"
 
-            visible: (Qt.platform.os === "windows") && root.pageEnabled
+            // ИЗМЕНЕНО: Отключаем показ предупреждающей заглушки на Windows
+            visible: false
         }
     }
 
@@ -165,7 +168,7 @@ PageType {
 
         anchors.top: header.bottom
         anchors.bottom: parent.bottom
-        anchors.bottomMargin: addAppButton.implicitHeight + 48 + PageController.safeAreaBottomMargin + (searchField.textField.activeFocus ? 0 : PageController.imeHeight)
+        anchors.bottomMargin: addAppButton.implicitHeight + 48 + SettingsController.safeAreaBottomMargin + (searchField.textField.activeFocus ? 0 : SettingsController.imeHeight)
         anchors.left: parent.left
         anchors.right: parent.right
         clip: true
@@ -220,7 +223,7 @@ PageType {
         anchors.right: parent.right
         anchors.bottom: parent.bottom
         
-        height: addAppButton.implicitHeight + 48 + PageController.safeAreaBottomMargin
+        height: addAppButton.implicitHeight + 48 + SettingsController.safeAreaBottomMargin
         
         color: AmneziaStyle.color.midnightBlack
         
@@ -235,7 +238,7 @@ PageType {
             anchors.topMargin: 24
             anchors.rightMargin: 16
             anchors.leftMargin: 16
-            anchors.bottomMargin: 24 + PageController.safeAreaBottomMargin
+            anchors.bottomMargin: 24 + SettingsController.safeAreaBottomMargin
 
             TextFieldWithHeaderType {
                 id: searchField


### PR DESCRIPTION
Add split traffic for specific applications
Added a list of applications that should be included in the VPN
This improvement expands the functionality of the product.

<img width="192" height="392" alt="image" src="https://github.com/user-attachments/assets/e8607d80-5fe1-4161-abb1-b328a3d0dc12" />

Traffic splitting works the same way as in Android.

You will need to make changes to mullvad-split-tunnel.sys
https://github.com/mullvad/win-split-tunnel/pull/54#issue-4369721038