### PR TITLE
fix: pass S3/S4 params for all AWG containers, not only Awg2

### DIFF
--- a/client/core/configurators/awgConfigurator.cpp
+++ b/client/core/configurators/awgConfigurator.cpp
@@ -96,10 +96,8 @@ ProtocolConfig AwgConfigurator::createConfig(const ServerCredentials &credential
     newClientConfig.specialJunk4 = configMap.value(configKey::specialJunk4);
     newClientConfig.specialJunk5 = configMap.value(configKey::specialJunk5);
     
-    if (container == DockerContainer::Awg2) {
-        newClientConfig.cookieReplyPacketJunkSize = configMap.value(configKey::cookieReplyPacketJunkSize);
-        newClientConfig.transportPacketJunkSize = configMap.value(configKey::transportPacketJunkSize);
-    }
+    newClientConfig.cookieReplyPacketJunkSize = configMap.value(configKey::cookieReplyPacketJunkSize);
+    newClientConfig.transportPacketJunkSize = configMap.value(configKey::transportPacketJunkSize);
     
     newClientConfig.isObfuscationEnabled = false;
     


### PR DESCRIPTION
## Problem
cookieReplyPacketJunkSize and transportPacketJunkSize (S3/S4) were only
set when container == DockerContainer::Awg2. This caused AWG 2.0 to not
work for third-party imported configs (vpn:// links) on Linux because
those use DockerContainer::Awg.

## Root cause
In awgConfigurator.cpp, S3/S4 were wrapped in:
if (container == DockerContainer::Awg2) { ... }

## Fix
Remove the condition so S3/S4 are always passed regardless of container type.

Fixes #2219