### PR TITLE
Fix Fedora Linux reconnect after suspend

### DIFF
--- a/client/platforms/linux/daemon/linuxfirewall.cpp
+++ b/client/platforms/linux/daemon/linuxfirewall.cpp
@@ -33,6 +33,7 @@
 #include "linuxfirewall.h"
 #include "logger.h"
 #include "xray_defs.h"
+#include <QFileInfo>
 #include <QProcess>
 
 #define BRAND_CODE "amn"
@@ -46,13 +47,14 @@ namespace
 const QString kAnchorName{BRAND_CODE "vpn"};
 const QString kPacketTag{"0x3211"};
 const QString kCGroupId{"0x567"};
+const QString kRouteTableId{"3211"};
 const QString enabledKeyTemplate = "enabled:%1:%2";
 const QString disabledKeyTemplate = "disabled:%1:%2";
 const QString kVpnGroupName = BRAND_CODE "vpn";
 QHash<QString, LinuxFirewall::FilterCallbackFunc> anchorCallbacks;
 }
 
-QString LinuxFirewall::kRtableName = QStringLiteral("%1rt").arg(kAnchorName);
+QString LinuxFirewall::kRtableName = kRouteTableId;
 QString LinuxFirewall::kOutputChain = QStringLiteral("OUTPUT");
 QString LinuxFirewall::kPostRoutingChain = QStringLiteral("POSTROUTING");
 QString LinuxFirewall::kPreRoutingChain = QStringLiteral("PREROUTING");
@@ -65,6 +67,11 @@ QString LinuxFirewall::kMangleTable = QStringLiteral("mangle");
 static QString getCommand(LinuxFirewall::IPVersion ip)
 {
     return ip == LinuxFirewall::IPv6 ? QStringLiteral("ip6tables") : QStringLiteral("iptables");
+}
+
+static bool hasNetClsCgroupSupport()
+{
+    return QFileInfo::exists(QStringLiteral("/sys/fs/cgroup/net_cls"));
 }
 
 int LinuxFirewall::createChain(LinuxFirewall::IPVersion ip, const QString& chain, const QString& tableName)
@@ -287,6 +294,8 @@ void LinuxFirewall::install()
                                                              QStringLiteral("-m mark --mark %1 -j ACCEPT").arg(amnezia::xray::xrayTrafficMark),
                                                          });
 
+    installAnchor(Both, QStringLiteral("400.allowPIA"), {});
+
     installAnchor(IPv4, QStringLiteral("120.blockNets"), {});
 
     installAnchor(IPv4, QStringLiteral("110.allowNets"), {});
@@ -508,9 +517,13 @@ int LinuxFirewall::execute(const QString &command, bool ignoreErrors)
 
 void LinuxFirewall::setupTrafficSplitting()
 {
-    auto cGroupDir = "/sys/fs/cgroup/net_cls/" BRAND_CODE "vpnexclusions/";
-    logger.info() << "Should be setting up cgroup in" << cGroupDir << "for traffic splitting";
-    execute(QStringLiteral("if [ ! -d %1 ] ; then mkdir %1 ; sleep 0.1 ; echo %2 > %1/net_cls.classid ; fi").arg(cGroupDir).arg(kCGroupId));
+    if (hasNetClsCgroupSupport()) {
+        auto cGroupDir = "/sys/fs/cgroup/net_cls/" BRAND_CODE "vpnexclusions/";
+        logger.info() << "Should be setting up cgroup in" << cGroupDir << "for traffic splitting";
+        execute(QStringLiteral("if [ ! -d %1 ] ; then mkdir %1 ; sleep 0.1 ; echo %2 > %1/net_cls.classid ; fi").arg(cGroupDir).arg(kCGroupId));
+    } else {
+        logger.info() << "Skipping net_cls cgroup setup because this system uses cgroup v2";
+    }
     // Set a rule with priority 100 (lower priority than local but higher than main/default, 0 is highest priority)
     execute(QStringLiteral("if ! ip rule list | grep -q %1 ; then ip rule add from all fwmark %1 lookup %2 pri 100 ; fi").arg(kPacketTag, kRtableName));
 }

--- a/client/platforms/linux/linuxnetworkwatcherworker.cpp
+++ b/client/platforms/linux/linuxnetworkwatcherworker.cpp
@@ -202,9 +202,8 @@ void LinuxNetworkWatcherWorker::NMStateChanged(quint32 state)
 {
     logger.debug() << "NMStateChanged " << state;
 
-    if (state == NM_STATE_ASLEEP || state == NM_STATE_DISABLED) {
+    if (state == NM_STATE_CONNECTED_GLOBAL) {
         emit wakeup();
-    } else if (state == NM_STATE_CONNECTED_GLOBAL) {
         emit networkChanged();
     }
 }

--- a/service/server/killswitch.cpp
+++ b/service/server/killswitch.cpp
@@ -318,7 +318,7 @@ bool KillSwitch::enableKillSwitch(const QJsonObject &configStr, int vpnAdapterIn
     LinuxFirewall::setAnchorEnabled(LinuxFirewall::Both, QStringLiteral("100.blockAll"), blockAll);
     LinuxFirewall::setAnchorEnabled(LinuxFirewall::IPv4, QStringLiteral("110.allowNets"), allowNets);
     LinuxFirewall::updateAllowNets(allownets);
-    LinuxFirewall::setAnchorEnabled(LinuxFirewall::IPv4, QStringLiteral("120.blockNets"), blockAll);
+    LinuxFirewall::setAnchorEnabled(LinuxFirewall::IPv4, QStringLiteral("120.blockNets"), blockNets);
     LinuxFirewall::updateBlockNets(blocknets);
     LinuxFirewall::setAnchorEnabled(LinuxFirewall::Both, QStringLiteral("130.allowMarkedXray"), true);
     LinuxFirewall::setAnchorEnabled(LinuxFirewall::IPv4, QStringLiteral("200.allowVPN"), true);


### PR DESCRIPTION
I had a very specific issue with AmneziaVPN client on my linux laptop: after sleep mode the amneziavpn client broke the network, spiked the cpu and required to 
manually reconenct to the server for the network to be gone.

dove deeper into the code and found out that amneziavpn daemon was trying to recreate itself way before network was up and it stalled into some firewall/route/cgroup 
fedora-specific incompatabilities and left the system in partially broken state

- replace the named routing table amnvpnrt with numeric table id 3211
- skip net_cls handling on cgroup v2 systems
- create the missing 400.allowPIA firewall anchor before using it
- fix 120.blockNets handling to enable the correct killswitch rule
- emit wakeup/reconnect only after NetworkManager reaches CONNECTED_GLOBAL
