### PR TITLE
feat: real-time install progress log and progress bar for self-hosted setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ deploy/build_64/*
 winbuild*.bat
 .cache/
 .vscode/
+aqtinstall.log
 
 
 # Qt-es

--- a/client/core/controllers/coreSignalHandlers.cpp
+++ b/client/core/controllers/coreSignalHandlers.cpp
@@ -122,6 +122,12 @@ void CoreSignalHandlers::initSettingsSplitTunnelingHandler()
 
 void CoreSignalHandlers::initInstallControllerHandler()
 {
+    connect(m_coreController->m_installController, &InstallController::installationStepChanged,
+            m_coreController->m_installUiController, &InstallUiController::installationStepChanged,
+            Qt::QueuedConnection);
+    connect(m_coreController->m_installController, &InstallController::removalStepChanged,
+            m_coreController->m_installUiController, &InstallUiController::removalStepChanged,
+            Qt::QueuedConnection);
     connect(m_coreController->m_installController, &InstallController::serverIsBusy, m_coreController->m_installUiController, &InstallUiController::serverIsBusy);
     connect(m_coreController->m_installUiController, &InstallUiController::cancelInstallation, m_coreController->m_installController, &InstallController::cancelInstallation);
     connect(m_coreController->m_serversUiController, &ServersUiController::processedServerIdChanged,

--- a/client/core/controllers/selfhosted/installController.cpp
+++ b/client/core/controllers/selfhosted/installController.cpp
@@ -106,55 +106,68 @@ ErrorCode InstallController::setupContainer(const ServerCredentials &credentials
     SshSession sshSession(this);
     ErrorCode e = ErrorCode::NoError;
 
+    emit installationStepChanged(tr("Checking server access…"), 0.03);
     e = isUserInSudo(credentials, sshSession);
     if (e)
         return e;
 
+    emit installationStepChanged(tr("Checking server readiness…"), 0.07);
     e = isServerDpkgBusy(credentials, sshSession);
     if (e)
         return e;
 
+    emit installationStepChanged(tr("Installing Docker on the server…"), 0.12);
     e = installDockerWorker(credentials, container, sshSession);
     if (e)
         return e;
+    emit installationStepChanged(tr("Docker ready"), 0.30);
     qDebug().noquote() << "InstallController::setupContainer installDockerWorker finished";
 
     if (!isUpdate) {
+        emit installationStepChanged(tr("Checking port availability…"), 0.33);
         e = isServerPortBusy(credentials, container, config, sshSession);
         if (e)
             return e;
     }
 
+    emit installationStepChanged(tr("Preparing server environment…"), 0.38);
     e = prepareHostWorker(credentials, container, sshSession);
     if (e)
         return e;
     qDebug().noquote() << "InstallController::setupContainer prepareHostWorker finished";
 
+    emit installationStepChanged(tr("Removing old container…"), 0.42);
     const amnezia::ScriptVars removeContainerVars =
             amnezia::genBaseVars(credentials, container, QString(), QString());
     const bool removeDataVolume = !isUpdate && (container == DockerContainer::MtProxy || container == DockerContainer::Telemt);
     sshSession.runScript(credentials, buildRemoveContainerScript(removeContainerVars, removeDataVolume));
     qDebug().noquote() << "InstallController::setupContainer removeContainer finished";
 
+    emit installationStepChanged(tr("Building the VPN container…"), 0.47);
     qDebug().noquote() << "buildContainerWorker start";
     e = buildContainerWorker(credentials, container, config, sshSession);
     if (e)
         return e;
+    emit installationStepChanged(tr("Container image built"), 0.63);
     qDebug().noquote() << "InstallController::setupContainer buildContainerWorker finished";
 
+    emit installationStepChanged(tr("Starting the container…"), 0.68);
     e = runContainerWorker(credentials, container, config, sshSession);
     if (e)
         return e;
     qDebug().noquote() << "InstallController::setupContainer runContainerWorker finished";
 
+    emit installationStepChanged(tr("Configuring the protocol…"), 0.72);
     e = configureContainerWorker(credentials, container, config, sshSession);
     if (e)
         return e;
     qDebug().noquote() << "InstallController::setupContainer configureContainerWorker finished";
 
+    emit installationStepChanged(tr("Setting up firewall rules…"), 0.77);
     setupServerFirewall(credentials, sshSession);
     qDebug().noquote() << "InstallController::setupContainer setupServerFirewall finished";
 
+    emit installationStepChanged(tr("Running startup scripts…"), 0.90);
     return startupContainerWorker(credentials, container, config, sshSession);
 }
 
@@ -412,6 +425,8 @@ ErrorCode InstallController::prepareContainerConfig(DockerContainer container, c
     if (!ContainerUtils::isSupportedByCurrentPlatform(container)) {
         return ErrorCode::NoError;
     }
+
+    emit installationStepChanged(tr("Generating client configuration…"), 0.96);
 
     if (ContainerUtils::containerService(container) != ServiceType::Other) {
         Proto protocol = ContainerUtils::defaultProtocol(container);
@@ -999,9 +1014,11 @@ ErrorCode InstallController::removeAllContainers(const QString &serverId)
         return ErrorCode::InternalError;
     }
     SshSession sshSession(this);
+    emit removalStepChanged(tr("Removing all containers…"), 0.15);
     ErrorCode errorCode = sshSession.runScript(credentials, amnezia::scriptData(SharedScriptType::remove_all_containers));
 
     if (errorCode == ErrorCode::NoError) {
+        emit removalStepChanged(tr("Cleaning up configuration…"), 0.90);
         adminConfig->containers.clear();
         adminConfig->defaultContainer = DockerContainer::None;
         m_serversRepository->editServer(serverId, adminConfig->toJson(), serverConfigUtils::ConfigType::SelfHostedAdmin);
@@ -1024,10 +1041,12 @@ ErrorCode InstallController::removeContainer(const QString &serverId, DockerCont
     const amnezia::ScriptVars removeContainerVars =
             amnezia::genBaseVars(credentials, container, QString(), QString());
     const bool removeDataVolume = (container == DockerContainer::MtProxy || container == DockerContainer::Telemt);
+    emit removalStepChanged(tr("Removing container…"), 0.15);
     ErrorCode errorCode =
             sshSession.runScript(credentials, buildRemoveContainerScript(removeContainerVars, removeDataVolume));
 
     if (errorCode == ErrorCode::NoError) {
+        emit removalStepChanged(tr("Cleaning up configuration…"), 0.90);
         QMap<DockerContainer, ContainerConfig> containers = adminConfig->containers;
         containers.remove(container);
 

--- a/client/core/controllers/selfhosted/installController.h
+++ b/client/core/controllers/selfhosted/installController.h
@@ -91,6 +91,8 @@ signals:
     void configValidated(bool isValid);
     void validationErrorOccurred(ErrorCode errorCode);
 
+    void installationStepChanged(const QString &message, double progress);
+    void removalStepChanged(const QString &message, double progress);
     void serverIsBusy(const bool isBusy);
     void cancelInstallationRequested();
     void clientRevocationRequested(const QString &serverId, const ContainerConfig &containerConfig, DockerContainer container);

--- a/client/translations/amneziavpn_ru_RU.ts
+++ b/client/translations/amneziavpn_ru_RU.ts
@@ -479,6 +479,91 @@ Already installed containers were found on the server. All installed containers 
         <translation>Конфигурация API удалена</translation>
     </message>
     <message>
+        <location filename="../core/controllers/selfhosted/installController.cpp" line="109"/>
+        <source>Checking server access…</source>
+        <translation>Проверка доступа к серверу…</translation>
+    </message>
+    <message>
+        <location filename="../core/controllers/selfhosted/installController.cpp" line="114"/>
+        <source>Checking server readiness…</source>
+        <translation>Проверка готовности сервера…</translation>
+    </message>
+    <message>
+        <location filename="../core/controllers/selfhosted/installController.cpp" line="119"/>
+        <source>Installing Docker on the server…</source>
+        <translation>Установка Docker на сервере…</translation>
+    </message>
+    <message>
+        <location filename="../core/controllers/selfhosted/installController.cpp" line="123"/>
+        <source>Docker ready</source>
+        <translation>Docker готов</translation>
+    </message>
+    <message>
+        <location filename="../core/controllers/selfhosted/installController.cpp" line="127"/>
+        <source>Checking port availability…</source>
+        <translation>Проверка доступности порта…</translation>
+    </message>
+    <message>
+        <location filename="../core/controllers/selfhosted/installController.cpp" line="133"/>
+        <source>Preparing server environment…</source>
+        <translation>Подготовка окружения на сервере…</translation>
+    </message>
+    <message>
+        <location filename="../core/controllers/selfhosted/installController.cpp" line="139"/>
+        <source>Removing old container…</source>
+        <translation>Удаление старого контейнера…</translation>
+    </message>
+    <message>
+        <location filename="../core/controllers/selfhosted/installController.cpp" line="146"/>
+        <source>Building the VPN container…</source>
+        <translation>Сборка VPN-контейнера…</translation>
+    </message>
+    <message>
+        <location filename="../core/controllers/selfhosted/installController.cpp" line="151"/>
+        <source>Container image built</source>
+        <translation>Образ контейнера собран</translation>
+    </message>
+    <message>
+        <location filename="../core/controllers/selfhosted/installController.cpp" line="154"/>
+        <source>Starting the container…</source>
+        <translation>Запуск контейнера…</translation>
+    </message>
+    <message>
+        <location filename="../core/controllers/selfhosted/installController.cpp" line="160"/>
+        <source>Configuring the protocol…</source>
+        <translation>Настройка протокола…</translation>
+    </message>
+    <message>
+        <location filename="../core/controllers/selfhosted/installController.cpp" line="166"/>
+        <source>Setting up firewall rules…</source>
+        <translation>Настройка правил брандмауэра…</translation>
+    </message>
+    <message>
+        <location filename="../core/controllers/selfhosted/installController.cpp" line="170"/>
+        <source>Running startup scripts…</source>
+        <translation>Выполнение стартовых скриптов…</translation>
+    </message>
+    <message>
+        <location filename="../core/controllers/selfhosted/installController.cpp" line="429"/>
+        <source>Generating client configuration…</source>
+        <translation>Генерация клиентской конфигурации…</translation>
+    </message>
+    <message>
+        <location filename="../core/controllers/selfhosted/installController.cpp" line="1006"/>
+        <source>Removing all containers…</source>
+        <translation>Удаление всех контейнеров…</translation>
+    </message>
+    <message>
+        <location filename="../core/controllers/selfhosted/installController.cpp" line="1028"/>
+        <source>Removing container…</source>
+        <translation>Удаление контейнера…</translation>
+    </message>
+    <message>
+        <location filename="../core/controllers/selfhosted/installController.cpp" line="1044"/>
+        <source>Cleaning up configuration…</source>
+        <translation>Очистка конфигурации…</translation>
+    </message>
+    <message>
         <location filename="../ui/controllers/installController.cpp" line="818"/>
         <source>%1 cached profile cleared</source>
         <translation>%1 закэшированный профиль очищен</translation>
@@ -584,7 +669,17 @@ Already installed containers were found on the server. All installed containers 
     <message>
         <location filename="../ui/qml/Pages2/PageDeinstalling.qml" line="81"/>
         <source>Usually it takes no more than 5 minutes</source>
-        <translation>Обычно это занимает не более 5 минут</translation>
+        <translation type="vanished">Обычно это занимает не более 5 минут</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageDeinstalling.qml" line="20"/>
+        <source>Removing…</source>
+        <translation>Удаление…</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageDeinstalling.qml" line="109"/>
+        <source>Removal failed</source>
+        <translation>Ошибка удаления</translation>
     </message>
 </context>
 <context>
@@ -3607,6 +3702,21 @@ Thank you for staying with us!</source>
         <location filename="../ui/qml/Pages2/PageSetupWizardInstalling.qml" line="75"/>
         <source>Usually it takes no more than 5 minutes</source>
         <translation>Обычно это занимает не более 5 минут</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardInstalling.qml" line="21"/>
+        <source>Connecting to the server…</source>
+        <translation>Подключение к серверу…</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardInstalling.qml" line="111"/>
+        <source>Installation failed</source>
+        <translation>Ошибка установки</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardInstalling.qml" line="123"/>
+        <source>Server is busy with other updates, waiting…</source>
+        <translation>Сервер занят другими обновлениями, ожидание…</translation>
     </message>
 </context>
 <context>

--- a/client/ui/controllers/selfhosted/installUiController.h
+++ b/client/ui/controllers/selfhosted/installUiController.h
@@ -127,6 +127,8 @@ signals:
     void passphraseRequestStarted();
     void passphraseRequestFinished();
 
+    void installationStepChanged(const QString &message, double progress);
+    void removalStepChanged(const QString &message, double progress);
     void serverIsBusy(const bool isBusy);
     void cancelInstallation();
 

--- a/client/ui/qml/Pages2/PageDeinstalling.qml
+++ b/client/ui/qml/Pages2/PageDeinstalling.qml
@@ -15,14 +15,81 @@ import "../Config"
 PageType {
     id: root
 
-    Component.onCompleted: PageController.disableTabBar(true)
+    Component.onCompleted: {
+        PageController.disableTabBar(true)
+        root.appendLog(qsTr("Removing…"), false)
+    }
     Component.onDestruction: PageController.disableTabBar(false)
+
+    property real targetProgress: 0.0
+    property real displayProgress: 0.0
+
+    onTargetProgressChanged: {
+        if (root.displayProgress < root.targetProgress) {
+            catchUpAnim.to = root.targetProgress
+            catchUpAnim.restart()
+        }
+    }
+
+    NumberAnimation {
+        id: catchUpAnim
+        target: root
+        property: "displayProgress"
+        duration: 800
+        easing.type: Easing.OutCubic
+    }
+
+    Timer {
+        id: driftTimer
+        interval: 300
+        repeat: true
+        running: false
+        onTriggered: {
+            if (catchUpAnim.running) return
+            var cap = Math.min(root.targetProgress + 0.15, 0.99)
+            if (root.displayProgress < cap)
+                root.displayProgress = Math.min(root.displayProgress + 0.001, cap)
+        }
+    }
+
+    property int dotPhase: 1
+
+    Timer {
+        id: dotTimer
+        interval: 500
+        repeat: true
+        running: true
+        onTriggered: root.dotPhase = (root.dotPhase % 3) + 1
+    }
+
+    function appendLog(message, isError) {
+        if (logModel.count > 0)
+            logModel.setProperty(logModel.count - 1, "isLatest", false)
+        logModel.append({ "msg": message, "isError": isError, "isLatest": true })
+        root.dotPhase = 1
+    }
+
+    Connections {
+        target: InstallController
+
+        function onRemovalStepChanged(message, progress) {
+            root.targetProgress = progress
+            driftTimer.running = true
+            root.appendLog(message, false)
+        }
+
+        function onInstallationErrorOccurred(errorCode) {
+            root.appendLog(qsTr("Removal failed"), true)
+        }
+    }
+
+    ListModel {
+        id: logModel
+    }
 
     SortFilterProxyModel {
         id: proxyServersModel
-
         sourceModel: ServersModel
-
         filters: [
             ValueFilter {
                 roleName: "serverId"
@@ -35,8 +102,6 @@ PageType {
         id: listView
 
         anchors.fill: parent
-
-        spacing: 16
 
         model: proxyServersModel
 
@@ -56,29 +121,79 @@ PageType {
                 id: progressBar
 
                 Layout.fillWidth: true
+                Layout.preferredHeight: 6
                 Layout.topMargin: 32
                 Layout.leftMargin: 16
                 Layout.rightMargin: 16
 
-                Timer {
-                    id: timer
-
-                    interval: 300
-                    repeat: true
-                    running: true
-                    onTriggered: {
-                        progressBar.value += 0.003
-                    }
-                }
+                value: root.displayProgress
             }
 
-            ParagraphTextType {
+            Rectangle {
                 Layout.fillWidth: true
-                Layout.topMargin: 8
+                Layout.topMargin: 28
                 Layout.leftMargin: 16
                 Layout.rightMargin: 16
+                Layout.preferredHeight: 170
 
-                text: qsTr("Usually it takes no more than 5 minutes")
+                color: AmneziaStyle.color.onyxBlack
+                radius: 8
+                layer.enabled: true
+
+                HoverHandler {
+                    cursorShape: Qt.ArrowCursor
+                }
+
+                WheelHandler {
+                    onWheel: function(event) {
+                        var ticks = -event.angleDelta.y / 120
+                        var newY = logView.contentY + ticks * 36
+                        logView.contentY = Math.max(0,
+                            Math.min(Math.max(0, logView.contentHeight - logView.height), newY))
+                        event.accepted = true
+                    }
+                }
+
+                ListView {
+                    id: logView
+
+                    anchors.fill: parent
+                    anchors.margins: 12
+
+                    model: logModel
+                    clip: true
+                    spacing: 4
+                    interactive: false
+
+                    ScrollBar.vertical: ScrollBarType {}
+
+                    onCountChanged: Qt.callLater(positionViewAtEnd)
+
+                    delegate: Text {
+                        width: logView.width
+
+                        text: model.isLatest && model.msg.endsWith("…")
+                              ? model.msg.slice(0, -1) + ".".repeat(root.dotPhase)
+                              : model.msg
+                        wrapMode: Text.WordWrap
+
+                        font.pixelSize: 13
+                        font.family: "PT Root UI VF"
+                        font.bold: model.isLatest
+
+                        color: model.isError
+                               ? AmneziaStyle.color.vibrantRed
+                               : model.isLatest
+                                 ? AmneziaStyle.color.goldenApricot
+                                 : AmneziaStyle.color.mutedGray
+
+                        NumberAnimation on opacity {
+                            from: 0
+                            to: 1
+                            duration: 150
+                        }
+                    }
+                }
             }
         }
     }

--- a/client/ui/qml/Pages2/PageSetupWizardInstalling.qml
+++ b/client/ui/qml/Pages2/PageSetupWizardInstalling.qml
@@ -18,58 +18,139 @@ PageType {
     Component.onCompleted: {
         root.installingContainerIndex = ServersUiController.processedContainerIndex
         PageController.disableTabBar(true)
+        root.appendLog(qsTr("Connecting to the server…"), false)
     }
     Component.onDestruction: PageController.disableTabBar(false)
 
-    property bool isTimerRunning: true
-    property string progressBarText: qsTr("Usually it takes no more than 5 minutes")
     property bool isCancelButtonVisible: false
     property int installingContainerIndex: -1
+
+    property real targetProgress: 0.0
+    property real displayProgress: 0.0
+
+    onTargetProgressChanged: {
+        if (root.displayProgress < root.targetProgress) {
+            catchUpAnim.to = root.targetProgress
+            catchUpAnim.restart()
+        }
+    }
+
+    NumberAnimation {
+        id: catchUpAnim
+        target: root
+        property: "displayProgress"
+        duration: 800
+        easing.type: Easing.OutCubic
+    }
+
+    Timer {
+        id: driftTimer
+        interval: 300
+        repeat: true
+        running: false
+        onTriggered: {
+            if (catchUpAnim.running) return
+            var cap = Math.min(root.targetProgress + 0.15, 0.99)
+            if (root.displayProgress < cap)
+                root.displayProgress = Math.min(root.displayProgress + 0.001, cap)
+        }
+    }
+
+    property int dotPhase: 1
+
+    Timer {
+        id: dotTimer
+        interval: 500
+        repeat: true
+        running: true
+        onTriggered: root.dotPhase = (root.dotPhase % 3) + 1
+    }
+
+    property string pendingFinishMessage: ""
+    property bool pendingIsNewServer: false
+
+    Timer {
+        id: successCloseTimer
+        interval: 1100
+        repeat: false
+        onTriggered: {
+            if (root.pendingIsNewServer) {
+                PageController.goToPageHome()
+            } else {
+                PageController.closePage()
+                PageController.closePage()
+
+                if (stackView.currentItem.objectName === PageController.getPagePath(PageEnum.PageHome)) {
+                    PageController.restorePageHomeState(true)
+                }
+
+                if (stackView.currentItem.objectName === PageController.getPagePath(PageEnum.PageSetupWizardProtocols)) {
+                    PageController.goToPage(PageEnum.PageHome)
+                }
+            }
+            PageController.showNotificationMessage(root.pendingFinishMessage)
+        }
+    }
+
+    function appendLog(message, isError) {
+        if (logModel.count > 0)
+            logModel.setProperty(logModel.count - 1, "isLatest", false)
+        logModel.append({ "msg": message, "isError": isError, "isLatest": true })
+        root.dotPhase = 1
+    }
 
     Connections {
         target: InstallController
 
         function onInstallContainerFinished(finishedMessage, isServiceInstall) {
-            PageController.closePage() // close installing page
-            PageController.closePage() // close protocol settings page
-
-            if (stackView.currentItem.objectName === PageController.getPagePath(PageEnum.PageHome)) {
-                PageController.restorePageHomeState(true)
-            }
-
-            if (stackView.currentItem.objectName === PageController.getPagePath(PageEnum.PageSetupWizardProtocols)) {
-                PageController.goToPage(PageEnum.PageHome)
-            }
-
-            PageController.showNotificationMessage(finishedMessage)
+            root.pendingFinishMessage = finishedMessage
+            root.pendingIsNewServer = false
+            root.targetProgress = 1.0
+            catchUpAnim.to = 1.0
+            catchUpAnim.restart()
+            dotTimer.running = false
+            successCloseTimer.start()
         }
 
         function onInstallServerFinished(finishedMessage) {
-            PageController.goToPageHome()
-            PageController.showNotificationMessage(finishedMessage)
+            root.pendingFinishMessage = finishedMessage
+            root.pendingIsNewServer = true
+            root.targetProgress = 1.0
+            catchUpAnim.to = 1.0
+            catchUpAnim.restart()
+            dotTimer.running = false
+            successCloseTimer.start()
         }
 
         function onServerAlreadyExists(serverIndex) {
             PageController.goToStartPage()
             ServersUiController.setProcessedServerId(ServersUiController.getServerId(serverIndex))
             PageController.goToPage(PageEnum.PageSettingsServerInfo, false)
-
             PageController.showErrorMessage(qsTr("The server has already been added to the application"))
+        }
+
+        function onInstallationErrorOccurred(errorCode) {
+            root.appendLog(qsTr("Installation failed"), true)
+        }
+
+        function onInstallationStepChanged(message, progress) {
+            root.targetProgress = progress
+            driftTimer.running = true
+            root.appendLog(message, false)
         }
 
         function onServerIsBusy(isBusy) {
             if (isBusy) {
+                root.appendLog(qsTr("Server is busy with other updates, waiting…"), false)
                 root.isCancelButtonVisible = true
-                root.progressBarText = qsTr("Amnezia has detected that your server is currently ") +
-                                       qsTr("busy installing other software. Amnezia installation ") +
-                                       qsTr("will pause until the server finishes installing other software")
-                root.isTimerRunning = false
             } else {
                 root.isCancelButtonVisible = false
-                root.progressBarText = qsTr("Usually it takes no more than 5 minutes")
-                root.isTimerRunning = true
             }
         }
+    }
+
+    ListModel {
+        id: logModel
     }
 
     SortFilterProxyModel {
@@ -89,7 +170,6 @@ PageType {
         anchors.fill: parent
 
         currentIndex: -1
-
         model: proxyContainersModel
 
         delegate: ColumnLayout {
@@ -109,35 +189,84 @@ PageType {
                 id: progressBar
 
                 Layout.fillWidth: true
+                Layout.preferredHeight: 6
                 Layout.topMargin: 32
                 Layout.leftMargin: 16
                 Layout.rightMargin: 16
 
-                Timer {
-                    id: timer
+                value: root.displayProgress
+            }
 
-                    interval: 300
-                    repeat: true
-                    running: root.isTimerRunning
-                    onTriggered: {
-                        progressBar.value += 0.003
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.topMargin: 28
+                Layout.leftMargin: 16
+                Layout.rightMargin: 16
+                Layout.preferredHeight: 170
+
+                color: AmneziaStyle.color.onyxBlack
+                radius: 8
+                layer.enabled: true
+
+                HoverHandler {
+                    cursorShape: Qt.ArrowCursor
+                }
+
+                WheelHandler {
+                    onWheel: function(event) {
+                        var ticks = -event.angleDelta.y / 120
+                        var newY = logView.contentY + ticks * 36
+                        logView.contentY = Math.max(0,
+                            Math.min(Math.max(0, logView.contentHeight - logView.height), newY))
+                        event.accepted = true
+                    }
+                }
+
+                ListView {
+                    id: logView
+
+                    anchors.fill: parent
+                    anchors.margins: 12
+
+                    model: logModel
+                    clip: true
+                    spacing: 4
+                    interactive: false
+
+                    ScrollBar.vertical: ScrollBarType {}
+
+                    onCountChanged: Qt.callLater(positionViewAtEnd)
+
+                    delegate: Text {
+                        id: delegateText
+                        width: logView.width
+
+                        text: model.isLatest && model.msg.endsWith("…")
+                              ? model.msg.slice(0, -1) + ".".repeat(root.dotPhase)
+                              : model.msg
+                        wrapMode: Text.WordWrap
+
+                        font.pixelSize: 13
+                        font.family: "PT Root UI VF"
+                        font.bold: model.isLatest
+
+                        color: model.isError
+                               ? AmneziaStyle.color.vibrantRed
+                               : model.isLatest
+                                 ? AmneziaStyle.color.goldenApricot
+                                 : AmneziaStyle.color.mutedGray
+
+                        NumberAnimation on opacity {
+                            from: 0
+                            to: 1
+                            duration: 150
+                        }
                     }
                 }
             }
 
-            ParagraphTextType {
-                id: progressText
-
-                Layout.fillWidth: true
-                Layout.topMargin: 8
-                Layout.leftMargin: 16
-                Layout.rightMargin: 16
-
-                text: root.progressBarText
-            }
-
             BasicButtonType {
-                id: cancelIntallationButton
+                id: cancelInstallationButton
 
                 Layout.fillWidth: true
                 Layout.topMargin: 24


### PR DESCRIPTION
## Summary

feat: the appearance of the function of adding/removing self-contained protocols.

1. The old fake loading bar has been replaced with a realistic one, whose timings are based on tests with a real VPS
2. Added a log to track the actions of the protocol download script on your VPS
3. Added localization of the magazine into Russian

## Test plan

- [ ] Fresh install of a protocol (e.g. WireGuard) on a clean self-hosted server
- [ ] Reinstall a protocol on a server where Docker is already present
- [ ] Remove a protocol and verify the removal log and progress bar
- [ ] Verify Russian locale strings in the install/removal journal

P.s. Scrolling through the log is possible, but it requires unlocking the window, I didn't get into it.