### PR TITLE
fix: remove anonymous namespace from ConfigTypes to fix LTO ODR violation

### DIFF
--- a/client/core/controllers/selfhosted/importController.h
+++ b/client/core/controllers/selfhosted/importController.h
@@ -12,19 +12,16 @@
 #include "core/utils/routeModes.h"
 #include "core/utils/commonStructs.h"
 
-namespace
-{
-    enum class ConfigTypes {
-        Amnezia,
-        OpenVpn,
-        WireGuard,
-        Awg,
-        Xray,
-        ShadowSocks,
-        Backup,
-        Invalid
-    };
-}
+enum class ConfigTypes {
+    Amnezia,
+    OpenVpn,
+    WireGuard,
+    Awg,
+    Xray,
+    ShadowSocks,
+    Backup,
+    Invalid
+};
 
 using namespace amnezia;
 


### PR DESCRIPTION
## Problem

`ConfigTypes` is defined inside an anonymous namespace in `importController.h`, which is included by multiple translation units. When building with LTO and `-Werror=odr`, the compiler raises:

```
error: type 'struct ImportController' violates the C++ One Definition Rule [-Werror=odr]
note: type 'ConfigTypes' defined in anonymous namespace cannot match across the translation unit boundary
lto1: some warnings being treated as errors
```

Anonymous namespaces in headers make every translation unit see the type as distinct, which is an ODR violation under LTO.

## Fix

Remove the anonymous namespace wrapper from the `ConfigTypes` enum. The enum is only used within `ImportController`, so it can live at file scope without any naming conflict.