### PR TITLE
fix(macos): widen killswitch utun exemption so tunnels on high utunN aren't blocked

### DIFF
--- a/deploy/data/macos/pf/amn.200.allowVPN.conf
+++ b/deploy/data/macos/pf/amn.200.allowVPN.conf
@@ -1,9 +1,14 @@
-# Exempt the tunnel interface(s) used by the VPN connection
+# Exempt the tunnel interface(s) used by the VPN connection from the killswitch.
+#
+# macOS assigns the WireGuard/AmneziaWG tunnel the next free utunN unit. On hosts
+# that already run several utun-based services (Tailscale, iCloud Private Relay,
+# other VPNs, ...) the unit number can climb well past 30, and it increments on
+# every (re)connect until reboot. If the tunnel lands on a utun outside this list,
+# 100.blockAll drops the tunnel's own traffic -> "connected" but zero connectivity.
+# Range widened from utun0..utun30 to utun0..utun99 to cover those hosts.
+# (Ideal long-term fix: exempt the daemon's actual m_ifname dynamically instead of
+#  enumerating a fixed range.)
 
-utunInterfaces = "{                                                                         \
-    utun0, utun1, utun2, utun3, utun4, utun5, utun6, utun7, utun8, utun9,   utun10,         \
-    utun11, utun12, utun13, utun14, utun15, utun16, utun17, utun18, utun19, utun20,         \
-    utun21, utun22, utun23, utun24, utun25, utun26, utun27, utun28, utun29, utun30          \
-}"
+utunInterfaces = "{ utun0, utun1, utun2, utun3, utun4, utun5, utun6, utun7, utun8, utun9, utun10, utun11, utun12, utun13, utun14, utun15, utun16, utun17, utun18, utun19, utun20, utun21, utun22, utun23, utun24, utun25, utun26, utun27, utun28, utun29, utun30, utun31, utun32, utun33, utun34, utun35, utun36, utun37, utun38, utun39, utun40, utun41, utun42, utun43, utun44, utun45, utun46, utun47, utun48, utun49, utun50, utun51, utun52, utun53, utun54, utun55, utun56, utun57, utun58, utun59, utun60, utun61, utun62, utun63, utun64, utun65, utun66, utun67, utun68, utun69, utun70, utun71, utun72, utun73, utun74, utun75, utun76, utun77, utun78, utun79, utun80, utun81, utun82, utun83, utun84, utun85, utun86, utun87, utun88, utun89, utun90, utun91, utun92, utun93, utun94, utun95, utun96, utun97, utun98, utun99 }"
 
 pass out on $utunInterfaces flags any no state


### PR DESCRIPTION
## Problem

The macOS pf killswitch anchor `200.allowVPN` (`deploy/data/macos/pf/amn.200.allowVPN.conf`) exempts a hardcoded list of tunnel interfaces, `utun0 … utun30`.

macOS assigns the WireGuard/AmneziaWG tunnel the next free `utunN` unit. On machines that already run several utun-based services (Tailscale, iCloud Private Relay, other VPNs), that number starts high and **increments on every reconnect** until reboot. When the tunnel lands on a unit **> utun30**, anchor `100.blockAll` (`block drop out all`) drops the tunnel's own egress.

Symptom: the client shows **Connected**, the WireGuard handshake completes (handshake packets egress `en0`, which is allowed), and routes `0/1` + `128.0/1` correctly point at the tunnel — but **no user traffic passes** and the machine appears offline, with no error surfaced.

**Reproduced on:** macOS 26/27, Apple Silicon, "VPN by Amnezia" (AmneziaWG). Across reconnects the tunnel landed on `utun40`–`utun57`; `pfctl -a 'amn/200.allowVPN' -sr` showed the exemption stopping at `utun30`, so `100.blockAll` dropped everything routed into the tunnel. Verified end-to-end against a native build: with this change the AmneziaWG tunnel passes traffic normally; without it, it connects but carries nothing.

## Fix

Widen the static exemption range from `utun0 … utun30` to `utun0 … utun99`.

## Possible follow-up

This keeps the existing static-list approach, just with more headroom. A more robust fix would exempt the **actual** tunnel interface dynamically — the daemon already knows it (`wireguardutilsmacos.cpp` → `m_ifname`), `KillSwitch::enableKillSwitch(configStr, vpnAdapterIndex)` already plumbs an adapter index, and `MacOSFirewall::setAnchorTable` already injects dynamic values (the server IP) into a pf table. Exempting `m_ifname` directly would remove the fixed cap entirely. Left out here to keep the change minimal.

One note for reviewers: `MacOSFirewall::setAnchorEnabled` only reloads an anchor's `.conf` when the anchor is currently empty, so a running daemon won't pick up this change until the anchor is flushed / the service reloads.
