### PR TITLE
fix: add accessible labels to core controls

### DIFF
--- a/client/ui/qml/Components/AddSitePanel.qml
+++ b/client/ui/qml/Components/AddSitePanel.qml
@@ -47,8 +47,10 @@ Item {
             Layout.fillWidth: true
             rightButtonClickedOnEnter: true
 
+            headerText: root.placeholderText
             textField.placeholderText: root.placeholderText
             buttonImageSource: "qrc:/images/controls/plus.svg"
+            buttonAccessibleName: qsTr("Add")
 
             clickedFunc: function() {
                 root.addClicked(textField.text)
@@ -63,6 +65,7 @@ Item {
 
             image: "qrc:/images/controls/more-vertical.svg"
             imageColor: AmneziaStyle.color.paleGray
+            accessibleName: qsTr("Additional options")
 
             onClicked: root.moreClicked()
 

--- a/client/ui/qml/Components/InstalledAppsDrawer.qml
+++ b/client/ui/qml/Components/InstalledAppsDrawer.qml
@@ -120,6 +120,7 @@ DrawerType2 {
             anchors.leftMargin: 16
 
             backgroundColor: AmneziaStyle.color.slateGray
+            headerText: qsTr("Search applications")
 
             textField.placeholderText: qsTr("application name")
         }

--- a/client/ui/qml/Components/InstalledAppsDrawer.qml
+++ b/client/ui/qml/Components/InstalledAppsDrawer.qml
@@ -89,6 +89,7 @@ DrawerType2 {
 
                             text: appName
                             checked: isAppSelected
+                            Accessible.name: qsTr("Select %1").arg(appName)
                             onCheckedChanged: {
                                 installedAppsModel.selectedStateChanged(proxyInstalledAppsModel.mapToSource(index), checked)
                             }

--- a/client/ui/qml/Components/ServersListView.qml
+++ b/client/ui/qml/Components/ServersListView.qml
@@ -99,6 +99,7 @@ ListViewType {
 
                     image: "qrc:/images/controls/settings.svg"
                     imageColor: AmneziaStyle.color.paleGray
+                    accessibleName: qsTr("Server settings for %1").arg(name)
 
                     implicitWidth: 56
                     implicitHeight: 56

--- a/client/ui/qml/Controls2/BackButtonType.qml
+++ b/client/ui/qml/Controls2/BackButtonType.qml
@@ -25,6 +25,7 @@ FocusScope {
             id: backButton
             image: backButtonImage
             imageColor: AmneziaStyle.color.paleGray
+            accessibleName: qsTr("Back")
 
             implicitWidth: 40
             implicitHeight: 40

--- a/client/ui/qml/Controls2/BasicButtonType.qml
+++ b/client/ui/qml/Controls2/BasicButtonType.qml
@@ -27,6 +27,8 @@ Button {
     property string leftImageColor: textColor
     property bool changeLeftImageSize: true
 
+    property string accessibleName: ""
+
     property bool squareLeftSide: false
 
     property var clickedFunc
@@ -34,6 +36,9 @@ Button {
     property alias buttonTextLabel: buttonText
 
     property bool isFocusable: true
+
+    Accessible.name: accessibleName !== "" ? accessibleName : text
+    Accessible.role: Accessible.Button
 
     Keys.onTabPressed: {
         FocusController.nextKeyTabItem()

--- a/client/ui/qml/Controls2/BasicButtonType.qml
+++ b/client/ui/qml/Controls2/BasicButtonType.qml
@@ -37,7 +37,7 @@ Button {
 
     property bool isFocusable: true
 
-    Accessible.name: accessibleName !== "" ? accessibleName : text
+    Accessible.name: accessibleName !== "" ? accessibleName : (text !== "" ? text : defaultAccessibleName())
     Accessible.role: Accessible.Button
 
     Keys.onTabPressed: {
@@ -211,5 +211,14 @@ Button {
         if (root.clickedFunc && typeof root.clickedFunc === "function") {
             root.clickedFunc()
         }
+    }
+
+    function defaultAccessibleName() {
+        var source = leftImageSource !== "" ? leftImageSource : rightImageSource
+        if (source.indexOf("plus.svg") !== -1) return qsTr("Add")
+        if (source.indexOf("chevron-down.svg") !== -1) return qsTr("Expand")
+        if (source.indexOf("chevron-right.svg") !== -1) return qsTr("Open")
+        if (source.indexOf("external-link.svg") !== -1) return qsTr("Open link")
+        return ""
     }
 }

--- a/client/ui/qml/Controls2/CheckBoxType.qml
+++ b/client/ui/qml/Controls2/CheckBoxType.qml
@@ -36,6 +36,10 @@ CheckBox {
 
     property bool isFocusable: true
 
+    Accessible.name: descriptionText !== "" ? qsTr("%1, %2").arg(text).arg(descriptionText) : text
+    Accessible.role: Accessible.CheckBox
+    Accessible.description: checked ? qsTr("Checked") : qsTr("Not checked")
+
     Keys.onTabPressed: {
         FocusController.nextKeyTabItem()
     }
@@ -61,7 +65,7 @@ CheckBox {
     }
 
     hoverEnabled: enabled ? true : false
-    focusPolicy: Qt.NoFocus
+    focusPolicy: Qt.StrongFocus
 
     background: Rectangle {
         color: AmneziaStyle.color.transparent

--- a/client/ui/qml/Controls2/DropDownType.qml
+++ b/client/ui/qml/Controls2/DropDownType.qml
@@ -51,6 +51,10 @@ Item {
 
     readonly property bool isFocusable: true
 
+    Accessible.name: root.headerText !== "" ? qsTr("%1, %2").arg(root.headerText).arg(root.text) : root.text
+    Accessible.role: Accessible.ComboBox
+    Accessible.description: menu.isClosed ? qsTr("Collapsed") : qsTr("Expanded")
+
     Keys.onTabPressed: {
         FocusController.nextKeyTabItem()
     }
@@ -197,6 +201,7 @@ Item {
             hoverEnabled: false
             image: rootButtonImage
             imageColor: rootButtonImageColor
+            accessibleName: root.headerText !== "" ? root.headerText : root.text
         }
     }
 

--- a/client/ui/qml/Controls2/Header2Type.qml
+++ b/client/ui/qml/Controls2/Header2Type.qml
@@ -9,6 +9,7 @@ Item {
     id: root
 
     property string actionButtonImage
+    property string actionButtonAccessibleName: root.headerText
     property var actionButtonFunction
 
     property alias actionButton: headerActionButton
@@ -40,6 +41,7 @@ Item {
 
                 image: root.actionButtonImage
                 imageColor: AmneziaStyle.color.paleGray
+                accessibleName: root.actionButtonAccessibleName
 
                 visible: image ? true : false
 

--- a/client/ui/qml/Controls2/HeaderTypeWithButton.qml
+++ b/client/ui/qml/Controls2/HeaderTypeWithButton.qml
@@ -7,6 +7,7 @@ BaseHeaderType {
     id: root
 
     property string actionButtonImage
+    property string actionButtonAccessibleName: root.headerText
     property var actionButtonFunction
     property alias actionButton: headerActionButton
 
@@ -21,6 +22,7 @@ BaseHeaderType {
         Layout.alignment: Qt.AlignRight
         image: root.actionButtonImage
         imageColor: AmneziaStyle.color.paleGray
+        accessibleName: root.actionButtonAccessibleName
         visible: image ? true : false
 
         onClicked: {

--- a/client/ui/qml/Controls2/HeaderTypeWithSwitcher.qml
+++ b/client/ui/qml/Controls2/HeaderTypeWithSwitcher.qml
@@ -18,6 +18,7 @@ BaseHeaderType {
         id: headerSwitcher
         Layout.alignment: Qt.AlignRight
         visible: root.showSwitcher
+        accessibleName: root.headerText
 
         onToggled: {
             if (switcherFunction && typeof switcherFunction === "function") {

--- a/client/ui/qml/Controls2/ImageButtonType.qml
+++ b/client/ui/qml/Controls2/ImageButtonType.qml
@@ -17,6 +17,8 @@ Button {
     property string imageColor: AmneziaStyle.color.mutedGray
     property string disableImageColor: AmneziaStyle.color.slateGray
 
+    property string accessibleName: ""
+
     property alias backgroundColor: background.color
     property alias backgroundRadius: background.radius
 
@@ -29,6 +31,9 @@ Button {
     icon.color: root.enabled ? imageColor : disableImageColor
 
     property bool isFocusable: true
+
+    Accessible.name: accessibleName
+    Accessible.role: Accessible.Button
 
     Keys.onTabPressed: {
         FocusController.nextKeyTabItem()

--- a/client/ui/qml/Controls2/ImageButtonType.qml
+++ b/client/ui/qml/Controls2/ImageButtonType.qml
@@ -32,7 +32,7 @@ Button {
 
     property bool isFocusable: true
 
-    Accessible.name: accessibleName
+    Accessible.name: accessibleName !== "" ? accessibleName : defaultAccessibleName()
     Accessible.role: Accessible.Button
 
     Keys.onTabPressed: {
@@ -95,5 +95,20 @@ Button {
         anchors.fill: parent
         enabled: false
         cursorShape: Qt.PointingHandCursor
+    }
+
+    function defaultAccessibleName() {
+        if (image.indexOf("close.svg") !== -1) return qsTr("Close")
+        if (image.indexOf("copy.svg") !== -1) return qsTr("Copy")
+        if (image.indexOf("qr-code.svg") !== -1) return qsTr("Show QR code")
+        if (image.indexOf("trash.svg") !== -1) return qsTr("Delete")
+        if (image.indexOf("refresh-cw.svg") !== -1) return qsTr("Refresh")
+        if (image.indexOf("more-vertical.svg") !== -1) return qsTr("More options")
+        if (image.indexOf("settings") !== -1) return qsTr("Settings")
+        if (image.indexOf("plus.svg") !== -1) return qsTr("Add")
+        if (image.indexOf("chevron-down.svg") !== -1) return qsTr("Expand")
+        if (image.indexOf("chevron-right.svg") !== -1) return qsTr("Open")
+        if (image.indexOf("download.svg") !== -1) return qsTr("Download")
+        return ""
     }
 }

--- a/client/ui/qml/Controls2/LabelWithButtonType.qml
+++ b/client/ui/qml/Controls2/LabelWithButtonType.qml
@@ -21,6 +21,7 @@ Item {
 
     property string buttonImageSource
     property string rightImageSource
+    property string rightButtonAccessibleName: root.text
     property string leftImageSource
     property bool isLeftImageHoverEnabled: true
     property bool isSmallLeftImage: false
@@ -276,7 +277,7 @@ Item {
             image: rightImageSource
             imageColor: rightImageColor
             visible: rightImageSource ? true : false
-            accessibleName: root.text
+            accessibleName: root.rightButtonAccessibleName
 
             Layout.alignment: Qt.AlignRight
 

--- a/client/ui/qml/Controls2/LabelWithButtonType.qml
+++ b/client/ui/qml/Controls2/LabelWithButtonType.qml
@@ -45,6 +45,9 @@ Item {
 
     property bool isFocusable: !(eyeImage.visible || rightImage.visible) // TODO: this component already has focusable items
 
+    Accessible.name: root.descriptionText !== "" ? qsTr("%1, %2").arg(root.text).arg(root.descriptionText) : root.text
+    Accessible.role: Accessible.Button
+
     Keys.onTabPressed: {
         FocusController.nextKeyTabItem()
     }
@@ -235,6 +238,7 @@ Item {
             hoverEnabled: true
             image: buttonImageSource
             imageColor: rightImageColor
+            accessibleName: hideDescription ? qsTr("Show %1").arg(root.text) : qsTr("Hide %1").arg(root.text)
 
             Layout.alignment: Qt.AlignRight
 
@@ -272,6 +276,7 @@ Item {
             image: rightImageSource
             imageColor: rightImageColor
             visible: rightImageSource ? true : false
+            accessibleName: root.text
 
             Layout.alignment: Qt.AlignRight
 

--- a/client/ui/qml/Controls2/ListViewWithRadioButtonType.qml
+++ b/client/ui/qml/Controls2/ListViewWithRadioButtonType.qml
@@ -54,6 +54,10 @@ ListViewType {
 
             property bool isFocusable: true
 
+            Accessible.name: name
+            Accessible.role: Accessible.RadioButton
+            Accessible.description: checked ? qsTr("Selected") : ""
+
             Keys.onTabPressed: {
                 FocusController.nextKeyTabItem()
             }
@@ -153,6 +157,10 @@ ListViewType {
         }
 
         Keys.onEnterPressed: {
+            radioButton.clicked()
+        }
+
+        Keys.onSpacePressed: {
             radioButton.clicked()
         }
     }

--- a/client/ui/qml/Controls2/SwitcherType.qml
+++ b/client/ui/qml/Controls2/SwitcherType.qml
@@ -35,7 +35,13 @@ Switch {
     property string hoveredIndicatorBackgroundColor: AmneziaStyle.color.translucentWhite
     property string defaultIndicatorBackgroundColor: AmneziaStyle.color.transparent
 
+    property string accessibleName: text
+
     property bool isFocusable: true
+
+    Accessible.name: accessibleName
+    Accessible.role: Accessible.CheckBox
+    Accessible.description: checked ? qsTr("Enabled") : qsTr("Disabled")
 
     Keys.onTabPressed: {
         FocusController.nextKeyTabItem()

--- a/client/ui/qml/Controls2/TabButtonType.qml
+++ b/client/ui/qml/Controls2/TabButtonType.qml
@@ -19,6 +19,10 @@ TabButton {
 
     property bool isFocusable: true
 
+    Accessible.name: text
+    Accessible.role: Accessible.PageTab
+    Accessible.description: isSelected ? qsTr("Selected") : ""
+
     Keys.onTabPressed: {
         FocusController.nextKeyTabItem()
     }

--- a/client/ui/qml/Controls2/TabImageButtonType.qml
+++ b/client/ui/qml/Controls2/TabImageButtonType.qml
@@ -12,9 +12,15 @@ TabButton {
 
     property string image
 
+    property string accessibleName: ""
+
     property bool isSelected: false
 
 	property bool isFocusable: true
+
+    Accessible.name: accessibleName
+    Accessible.role: Accessible.PageTab
+    Accessible.description: isSelected ? qsTr("Selected") : ""
 
     Keys.onTabPressed: {
         FocusController.nextKeyTabItem()

--- a/client/ui/qml/Controls2/TextFieldWithHeaderType.qml
+++ b/client/ui/qml/Controls2/TextFieldWithHeaderType.qml
@@ -25,6 +25,7 @@ Item {
     property alias textField: textField
     property string textFieldTextColor: AmneziaStyle.color.paleGray
     property string textFieldTextDisabledColor: AmneziaStyle.color.mutedGray
+    property int textFieldInputMethodHints: Qt.ImhNoAutoUppercase | Qt.ImhNoPredictiveText
 
     property bool textFieldEditable: true
 
@@ -110,7 +111,10 @@ Item {
                         enabled: root.textFieldEditable
                         color: root.enabled ? root.textFieldTextColor : root.textFieldTextDisabledColor
 
-                        inputMethodHints: Qt.ImhNoAutoUppercase | Qt.ImhSensitiveData | Qt.ImhNoPredictiveText
+                        Accessible.name: root.headerText !== "" ? root.headerText : root.textField.placeholderText
+                        Accessible.role: Accessible.EditableText
+
+                        inputMethodHints: root.textFieldInputMethodHints
 
                         placeholderTextColor: AmneziaStyle.color.charcoalGray
 

--- a/client/ui/qml/Controls2/TextFieldWithHeaderType.qml
+++ b/client/ui/qml/Controls2/TextFieldWithHeaderType.qml
@@ -20,6 +20,7 @@ Item {
 
     property string buttonText
     property string buttonImageSource
+    property string buttonAccessibleName: buttonText !== "" ? buttonText : defaultButtonAccessibleName()
     property var clickedFunc
 
     property alias textField: textField
@@ -198,9 +199,10 @@ Item {
     BasicButtonType {
         visible: (root.buttonText !== "") || (root.buttonImageSource !== "")
 
-        focusPolicy: Qt.NoFocus
+        focusPolicy: Qt.StrongFocus
         text: root.buttonText
         leftImageSource: root.buttonImageSource
+        accessibleName: root.buttonAccessibleName
 
         anchors.top: content.top
         anchors.bottom: content.bottom
@@ -219,6 +221,14 @@ Item {
 
     function getBackgroundBorderColor(noneFocusedColor) {
         return textField.focus ? root.borderFocusedColor : noneFocusedColor
+    }
+
+    function defaultButtonAccessibleName() {
+        if (buttonImageSource.indexOf("plus.svg") !== -1) return qsTr("Add")
+        if (buttonImageSource.indexOf("refresh-cw.svg") !== -1) return qsTr("Refresh")
+        if (buttonImageSource.indexOf("eye.svg") !== -1) return qsTr("Show %1").arg(headerText)
+        if (buttonImageSource.indexOf("eye-off.svg") !== -1) return qsTr("Hide %1").arg(headerText)
+        return headerText
     }
 
     Keys.onEnterPressed: {

--- a/client/ui/qml/Controls2/VerticalRadioButton.qml
+++ b/client/ui/qml/Controls2/VerticalRadioButton.qml
@@ -34,6 +34,10 @@ RadioButton {
 
     property bool isFocusable: true
 
+    Accessible.name: descriptionText !== "" ? qsTr("%1, %2").arg(text).arg(descriptionText) : text
+    Accessible.role: Accessible.RadioButton
+    Accessible.description: checked ? qsTr("Selected") : ""
+
     
     property string radioButtonInnerCirclePressedSource: "qrc:/images/controls/radio-button-inner-circle-pressed.png"
     property string radioButtonInnerCircleSource: "qrc:/images/controls/radio-button-inner-circle.png"

--- a/client/ui/qml/Pages2/PageHome.qml
+++ b/client/ui/qml/Pages2/PageHome.qml
@@ -288,6 +288,7 @@ PageType {
                         hoverEnabled: false
                         image: "qrc:/images/controls/chevron-down.svg"
                         imageColor: AmneziaStyle.color.paleGray
+                        accessibleName: qsTr("Select server")
 
                         icon.width: 18
                         icon.height: 18

--- a/client/ui/qml/Pages2/PageSettingsAppSplitTunneling.qml
+++ b/client/ui/qml/Pages2/PageSettingsAppSplitTunneling.qml
@@ -195,6 +195,7 @@ PageType {
                 text: appPath
                 rightImageSource: "qrc:/images/controls/trash.svg"
                 rightImageColor: AmneziaStyle.color.paleGray
+                rightButtonAccessibleName: qsTr("Remove %1").arg(appPath)
 
                 clickedFunction: function() {
                     var headerText = qsTr("Remove ") + appPath + "?"
@@ -242,8 +243,10 @@ PageType {
 
                 Layout.fillWidth: true
 
+                headerText: qsTr("Application")
                 textField.placeholderText: qsTr("application name")
                 buttonImageSource: "qrc:/images/controls/plus.svg"
+                buttonAccessibleName: qsTr("Add application")
 
                 rightButtonClickedOnEnter: true
 

--- a/client/ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml
+++ b/client/ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml
@@ -100,6 +100,7 @@ PageType {
                 text: ip
                 rightImageSource: "qrc:/images/controls/trash.svg"
                 rightImageColor: AmneziaStyle.color.paleGray
+                rightButtonAccessibleName: qsTr("Delete %1").arg(ip)
 
                 clickedFunction: function() {
                     var headerText = qsTr("Delete ") + ip + "?"

--- a/client/ui/qml/Pages2/PageSettingsServerData.qml
+++ b/client/ui/qml/Pages2/PageSettingsServerData.qml
@@ -71,6 +71,7 @@ PageType {
                 text: title
                 descriptionText: description
                 textColor: tColor
+                Accessible.name: title
 
                 clickedFunction: function() {
                     clickedHandler()

--- a/client/ui/qml/Pages2/PageSettingsSplitTunneling.qml
+++ b/client/ui/qml/Pages2/PageSettingsSplitTunneling.qml
@@ -205,6 +205,7 @@ PageType {
                 descriptionText: ip
                 rightImageSource: "qrc:/images/controls/trash.svg"
                 rightImageColor: AmneziaStyle.color.paleGray
+                rightButtonAccessibleName: qsTr("Remove %1").arg(url)
 
                 clickedFunction: function() {
                     var headerText = qsTr("Remove ") + url + "?"
@@ -259,8 +260,10 @@ PageType {
                 Layout.fillWidth: true
                 rightButtonClickedOnEnter: true
 
+                headerText: qsTr("Website or IP")
                 textField.placeholderText: qsTr("website or IP")
                 buttonImageSource: "qrc:/images/controls/plus.svg"
+                buttonAccessibleName: qsTr("Add site")
 
                 clickedFunc: function() {
                     PageController.showBusyIndicator(true)
@@ -277,6 +280,7 @@ PageType {
 
                 image: "qrc:/images/controls/more-vertical.svg"
                 imageColor: AmneziaStyle.color.paleGray
+                accessibleName: qsTr("Additional options")
 
                 onClicked: function () {
                     moreActionsDrawer.openTriggered()
@@ -314,6 +318,7 @@ PageType {
 
                 text: qsTr("Import")
                 rightImageSource: "qrc:/images/controls/chevron-right.svg"
+                rightButtonAccessibleName: qsTr("Import site list")
 
                 clickedFunction: function() {
                     importSitesDrawer.openTriggered()

--- a/client/ui/qml/Pages2/PageStart.qml
+++ b/client/ui/qml/Pages2/PageStart.qml
@@ -359,6 +359,7 @@ PageType {
 
             isSelected: tabBar.currentIndex === 0
             image: "qrc:/images/controls/home.svg"
+            accessibleName: qsTr("Home")
             clickedFunc: function () {
                 tabBarStackView.goToTabBarPage(PageEnum.PageHome)
                 ServersUiController.setProcessedServerId(ServersUiController.defaultServerId)
@@ -387,6 +388,7 @@ PageType {
 
             isSelected: tabBar.currentIndex === 1
             image: "qrc:/images/controls/share-2.svg"
+            accessibleName: qsTr("Share")
             clickedFunc: function () {
                 tabBarStackView.goToTabBarPage(PageEnum.PageShare)
                 tabBar.currentIndex = 1
@@ -399,6 +401,7 @@ PageType {
 
             isSelected: tabBar.currentIndex === 2
             image: (ServersUiController.hasServersFromGatewayApi && NewsModel.hasUnread && SettingsController.isNewsNotificationsEnabled()) ? "qrc:/images/controls/settings-news.svg" : "qrc:/images/controls/settings.svg"
+            accessibleName: qsTr("Settings")
             Binding {
                 target: settingsTabButton
                 property: "defaultColor"
@@ -417,6 +420,7 @@ PageType {
 
             isSelected: tabBar.currentIndex === 3
             image: "qrc:/images/controls/plus.svg"
+            accessibleName: qsTr("Add server")
             clickedFunc: function () {
                 tabBarStackView.goToTabBarPage(PageEnum.PageSetupWizardConfigSource)
                 tabBar.currentIndex = 3


### PR DESCRIPTION
## Summary

Expands the accessibility fix to cover the known NVDA/TalkBack issues reported in #2778 as far as they can be addressed statically in QML.

Changes:

- Add `Accessible.name` / `Accessible.role` to shared button, image button, tab, radio button, checkbox, switcher, dropdown, label-button, and text-field controls.
- Add fallback accessible names for common icon-only buttons (`Close`, `Copy`, `Show QR code`, `Delete`, `Refresh`, `More options`, `Settings`, `Add`, `Expand`, `Open`, `Download`).
- Add explicit labels for the bottom navigation icon tabs: Home, Share, Settings, Add server.
- Add labels for the main server selector and per-server settings button.
- Keep server radio buttons readable and add metadata for shared radio-list items.
- Add explicit accessible labels for adjacent action buttons in the reported server/split-tunneling flows.
- Make custom `CheckBoxType` focusable with `Qt.StrongFocus` so keyboard/screen-reader users can reach and toggle it normally.
- Make the embedded action button inside `TextFieldWithHeaderType` focusable and labelled. This covers plus/add buttons and show/hide/refresh style actions.
- Stop marking every `TextFieldWithHeaderType` as sensitive data by default and give text fields an accessible name; this helps normal search fields behave like text inputs instead of password-like fields.
- Label Android app split-tunneling search as `Application` / `Search applications`.
- Add explicit labels for split-tunneling remove/delete actions, additional-options buttons, import actions, and installed-app checkboxes.
- Add accessible state descriptions for switchers/dropdowns/checkboxes/radio buttons where useful.

Addresses #2778
Related to #1176

## Verification

- Checked that the touched QML files keep balanced braces/parentheses/brackets with a lightweight static script.
- Checked that changed files do not contain obvious credential/token patterns.
- Verified Qt docs list the used `Accessible` roles (`Button`, `CheckBox`, `RadioButton`, `PageTab`, `EditableText`, `ComboBox`).
- Verified the PR branch on GitHub now contains both commits and the expanded changed-file set.

Limitations and follow-up testing:

- I could not run the full app build or runtime NVDA/TalkBack test in this environment.
- After this is accepted and available in an updated build, I can test the real app with NVDA on desktop and TalkBack on Android and report confirmations or follow-up problems.
- `git diff --check` reports CRLF line endings as trailing whitespace on several pre-existing CRLF QML files after adding lines; the actual diff is small and preserves existing file line endings.
