### PR TITLE
Fix AllowedIPs parsing when comma is not followed by space

### DIFF
--- a/client/core/controllers/selfhosted/importController.cpp
+++ b/client/core/controllers/selfhosted/importController.cpp
@@ -567,7 +567,7 @@ QJsonObject ImportController::extractWireGuardConfig(const QString &data, Config
     }
 
     QJsonArray allowedIpsJsonArray = QJsonArray::fromStringList(
-                configMap.value(protocols::wireguard::AllowedIPs).split(", "));
+                ProtocolUtils::parseAllowedIps(configMap.value(protocols::wireguard::AllowedIPs)));
 
     lastConfig[configKey::allowedIps] = allowedIpsJsonArray;
 

--- a/client/core/protocols/protocolUtils.cpp
+++ b/client/core/protocols/protocolUtils.cpp
@@ -222,3 +222,62 @@ QString ProtocolUtils::getProtocolVersionString(const QJsonObject &protocolConfi
     if (version == protocols::awg::awgV1_5) return QObject::tr(" (version 1.5)");
     return "";
 }
+
+QStringList ProtocolUtils::parseAllowedIps(const QString &allowedIpsString)
+{
+    QStringList result;
+    for (const QString &part : allowedIpsString.split(',', Qt::SkipEmptyParts)) {
+        const QString trimmed = part.trimmed();
+        if (!trimmed.isEmpty()) {
+            result.append(trimmed);
+        }
+    }
+    return result;
+}
+
+QStringList ProtocolUtils::normalizeAllowedIpsList(const QStringList &allowedIps)
+{
+    QStringList result;
+    for (const QString &ip : allowedIps) {
+        if (ip.contains(',')) {
+            result.append(parseAllowedIps(ip));
+        } else {
+            const QString trimmed = ip.trimmed();
+            if (!trimmed.isEmpty()) {
+                result.append(trimmed);
+            }
+        }
+    }
+    return result;
+}
+
+bool ProtocolUtils::isFullTunnelAllowedIps(const QStringList &allowedIps)
+{
+    return allowedIps.contains("0.0.0.0/0") && allowedIps.contains("::/0");
+}
+
+bool ProtocolUtils::hasServerSideSplitTunneling(const QStringList &allowedIps, const QString &nativeConfig)
+{
+    const QStringList normalizedIps = normalizeAllowedIpsList(allowedIps);
+    if (!normalizedIps.isEmpty()) {
+        return !isFullTunnelAllowedIps(normalizedIps);
+    }
+
+    if (nativeConfig.isEmpty()) {
+        return false;
+    }
+
+    for (const QString &line : nativeConfig.split('\n')) {
+        if (!line.contains("AllowedIPs")) {
+            continue;
+        }
+        const QStringList parts = line.split(" = ");
+        if (parts.size() < 2) {
+            break;
+        }
+        const QStringList parsedIps = parseAllowedIps(parts.at(1));
+        return !parsedIps.isEmpty() && !isFullTunnelAllowedIps(parsedIps);
+    }
+
+    return false;
+}

--- a/client/core/protocols/protocolUtils.h
+++ b/client/core/protocols/protocolUtils.h
@@ -41,6 +41,11 @@ namespace amnezia
 
         QString getProtocolVersion(const QJsonObject &protocolConfig);
         QString getProtocolVersionString(const QJsonObject &protocolConfig);
+
+        QStringList parseAllowedIps(const QString &allowedIpsString);
+        QStringList normalizeAllowedIpsList(const QStringList &allowedIps);
+        bool isFullTunnelAllowedIps(const QStringList &allowedIps);
+        bool hasServerSideSplitTunneling(const QStringList &allowedIps, const QString &nativeConfig = QString());
     }
 }
 

--- a/client/ui/controllers/serversUiController.cpp
+++ b/client/ui/controllers/serversUiController.cpp
@@ -3,6 +3,7 @@
 #include "core/utils/containerEnum.h"
 #include "core/utils/containers/containerUtils.h"
 #include "core/utils/protocolEnum.h"
+#include "core/protocols/protocolUtils.h"
 #include "core/models/protocolConfig.h"
 #include "core/models/containerConfig.h"
 
@@ -221,19 +222,10 @@ bool ServersUiController::isDefaultServerDefaultContainerHasSplitTunneling() con
     const ContainerConfig containerConfig = m_serversController->getContainerConfig(defaultServerId, defaultContainer);
     
     if (defaultContainer == DockerContainer::Awg || defaultContainer == DockerContainer::WireGuard) {
-        auto hasSplitTunnelingFromAllowedIps = [](const QStringList& allowedIps, const QString& nativeConfig) -> bool {
-            bool hasSplitTunneling = !allowedIps.isEmpty() && !allowedIps.contains("0.0.0.0/0");
-            if (!hasSplitTunneling && !nativeConfig.isEmpty()) {
-                hasSplitTunneling = nativeConfig.contains("AllowedIPs") 
-                    && !nativeConfig.contains("AllowedIPs = 0.0.0.0/0, ::/0");
-            }
-            return hasSplitTunneling;
-        };
-        
         if (defaultContainer == DockerContainer::Awg) {
             if (const auto* awgConfig = containerConfig.getAwgProtocolConfig()) {
                 if (awgConfig->hasClientConfig()) {
-                    return hasSplitTunnelingFromAllowedIps(
+                    return ProtocolUtils::hasServerSideSplitTunneling(
                         awgConfig->clientConfig->allowedIps,
                         awgConfig->clientConfig->nativeConfig
                     );
@@ -242,7 +234,7 @@ bool ServersUiController::isDefaultServerDefaultContainerHasSplitTunneling() con
         } else if (defaultContainer == DockerContainer::WireGuard) {
             if (const auto* wgConfig = containerConfig.getWireGuardProtocolConfig()) {
                 if (wgConfig->hasClientConfig()) {
-                    return hasSplitTunnelingFromAllowedIps(
+                    return ProtocolUtils::hasServerSideSplitTunneling(
                         wgConfig->clientConfig->allowedIps,
                         wgConfig->clientConfig->nativeConfig
                     );

--- a/client/vpnConnection.cpp
+++ b/client/vpnConnection.cpp
@@ -31,6 +31,7 @@
 
 #include "core/utils/networkUtilities.h"
 #include "core/utils/serverConfigUtils.h"
+#include "core/protocols/protocolUtils.h"
 #include "vpnConnection.h"
 
 using namespace ProtocolUtils;
@@ -382,7 +383,8 @@ void VpnConnection::appendSplitTunnelingConfig()
         allowSiteBasedSplitTunneling = false;
         auto configData = m_vpnConfiguration.value(protocolName + "_config_data").toObject();
         if (configData.value(configKey::allowedIps).isString()) {
-            QJsonArray allowedIpsJsonArray = QJsonArray::fromStringList(configData.value(configKey::allowedIps).toString().split(", "));
+            QJsonArray allowedIpsJsonArray = QJsonArray::fromStringList(
+                    parseAllowedIps(configData.value(configKey::allowedIps).toString()));
             configData.insert(configKey::allowedIps, allowedIpsJsonArray);
             m_vpnConfiguration.insert(protocolName + "_config_data", configData);
         } else if (configData.value(configKey::allowedIps).isUndefined()) {
@@ -391,10 +393,10 @@ void VpnConnection::appendSplitTunnelingConfig()
             for (auto &line : nativeConfigLines) {
                 if (line.contains("AllowedIPs")) {
                     auto allowedIpsString = line.split(" = ");
-                    if (allowedIpsString.size() < 1) {
+                    if (allowedIpsString.size() < 2) {
                         break;
                     }
-                    QJsonArray allowedIpsJsonArray = QJsonArray::fromStringList(allowedIpsString.at(1).split(", "));
+                    QJsonArray allowedIpsJsonArray = QJsonArray::fromStringList(parseAllowedIps(allowedIpsString.at(1)));
                     configData.insert(configKey::allowedIps, allowedIpsJsonArray);
                     m_vpnConfiguration.insert(protocolName + "_config_data", configData);
                     break;
@@ -419,7 +421,11 @@ void VpnConnection::appendSplitTunnelingConfig()
         }
 
         QJsonArray allowedIpsJsonArray = configData.value(configKey::allowedIps).toArray();
-        if (allowedIpsJsonArray.contains("0.0.0.0/0") && allowedIpsJsonArray.contains("::/0")) {
+        QStringList allowedIpsList;
+        for (const QJsonValue &val : allowedIpsJsonArray) {
+            allowedIpsList.append(val.toString());
+        }
+        if (isFullTunnelAllowedIps(normalizeAllowedIpsList(allowedIpsList))) {
             allowSiteBasedSplitTunneling = true;
         }
     }


### PR DESCRIPTION
## Summary
- Add `ProtocolUtils::parseAllowedIps()` to split AllowedIPs by comma with optional whitespace, matching WireGuard config format.
- Use the new parser when importing WireGuard configs and when reading AllowedIPs from native config at connection time.
- Replace fragile string comparison for server-side split tunneling detection with parsed AllowedIPs checks, including normalization of legacy malformed entries.

## Problem
When a WireGuard/AWG config contains `AllowedIPs = 0.0.0.0/0,::/0` (no space after comma), the client split the value only on `", "`. This produced a single entry `"0.0.0.0/0,::/0"` instead of two separate routes, causing the app to incorrectly treat full-tunnel servers as having server-side split tunneling and show "Default server does not support split tunneling function".

## Test plan
- [ ] Import a WireGuard config with `AllowedIPs = 0.0.0.0/0,::/0` (no space after comma) and verify split tunneling settings page opens without error.
- [ ] Import a config with `AllowedIPs = 0.0.0.0/0, ::/0` (with space) and verify behavior is unchanged.
- [ ] Import a config with custom AllowedIPs (e.g. `10.0.0.0/8,192.168.0.0/16`) and verify server-side split tunneling is still detected correctly.
- [ ] Connect to a full-tunnel WireGuard/AWG server and verify client-side site split tunneling works when enabled.


Made with [Cursor](https://cursor.com)