### PR TITLE
fix: enhance split tunneling IP handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ deploy/build_64/*
 winbuild*.bat
 .cache/
 .vscode/
+.venv/
+.cursor*
 
 
 # Qt-es

--- a/client/core/controllers/ipSplitTunnelingController.cpp
+++ b/client/core/controllers/ipSplitTunnelingController.cpp
@@ -1,6 +1,7 @@
 #include "ipSplitTunnelingController.h"
 #include "core/utils/networkUtilities.h"
 #include <QJsonObject>
+#include <QDebug>
 
 IpSplitTunnelingController::IpSplitTunnelingController(SecureAppSettingsRepository* appSettingsRepository, QObject* parent)
     : QObject(parent),
@@ -14,47 +15,56 @@ IpSplitTunnelingController::IpSplitTunnelingController(SecureAppSettingsReposito
     fillSites();
 }
 
-bool IpSplitTunnelingController::addSiteInternal(const QString &hostname, const QString &ip)
+bool IpSplitTunnelingController::addSiteInternal(const QString &hostname, const QStringList &ips)
 {
     QVariantMap existing = m_appSettingsRepository->vpnSites(m_currentRouteMode);
-    if (existing.contains(hostname) && ip.isEmpty()) {
+    if (existing.contains(hostname) && ips.isEmpty()) {
         return false;
     }
 
     for (int i = 0; i < m_sites.size(); i++) {
-        if (m_sites[i].first == hostname && (m_sites[i].second.isEmpty() && !ip.isEmpty())) {
-            m_sites[i].second = ip;
-            m_appSettingsRepository->addVpnSite(m_currentRouteMode, hostname, ip);
+        if (m_sites[i].first == hostname) {
+            bool changed = false;
+            for (const QString &ip : ips) {
+                if (!ip.isEmpty() && !m_sites[i].second.contains(ip)) {
+                    m_sites[i].second.append(ip);
+                    changed = true;
+                }
+            }
+            if (!changed) {
+                return false;
+            }
+            m_appSettingsRepository->addVpnSite(m_currentRouteMode, hostname, ips);
             return true;
-        } else if (m_sites[i].first == hostname && (m_sites[i].second == ip)) {
-            return false;
         }
     }
-    m_sites.append(qMakePair(hostname, ip));
-    m_appSettingsRepository->addVpnSite(m_currentRouteMode, hostname, ip);
+    m_sites.append(qMakePair(hostname, ips));
+    m_appSettingsRepository->addVpnSite(m_currentRouteMode, hostname, ips);
     return true;
 }
 
-void IpSplitTunnelingController::addSites(const QMap<QString, QString> &sites, bool replaceExisting)
+void IpSplitTunnelingController::addSites(const QMap<QString, QStringList> &sites, bool replaceExisting)
 {
     if (replaceExisting) {
         m_sites.clear();
     }
     for (auto it = sites.constBegin(); it != sites.constEnd(); ++it) {
         const QString &hostname = it.key();
-        const QString &ip = it.value();
+        const QStringList &ips = it.value();
         bool found = false;
         for (int i = 0; i < m_sites.size(); i++) {
             if (m_sites[i].first == hostname) {
-                if (!ip.isEmpty()) {
-                    m_sites[i].second = ip;
+                for (const QString &ip : ips) {
+                    if (!ip.isEmpty() && !m_sites[i].second.contains(ip)) {
+                        m_sites[i].second.append(ip);
+                    }
                 }
                 found = true;
                 break;
             }
         }
         if (!found) {
-            m_sites.append(qMakePair(hostname, ip));
+            m_sites.append(qMakePair(hostname, ips));
         }
     }
     if (replaceExisting) {
@@ -72,11 +82,11 @@ bool IpSplitTunnelingController::addSite(const QString &hostname)
     }
     
     if (NetworkUtilities::ipAddressWithSubnetRegExp().exactMatch(normalizedHostname)) {
-        processSite(normalizedHostname, "");
+        processSite(normalizedHostname, {});
         return true;
     }
     
-    if (addSiteInternal(normalizedHostname, "")) {
+    if (addSiteInternal(normalizedHostname, {})) {
         QHostInfo::lookupHost(normalizedHostname, this, SLOT(onHostResolved(QHostInfo)));
         return true;
     }
@@ -124,7 +134,7 @@ bool IpSplitTunnelingController::isSplitTunnelingEnabled() const
     return m_appSettingsRepository->isSitesSplitTunnelingEnabled();
 }
 
-QVector<QPair<QString, QString>> IpSplitTunnelingController::getCurrentSites() const
+QVector<QPair<QString, QStringList>> IpSplitTunnelingController::getCurrentSites() const
 {
     return m_sites;
 }
@@ -134,7 +144,7 @@ void IpSplitTunnelingController::fillSites()
     QVariantMap sitesMap = m_appSettingsRepository->vpnSites(m_currentRouteMode);
     m_sites.clear();
     for (auto it = sitesMap.begin(); it != sitesMap.end(); ++it) {
-        m_sites.append(qMakePair(it.key(), it.value().toString()));
+        m_sites.append(qMakePair(it.key(), SecureAppSettingsRepository::siteIpList(it.value())));
     }
 }
 
@@ -164,29 +174,40 @@ void IpSplitTunnelingController::onHostResolved(const QHostInfo &hostInfo)
 {
     const QList<QHostAddress> &addresses = hostInfo.addresses();
     QString hostname = hostInfo.hostName();
-    
+
+    QStringList allIpv4;
     for (const QHostAddress &addr : addresses) {
         if (addr.protocol() == QAbstractSocket::NetworkLayerProtocol::IPv4Protocol) {
-            processSiteAfterResolve(hostname, addr.toString());
-            break;
+            allIpv4.append(addr.toString());
         }
+    }
+    allIpv4.removeDuplicates();
+    qDebug() << "[SplitTunneling] Host resolved:" << hostname
+             << "-> adding all IPv4 addresses to list:" << allIpv4;
+
+    if (!allIpv4.isEmpty()) {
+        processSiteAfterResolve(hostname, allIpv4);
     }
 }
 
-void IpSplitTunnelingController::processSiteAfterResolve(const QString &hostname, const QString &ip)
+void IpSplitTunnelingController::processSiteAfterResolve(const QString &hostname, const QStringList &ips)
 {
     for (int i = 0; i < m_sites.size(); i++) {
-        if (m_sites[i].first == hostname && m_sites[i].second.isEmpty()) {
-            m_sites[i].second = ip;
-            m_appSettingsRepository->addVpnSite(m_currentRouteMode, hostname, ip);
+        if (m_sites[i].first == hostname) {
+            for (const QString &ip : ips) {
+                if (!ip.isEmpty() && !m_sites[i].second.contains(ip)) {
+                    m_sites[i].second.append(ip);
+                }
+            }
             break;
         }
     }
+    m_appSettingsRepository->addVpnSite(m_currentRouteMode, hostname, ips);
 }
 
-void IpSplitTunnelingController::processSite(const QString &hostname, const QString &ip)
+void IpSplitTunnelingController::processSite(const QString &hostname, const QStringList &ips)
 {
-    addSiteInternal(hostname, ip);
+    addSiteInternal(hostname, ips);
 }
 
 bool IpSplitTunnelingController::importSitesFromJson(const QByteArray& jsonData, bool replaceExisting, QString &errorMessage)
@@ -205,12 +226,25 @@ bool IpSplitTunnelingController::importSitesFromJson(const QByteArray& jsonData,
     }
     
     QJsonArray jsonArray = jsonDocument.array();
-    QMap<QString, QString> sites;
+    QMap<QString, QStringList> sites;
     
     for (auto jsonValue : jsonArray) {
         QJsonObject jsonObject = jsonValue.toObject();
         QString hostname = jsonObject.value("hostname").toString("");
-        QString ip = jsonObject.value("ip").toString("");
+
+        QStringList ips;
+        if (jsonObject.value("ips").isArray()) {
+            const QJsonArray ipsArray = jsonObject.value("ips").toArray();
+            for (const auto &ipValue : ipsArray) {
+                ips.append(ipValue.toString());
+            }
+        }
+        const QString singleIp = jsonObject.value("ip").toString("");
+        if (!singleIp.isEmpty()) {
+            ips.append(singleIp);
+        }
+        ips.removeAll(QString());
+        ips.removeDuplicates();
         
         QString normalizedHostname = normalizeHostname(hostname);
         
@@ -219,7 +253,7 @@ bool IpSplitTunnelingController::importSitesFromJson(const QByteArray& jsonData,
             continue;
         }
         
-        sites.insert(normalizedHostname, ip);
+        sites.insert(normalizedHostname, ips);
     }
     
     addSites(sites, replaceExisting);
@@ -229,13 +263,21 @@ bool IpSplitTunnelingController::importSitesFromJson(const QByteArray& jsonData,
 
 QByteArray IpSplitTunnelingController::exportSitesToJson() const
 {
-    QVector<QPair<QString, QString>> sites = getCurrentSites();
+    QVector<QPair<QString, QStringList>> sites = getCurrentSites();
     QJsonArray jsonArray;
     
     for (const auto &site : sites) {
         QJsonObject jsonObject;
         jsonObject["hostname"] = site.first;
-        jsonObject["ip"] = site.second;
+
+        QJsonArray ipsArray;
+        for (const QString &ip : site.second) {
+            ipsArray.append(ip);
+        }
+        jsonObject["ips"] = ipsArray;
+        // Keep the legacy "ip" field (first address) for backward compatibility.
+        jsonObject["ip"] = site.second.isEmpty() ? QString() : site.second.first();
+
         jsonArray.append(jsonObject);
     }
     

--- a/client/core/controllers/ipSplitTunnelingController.h
+++ b/client/core/controllers/ipSplitTunnelingController.h
@@ -25,7 +25,7 @@ public:
     explicit IpSplitTunnelingController(SecureAppSettingsRepository* appSettingsRepository, QObject* parent = nullptr);
 
     bool addSite(const QString &hostname);
-    void addSites(const QMap<QString, QString> &sites, bool replaceExisting);
+    void addSites(const QMap<QString, QStringList> &sites, bool replaceExisting);
     bool removeSite(const QString &hostname);
     void removeSites();
     void setRouteMode(RouteMode routeMode);
@@ -33,7 +33,7 @@ public:
 
     RouteMode getRouteMode() const;
     bool isSplitTunnelingEnabled() const;
-    QVector<QPair<QString, QString>> getCurrentSites() const;
+    QVector<QPair<QString, QStringList>> getCurrentSites() const;
 
     bool importSitesFromJson(const QByteArray& jsonData, bool replaceExisting, QString &errorMessage);
     QByteArray exportSitesToJson() const;
@@ -43,15 +43,15 @@ private slots:
 
 private:
     void fillSites();
-    bool addSiteInternal(const QString &hostname, const QString &ip);
+    bool addSiteInternal(const QString &hostname, const QStringList &ips);
     QString normalizeHostname(const QString &hostname) const;
     bool validateHostname(const QString &hostname) const;
-    void processSiteAfterResolve(const QString &hostname, const QString &ip);
-    void processSite(const QString &hostname, const QString &ip);
+    void processSiteAfterResolve(const QString &hostname, const QStringList &ips);
+    void processSite(const QString &hostname, const QStringList &ips);
 
     SecureAppSettingsRepository* m_appSettingsRepository;
     RouteMode m_currentRouteMode;
-    QVector<QPair<QString, QString>> m_sites;
+    QVector<QPair<QString, QStringList>> m_sites;
 };
 
 #endif // IPSPLITTUNNELINGCONTROLLER_H

--- a/client/core/repositories/secureAppSettingsRepository.cpp
+++ b/client/core/repositories/secureAppSettingsRepository.cpp
@@ -120,34 +120,60 @@ QVariantMap SecureAppSettingsRepository::vpnSites(RouteMode mode) const
     return value("Conf/" + routeModeString(mode)).toMap();
 }
 
+QStringList SecureAppSettingsRepository::siteIpList(const QVariant &value)
+{
+    // QVariant::toStringList() handles both a QStringList/QVariantList and a single QString
+    // (a single string is returned as a one-element list), which covers the legacy format.
+    QStringList result = value.toStringList();
+    result.removeAll(QString());
+    result.removeDuplicates();
+    return result;
+}
+
 void SecureAppSettingsRepository::setVpnSites(RouteMode mode, const QVariantMap &sites)
 {
     setValue("Conf/" + routeModeString(mode), sites);
 }
 
-bool SecureAppSettingsRepository::addVpnSite(RouteMode mode, const QString &site, const QString &ip)
+bool SecureAppSettingsRepository::addVpnSite(RouteMode mode, const QString &site, const QStringList &ips)
 {
     QVariantMap sites = vpnSites(mode);
-    if (sites.contains(site) && ip.isEmpty())
+    const bool siteExisted = sites.contains(site);
+
+    if (siteExisted && ips.isEmpty())
         return false;
 
-    sites.insert(site, ip);
+    QStringList mergedIps = siteIpList(sites.value(site));
+    bool changed = !siteExisted;
+    for (const QString &ip : ips) {
+        if (!ip.isEmpty() && !mergedIps.contains(ip)) {
+            mergedIps.append(ip);
+            changed = true;
+        }
+    }
+
+    if (!changed)
+        return false;
+
+    sites.insert(site, mergedIps);
     setVpnSites(mode, sites);
     emit sitesChanged(mode);
     return true;
 }
 
-void SecureAppSettingsRepository::addVpnSites(RouteMode mode, const QMap<QString, QString> &sites)
+void SecureAppSettingsRepository::addVpnSites(RouteMode mode, const QMap<QString, QStringList> &sites)
 {
     QVariantMap allSites = vpnSites(mode);
     for (auto i = sites.constBegin(); i != sites.constEnd(); ++i) {
         const QString &site = i.key();
-        const QString &ip = i.value();
 
-        if (allSites.contains(site) && allSites.value(site) == ip)
-            continue;
+        QStringList mergedIps = siteIpList(allSites.value(site));
+        for (const QString &ip : i.value()) {
+            if (!ip.isEmpty() && !mergedIps.contains(ip))
+                mergedIps.append(ip);
+        }
 
-        allSites.insert(site, ip);
+        allSites.insert(site, mergedIps);
     }
 
     setVpnSites(mode, allSites);

--- a/client/core/repositories/secureAppSettingsRepository.h
+++ b/client/core/repositories/secureAppSettingsRepository.h
@@ -38,11 +38,15 @@ public:
 
     RouteMode routeMode() const;
     void setRouteMode(RouteMode mode);
-    bool addVpnSite(RouteMode mode, const QString &site, const QString &ip = "");
-    void addVpnSites(RouteMode mode, const QMap<QString, QString> &sites);
+    bool addVpnSite(RouteMode mode, const QString &site, const QStringList &ips = {});
+    void addVpnSites(RouteMode mode, const QMap<QString, QStringList> &sites);
     void removeVpnSite(RouteMode mode, const QString &site);
     void removeAllVpnSites(RouteMode mode);
     QVariantMap vpnSites(RouteMode mode) const;
+
+    // Normalizes a stored vpn site value into a list of IPs.
+    // Supports both the legacy format (a single IP string) and the current one (a list of IPs).
+    static QStringList siteIpList(const QVariant &value);
     bool isSitesSplitTunnelingEnabled() const;
     void setSitesSplitTunnelingEnabled(bool enabled);
 

--- a/client/ui/models/ipSplitTunnelingModel.cpp
+++ b/client/ui/models/ipSplitTunnelingModel.cpp
@@ -22,7 +22,7 @@ QVariant IpSplitTunnelingModel::data(const QModelIndex &index, int role) const
         break;
     }
     case IpRole: {
-        return m_sites.at(index.row()).second;
+        return m_sites.at(index.row()).second.join(", ");
         break;
     }
     default: {
@@ -33,7 +33,7 @@ QVariant IpSplitTunnelingModel::data(const QModelIndex &index, int role) const
     return QVariant();
 }
 
-void IpSplitTunnelingModel::updateModel(const QVector<QPair<QString, QString>> &sites)
+void IpSplitTunnelingModel::updateModel(const QVector<QPair<QString, QStringList>> &sites)
 {
     beginResetModel();
     m_sites = sites;

--- a/client/ui/models/ipSplitTunnelingModel.h
+++ b/client/ui/models/ipSplitTunnelingModel.h
@@ -4,6 +4,7 @@
 #include <QAbstractListModel>
 #include <QVector>
 #include <QPair>
+#include <QStringList>
 
 class IpSplitTunnelingModel : public QAbstractListModel
 {
@@ -22,13 +23,13 @@ public:
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 
 public slots:
-    void updateModel(const QVector<QPair<QString, QString>> &sites);
+    void updateModel(const QVector<QPair<QString, QStringList>> &sites);
 
 protected:
     QHash<int, QByteArray> roleNames() const override;
 
 private:
-    QVector<QPair<QString, QString>> m_sites;
+    QVector<QPair<QString, QStringList>> m_sites;
 };
 
 #endif // IPSPLITTUNNELINGMODEL_H

--- a/client/vpnConnection.cpp
+++ b/client/vpnConnection.cpp
@@ -215,8 +215,11 @@ void VpnConnection::addSitesRoutes(const QString &gw, amnezia::RouteMode mode)
         if (NetworkUtilities::checkIpSubnetFormat(i.key())) {
             ips.append(i.key());
         } else {
-            if (NetworkUtilities::checkIpSubnetFormat(i.value().toString())) {
-                ips.append(i.value().toString());
+            const QStringList siteIps = SecureAppSettingsRepository::siteIpList(i.value());
+            for (const QString &ip : siteIps) {
+                if (NetworkUtilities::checkIpSubnetFormat(ip)) {
+                    ips.append(ip);
+                }
             }
             sites.append(i.key());
         }
@@ -230,25 +233,32 @@ void VpnConnection::addSitesRoutes(const QString &gw, amnezia::RouteMode mode)
     // re-resolve domains
     for (const QString &site : sites) {
         const auto &cbResolv = [this, site, gw, mode, ips](const QHostInfo &hostInfo) {
-            const QList<QHostAddress> &addresses = hostInfo.addresses();
-            QString ipv4Addr;
+            QStringList resolvedIps;
             for (const QHostAddress &addr : hostInfo.addresses()) {
                 if (addr.protocol() == QAbstractSocket::NetworkLayerProtocol::IPv4Protocol) {
-                    const QString &ip = addr.toString();
-                    // qDebug() << "VpnConnection::addSitesRoutes updating site" << site << ip;
-                    if (!ips.contains(ip)) {
-                        IpcClient::withInterface([&gw, &ip](QSharedPointer<IpcInterfaceReplica> iface) {
-                            iface->routeAddList(gw, QStringList() << ip);
-                        });
-                        m_appSettingsRepository->addVpnSite(mode, site, ip);
-                    }
-                    IpcClient::withInterface([](QSharedPointer<IpcInterfaceReplica> iface) {
-                        auto reply = iface->flushDns();
-                        if (reply.waitForFinished() || !reply.returnValue())
-                            qWarning() << "VpnConnection::addSitesRoutes: Failed to flush DNS";
-                    });
-                    break;
+                    resolvedIps.append(addr.toString());
                 }
+            }
+            resolvedIps.removeDuplicates();
+            qDebug() << "[SplitTunneling] addSitesRoutes resolved" << site << "->" << resolvedIps;
+
+            QStringList newIps;
+            for (const QString &ip : resolvedIps) {
+                if (!ips.contains(ip)) {
+                    IpcClient::withInterface([&gw, &ip](QSharedPointer<IpcInterfaceReplica> iface) {
+                        iface->routeAddList(gw, QStringList() << ip);
+                    });
+                    newIps.append(ip);
+                }
+            }
+
+            if (!newIps.isEmpty()) {
+                m_appSettingsRepository->addVpnSite(mode, site, newIps);
+                IpcClient::withInterface([](QSharedPointer<IpcInterfaceReplica> iface) {
+                    auto reply = iface->flushDns();
+                    if (reply.waitForFinished() || !reply.returnValue())
+                        qWarning() << "VpnConnection::addSitesRoutes: Failed to flush DNS";
+                });
             }
         };
         QHostInfo::lookupHost(site, this, cbResolv);
@@ -435,8 +445,13 @@ void VpnConnection::appendSplitTunnelingConfig()
             for (auto i = m.constBegin(); i != m.constEnd(); ++i) {
                 if (NetworkUtilities::checkIpSubnetFormat(i.key())) {
                     sites.append(i.key());
-                } else if (NetworkUtilities::checkIpSubnetFormat(i.value().toString())) {
-                    sites.append(i.value().toString());
+                } else {
+                    const QStringList siteIps = SecureAppSettingsRepository::siteIpList(i.value());
+                    for (const QString &ip : siteIps) {
+                        if (NetworkUtilities::checkIpSubnetFormat(ip)) {
+                            sites.append(ip);
+                        }
+                    }
                 }
             }
             sites.removeDuplicates();


### PR DESCRIPTION
- Refactored `VpnConnection` and `IpSplitTunnelingController` to support multiple IPs per site, improving the handling of split tunneling configurations.
- Adjusted methods to utilize `QStringList` for IP addresses, ensuring better management of site IPs.
- Enhanced the `SecureAppSettingsRepository` to normalize and manage IP lists effectively.
- Updated UI models to reflect changes in data structure for sites with multiple IPs.