### PR TITLE
Fix config import parsing and VPN route edge cases

### DIFF
--- a/client/core/controllers/selfhosted/importController.cpp
+++ b/client/core/controllers/selfhosted/importController.cpp
@@ -511,9 +511,10 @@ QJsonObject ImportController::extractWireGuardConfig(const QString &data, Config
         if (trimmedLine.startsWith("[") && trimmedLine.endsWith("]")) {
             continue;
         } else {
-            QStringList parts = trimmedLine.split(" = ");
-            if (parts.count() == 2) {
-                configMap[parts.at(0).trimmed()] = parts.at(1).trimmed();
+            const qsizetype separatorIndex = trimmedLine.indexOf('=');
+            if (separatorIndex > 0) {
+                configMap[trimmedLine.left(separatorIndex).trimmed()] =
+                        trimmedLine.mid(separatorIndex + 1).trimmed();
             }
         }
     }
@@ -566,8 +567,9 @@ QJsonObject ImportController::extractWireGuardConfig(const QString &data, Config
         lastConfig[configKey::persistentKeepAlive] = configMap.value(protocols::wireguard::PersistentKeepalive);
     }
 
-    QJsonArray allowedIpsJsonArray = QJsonArray::fromStringList(
-                configMap.value(protocols::wireguard::AllowedIPs).split(", "));
+    const QStringList allowedIps = configMap.value(protocols::wireguard::AllowedIPs).split(
+            QRegularExpression("\\s*,\\s*"), Qt::SkipEmptyParts);
+    QJsonArray allowedIpsJsonArray = QJsonArray::fromStringList(allowedIps);
 
     lastConfig[configKey::allowedIps] = allowedIpsJsonArray;
 
@@ -635,11 +637,24 @@ QJsonObject ImportController::extractXrayConfig(const QString &data, ConfigTypes
 {
     QJsonParseError parserErr;
     QJsonDocument jsonConf = QJsonDocument::fromJson(data.toLocal8Bit(), &parserErr);
+    if (parserErr.error != QJsonParseError::NoError || !jsonConf.isObject()) {
+        qDebug() << "Xray config JSON parse failed:" << parserErr.errorString();
+        return QJsonObject();
+    }
+
+    const QJsonObject parsedConfig = jsonConf.object();
+    if (!parsedConfig.value(protocols::xray::inbounds).isArray()
+            || !parsedConfig.value(protocols::xray::outbounds).isArray()) {
+        qDebug() << "Xray config is missing inbounds or outbounds";
+        return QJsonObject();
+    }
+
+    const QString serializedConfig = QString::fromUtf8(jsonConf.toJson());
 
     QJsonObject xrayVpnConfig;
-    xrayVpnConfig[configKey::config] = jsonConf.toJson().constData();
+    xrayVpnConfig[configKey::config] = serializedConfig;
     QJsonObject lastConfig;
-    lastConfig[configKey::lastConfig] = jsonConf.toJson().constData();
+    lastConfig[configKey::lastConfig] = serializedConfig;
     lastConfig[configKey::isThirdPartyConfig] = true;
 
     QJsonObject containers;

--- a/client/core/protocols/vpnProtocol.cpp
+++ b/client/core/protocols/vpnProtocol.cpp
@@ -19,6 +19,7 @@ VpnProtocol::VpnProtocol(const QJsonObject &configuration, QObject *parent)
       m_connectionState(Vpn::ConnectionState::Unknown),
       m_rawConfig(configuration),
       m_timeoutTimer(new QTimer(this)),
+      m_lastError(ErrorCode::NoError),
       m_receivedBytes(0),
       m_sentBytes(0)
 {

--- a/client/core/utils/networkUtilities.cpp
+++ b/client/core/utils/networkUtilities.cpp
@@ -53,7 +53,8 @@ QRegularExpression NetworkUtilities::ipAddressRegExp()
 QRegExp NetworkUtilities::ipAddressWithSubnetRegExp()
 {
     return QRegExp("(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\\.){3}"
-                   "(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])(\\/[0-9]{1,2}){0,1}");
+                   "(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])"
+                   "(\\/(?:[0-9]|[1-2][0-9]|3[0-2])){0,1}");
 }
 
 QRegExp NetworkUtilities::ipNetwork24RegExp()
@@ -78,12 +79,16 @@ QString NetworkUtilities::netMaskFromIpWithSubnet(const QString ip)
     if (!ip.contains("/"))
         return "255.255.255.255";
 
-    bool ok;
-    int prefix = ip.split("/").at(1).toInt(&ok);
-    if (!ok)
+    const QStringList parts = ip.split("/");
+    if (parts.size() < 2)
         return "255.255.255.255";
 
-    unsigned long mask = (0xFFFFFFFF << (32 - prefix)) & 0xFFFFFFFF;
+    bool ok;
+    int prefix = parts.at(1).toInt(&ok);
+    if (!ok || prefix < 0 || prefix > 32)
+        return "255.255.255.255";
+
+    const quint32 mask = prefix == 0 ? 0 : 0xFFFFFFFFu << (32 - prefix);
 
     return QString("%1.%2.%3.%4").arg(mask >> 24).arg((mask >> 16) & 0xFF).arg((mask >> 8) & 0xFF).arg(mask & 0xFF);
 }

--- a/client/vpnConnection.cpp
+++ b/client/vpnConnection.cpp
@@ -37,7 +37,11 @@
 using namespace ProtocolUtils;
 
 VpnConnection::VpnConnection(SecureServersRepository* serversRepository, SecureAppSettingsRepository* appSettingsRepository, QObject *parent)
-    : QObject(parent), m_serversRepository(serversRepository), m_appSettingsRepository(appSettingsRepository), m_checkTimer(this)
+    : QObject(parent),
+      m_serversRepository(serversRepository),
+      m_appSettingsRepository(appSettingsRepository),
+      m_checkTimer(this),
+      m_connectionState(Vpn::ConnectionState::Disconnected)
 {
 #if defined(Q_OS_IOS) || defined(MACOS_NE)
     m_checkTimer.setInterval(1000);
@@ -420,12 +424,13 @@ void VpnConnection::appendSplitTunnelingConfig()
             auto nativeConfig = configData.value(configKey::config).toString();
             auto nativeConfigLines = nativeConfig.split("\n");
             for (auto &line : nativeConfigLines) {
-                if (line.contains("AllowedIPs")) {
-                    auto allowedIpsString = line.split(" = ");
-                    if (allowedIpsString.size() < 1) {
-                        break;
+                auto allowedIpsString = line.split("=", Qt::KeepEmptyParts);
+                if (allowedIpsString.size() >= 2 && allowedIpsString.first().trimmed() == QStringLiteral("AllowedIPs")) {
+                    QJsonArray allowedIpsJsonArray;
+                    const QString allowedIps = allowedIpsString.mid(1).join(QStringLiteral("=")).trimmed();
+                    for (const QString &allowedIp : allowedIps.split(",", Qt::SkipEmptyParts)) {
+                        allowedIpsJsonArray.append(allowedIp.trimmed());
                     }
-                    QJsonArray allowedIpsJsonArray = QJsonArray::fromStringList(allowedIpsString.at(1).split(", "));
                     configData.insert(configKey::allowedIps, allowedIpsJsonArray);
                     m_vpnConfiguration.insert(protocolName + "_config_data", configData);
                     break;
@@ -437,12 +442,12 @@ void VpnConnection::appendSplitTunnelingConfig()
             auto nativeConfig = configData.value(configKey::config).toString();
             auto nativeConfigLines = nativeConfig.split("\n");
             for (auto &line : nativeConfigLines) {
-                if (line.contains("PersistentKeepalive")) {
-                    auto persistentKeepaliveString = line.split(" = ");
-                    if (persistentKeepaliveString.size() > 1) {
-                        configData.insert(configKey::persistentKeepAlive, persistentKeepaliveString.at(1));
-                        m_vpnConfiguration.insert(protocolName + "_config_data", configData);
-                    }
+                auto persistentKeepaliveString = line.split("=", Qt::KeepEmptyParts);
+                if (persistentKeepaliveString.size() >= 2
+                        && persistentKeepaliveString.first().trimmed() == QStringLiteral("PersistentKeepalive")) {
+                    configData.insert(configKey::persistentKeepAlive,
+                                      persistentKeepaliveString.mid(1).join(QStringLiteral("=")).trimmed());
+                    m_vpnConfiguration.insert(protocolName + "_config_data", configData);
                     break;
                 }
             }

--- a/service/server/killswitch.cpp
+++ b/service/server/killswitch.cpp
@@ -318,7 +318,7 @@ bool KillSwitch::enableKillSwitch(const QJsonObject &configStr, int vpnAdapterIn
     LinuxFirewall::setAnchorEnabled(LinuxFirewall::Both, QStringLiteral("100.blockAll"), blockAll);
     LinuxFirewall::setAnchorEnabled(LinuxFirewall::IPv4, QStringLiteral("110.allowNets"), allowNets);
     LinuxFirewall::updateAllowNets(allownets);
-    LinuxFirewall::setAnchorEnabled(LinuxFirewall::IPv4, QStringLiteral("120.blockNets"), blockAll);
+    LinuxFirewall::setAnchorEnabled(LinuxFirewall::IPv4, QStringLiteral("120.blockNets"), blockNets);
     LinuxFirewall::updateBlockNets(blocknets);
     LinuxFirewall::setAnchorEnabled(LinuxFirewall::Both, QStringLiteral("130.allowMarkedXray"), true);
     LinuxFirewall::setAnchorEnabled(LinuxFirewall::IPv4, QStringLiteral("200.allowVPN"), true);

--- a/service/server/router_linux.cpp
+++ b/service/server/router_linux.cpp
@@ -269,11 +269,11 @@ bool RouterLinux::deleteTun(const QString &dev)
     ret = send(rtnl, &req, req.nh.nlmsg_len, 0);
     if (ret < 0)
         qDebug().noquote() << "can't send: errno";
-    ret = (unsigned int)ret != req.nh.nlmsg_len;
+    const bool success = (unsigned int)ret == req.nh.nlmsg_len;
 
     close(rtnl);
-    qDebug().noquote() << "deleteTun ret" << ret;
-    return ret;
+    qDebug().noquote() << "deleteTun ret" << success;
+    return success;
 }
 
 bool RouterLinux::updateResolvers(const QString& ifname, const QList<QHostAddress>& resolvers)


### PR DESCRIPTION
## Summary

- Accept WireGuard native configs that use `Key=Value` formatting and split `AllowedIPs` regardless of whitespace around commas.
- Reject malformed Xray configs that only contain `inbounds`/`outbounds` text but are not valid JSON objects with those arrays.
- Make legacy WG/AWG native config parsing tolerate `=` formatting without crashing on missing values.
- Initialize VPN connection/error state and fix Linux route/killswitch edge cases.

## Root cause

Several import and route paths assumed narrow formatting or uninitialized state: WireGuard parsers required literal `" = "`, Xray import did substring detection before JSON validation, CIDR mask generation accepted invalid prefixes, Linux block-net rules used the wrong flag, and `deleteTun()` inverted the netlink send result.

## Validation

- `git diff --check origin/dev...HEAD`
- `cmake -S . -B %TEMP%/amnezia-client-cmake-verify -DPREBUILTS_ONLY=ON` was attempted with Conan available in a temp venv. Configure reached Conan package resolution/build and then failed in the existing Windows OpenVPN recipe with `No message compiler found`, before project compilation.