### PR TITLE
fix: remove unused launchd socket listener on TCP port 5959 (macOS)

### DIFF
--- a/deploy/data/macos/AmneziaVPN.plist
+++ b/deploy/data/macos/AmneziaVPN.plist
@@ -14,17 +14,5 @@
     <true/>
     <key>GroupName</key>
     <string>amnvpn</string>
-    <key>Sockets</key>
-	<dict>
-	    <key>Listeners</key>
-	    <dict>
-	        <key>SockServiceName</key>
-                <string>5959</string>
-	        <key>SockType</key>
-	        <string>stream</string>
-	        <key>SockFamily</key>
-	        <string>IPv4</string>
-	    </dict>
-	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
## Problem

On macOS, after installing AmneziaVPN, TCP port **5959** is open as **root on all interfaces** (`*:5959`):

```
$ sudo lsof -iTCP:5959 -sTCP:LISTEN
COMMAND PID USER   TYPE NAME
launchd   1 root   IPv4 *:5959 (LISTEN)
```

The cause is the `Sockets`/`Listeners` section in `deploy/data/macos/AmneziaVPN.plist` (present since the original installer commit a2a5caf, Dec 2020). It tells launchd to open a TCP socket on port 5959 on behalf of `AmneziaVPN-service`. Since no `SockNodeName` is specified, launchd binds to the wildcard address — the port is reachable from the local network.

## Why it is dead config

- **The service never takes ownership of the socket.** There is no `launch_activate_socket()` / liblaunch check-in anywhere in the codebase (including vendored code), and no code references port 5959 at all.
- **All GUI ↔ service IPC uses local unix domain sockets**, not TCP: `QLocalServer` on `amnezia::getIpcServiceUrl()` → `/tmp/local:AmneziaVpnIpcInterface` (`ipc/ipc.h`, `service/server/localserver.cpp`), client side via QtRemoteObjects `local:` URLs (`client/core/utils/ipcClient.cpp`). The QtService control channel (`service/src/qtunixserversocket.cpp`) is also an `AF_UNIX` socket despite subclassing `QTcpServer`.
- **Socket activation is not used even conceptually**: the daemon has plain `KeepAlive=true` + `RunAtLoad=true`, so launchd starts it at boot and keeps it running regardless of the `Sockets` key.

## Impact of the leftover

- Unnecessary attack surface: a root-owned listening port exposed to the LAN (connections queue in launchd's accept backlog and are never serviced).
- Trivial network fingerprinting of machines running AmneziaVPN — undesirable for a censorship-circumvention tool.

## Fix

Remove the `Sockets` dict from the plist. Verified:

- `plutil -lint` passes.
- `post_install.sh` / `post_uninstall.sh` and `cmake/CPack.cmake` treat the plist as an opaque file (copy/`launchctl bootstrap` by label) and do not depend on the `Sockets` key.
- With `KeepAlive=true` + `RunAtLoad=true` the daemon lifecycle is unchanged; only the dangling wildcard listener disappears.
