### PR TITLE
Fix Windows site split tunneling for multi-address hostnames

### DIFF
--- a/client/platforms/windows/daemon/wireguardutilswindows.cpp
+++ b/client/platforms/windows/daemon/wireguardutilswindows.cpp
@@ -187,8 +187,12 @@ bool WireguardUtilsWindows::updatePeer(const InterfaceConfig& config) {
 
   // Exclude the server address, except for multihop exit servers.
   if (m_routeMonitor && config.m_hopType != InterfaceConfig::MultiHopExit) {
-    m_routeMonitor->addExclusionRoute(IPAddress(config.m_serverIpv4AddrIn));
-    m_routeMonitor->addExclusionRoute(IPAddress(config.m_serverIpv6AddrIn));
+    if (!config.m_serverIpv4AddrIn.isEmpty()) {
+      m_routeMonitor->addExclusionRoute(IPAddress(config.m_serverIpv4AddrIn));
+    }
+    if (!config.m_serverIpv6AddrIn.isEmpty()) {
+      m_routeMonitor->addExclusionRoute(IPAddress(config.m_serverIpv6AddrIn));
+    }
   }
 
   QString reply = m_tunnel.uapiCommand(message);

--- a/client/vpnConnection.cpp
+++ b/client/vpnConnection.cpp
@@ -6,6 +6,7 @@
 #include <QHostInfo>
 #include <QJsonObject>
 #include <QObject>
+#include <QSet>
 #include <QSharedPointer>
 #include <QString>
 #include <QStringList>
@@ -35,6 +36,29 @@
 
 using namespace ProtocolUtils;
 
+#ifdef Q_OS_WIN
+namespace
+{
+constexpr int SiteDnsLookupConcurrency = 64;
+constexpr int SiteDnsLookupTimeoutMs = 15000;
+}
+
+struct VpnConnection::SiteResolutionState
+{
+    DockerContainer container;
+    amnezia::RouteMode routeMode = amnezia::RouteMode::VpnAllSites;
+    QJsonObject vpnConfiguration;
+    QStringList hostnames;
+    QStringList resolvedIpv4Addresses;
+    QSet<int> lookupIds;
+    int nextHostnameIndex = 0;
+    int activeLookups = 0;
+    int completedLookups = 0;
+    int failedLookups = 0;
+    bool finished = false;
+};
+#endif
+
 VpnConnection::VpnConnection(SecureServersRepository* serversRepository, SecureAppSettingsRepository* appSettingsRepository, QObject *parent)
     : QObject(parent), m_serversRepository(serversRepository), m_appSettingsRepository(appSettingsRepository), m_checkTimer(this)
 {
@@ -47,6 +71,9 @@ VpnConnection::VpnConnection(SecureServersRepository* serversRepository, SecureA
 
 VpnConnection::~VpnConnection()
 {
+#ifdef Q_OS_WIN
+    cancelSiteDnsResolution();
+#endif
 }
 
 void VpnConnection::onBytesChanged(quint64 receivedBytes, quint64 sentBytes)
@@ -215,9 +242,11 @@ void VpnConnection::addSitesRoutes(const QString &gw, amnezia::RouteMode mode)
         if (NetworkUtilities::checkIpSubnetFormat(i.key())) {
             ips.append(i.key());
         } else {
+#ifndef Q_OS_WIN
             if (NetworkUtilities::checkIpSubnetFormat(i.value().toString())) {
                 ips.append(i.value().toString());
             }
+#endif
             sites.append(i.key());
         }
     }
@@ -229,26 +258,53 @@ void VpnConnection::addSitesRoutes(const QString &gw, amnezia::RouteMode mode)
 
     // re-resolve domains
     for (const QString &site : sites) {
-        const auto &cbResolv = [this, site, gw, mode, ips](const QHostInfo &hostInfo) {
-            const QList<QHostAddress> &addresses = hostInfo.addresses();
-            QString ipv4Addr;
+        const auto cbResolv = [this, site, gw, mode, ips](const QHostInfo &hostInfo) {
+            if (hostInfo.error() != QHostInfo::NoError) {
+                qWarning() << "VpnConnection::addSitesRoutes: failed to resolve" << site
+                           << hostInfo.errorString();
+                return;
+            }
+
+            QStringList ipv4Addresses;
             for (const QHostAddress &addr : hostInfo.addresses()) {
                 if (addr.protocol() == QAbstractSocket::NetworkLayerProtocol::IPv4Protocol) {
-                    const QString &ip = addr.toString();
-                    // qDebug() << "VpnConnection::addSitesRoutes updating site" << site << ip;
-                    if (!ips.contains(ip)) {
-                        IpcClient::withInterface([&gw, &ip](QSharedPointer<IpcInterfaceReplica> iface) {
-                            iface->routeAddList(gw, QStringList() << ip);
-                        });
-                        m_appSettingsRepository->addVpnSite(mode, site, ip);
-                    }
-                    IpcClient::withInterface([](QSharedPointer<IpcInterfaceReplica> iface) {
-                        auto reply = iface->flushDns();
-                        if (reply.waitForFinished() || !reply.returnValue())
-                            qWarning() << "VpnConnection::addSitesRoutes: Failed to flush DNS";
-                    });
-                    break;
+                    ipv4Addresses.append(addr.toString());
                 }
+            }
+            ipv4Addresses.removeDuplicates();
+
+            if (ipv4Addresses.isEmpty()) {
+                qWarning() << "VpnConnection::addSitesRoutes: no IPv4 address for" << site;
+                return;
+            }
+
+            QStringList addressesForRoutes = ipv4Addresses;
+#ifndef Q_OS_WIN
+            if (addressesForRoutes.size() > 1) {
+                addressesForRoutes = { addressesForRoutes.constFirst() };
+            }
+#endif
+
+            QStringList addressesToAdd;
+            for (const QString &address : addressesForRoutes) {
+                if (!ips.contains(address)) {
+                    addressesToAdd.append(address);
+                }
+            }
+            addressesToAdd.removeDuplicates();
+
+            if (!addressesToAdd.isEmpty()) {
+                IpcClient::withInterface([gw, addressesToAdd](QSharedPointer<IpcInterfaceReplica> iface) {
+                    iface->routeAddList(gw, addressesToAdd);
+                });
+
+                // Keep the existing single-IP settings format for JSON compatibility.
+                m_appSettingsRepository->addVpnSite(mode, site, addressesToAdd.constFirst());
+                IpcClient::withInterface([](QSharedPointer<IpcInterfaceReplica> iface) {
+                    auto reply = iface->flushDns();
+                    if (!reply.waitForFinished() || !reply.returnValue())
+                        qWarning() << "VpnConnection::addSitesRoutes: Failed to flush DNS";
+                });
             }
         };
         QHostInfo::lookupHost(site, this, cbResolv);
@@ -302,6 +358,154 @@ void VpnConnection::connectToVpn(const QString &serverId, DockerContainer contai
     m_remoteAddress = NetworkUtilities::getIPAddress(vpnConfiguration.value(configKey::hostName).toString());
     setConnectionState(Vpn::ConnectionState::Connecting);
 
+#ifdef Q_OS_WIN
+    cancelSiteDnsResolution();
+    if (m_appSettingsRepository->isSitesSplitTunnelingEnabled()
+        && m_appSettingsRepository->routeMode() != amnezia::RouteMode::VpnAllSites) {
+        resolveSiteAddressesAndConnect(container, vpnConfiguration);
+        return;
+    }
+#endif
+
+    continueConnectToVpn(container, vpnConfiguration, {}, false);
+}
+
+#ifdef Q_OS_WIN
+void VpnConnection::resolveSiteAddressesAndConnect(DockerContainer container, const QJsonObject &vpnConfiguration)
+{
+    auto state = QSharedPointer<SiteResolutionState>::create();
+    state->container = container;
+    state->vpnConfiguration = vpnConfiguration;
+
+    state->routeMode = m_appSettingsRepository->routeMode();
+    const QVariantMap sites = m_appSettingsRepository->vpnSites(state->routeMode);
+    for (auto it = sites.constBegin(); it != sites.constEnd(); ++it) {
+        if (NetworkUtilities::checkIpSubnetFormat(it.key())) {
+            state->resolvedIpv4Addresses.append(it.key());
+        } else {
+            state->hostnames.append(it.key());
+        }
+    }
+    state->hostnames.removeDuplicates();
+    state->resolvedIpv4Addresses.removeDuplicates();
+
+    qDebug() << "VpnConnection: resolving site split tunneling hostnames"
+             << "routeMode=" << state->routeMode
+             << "hostnameCount=" << state->hostnames.size()
+             << "explicitAddressCount=" << state->resolvedIpv4Addresses.size();
+
+    m_siteResolutionState = state;
+
+    QTimer::singleShot(SiteDnsLookupTimeoutMs, this, [this, state]() {
+        if (m_siteResolutionState == state && !state->finished) {
+            finishSiteDnsResolution(state, true);
+        }
+    });
+
+    startSiteDnsLookups(state);
+}
+
+void VpnConnection::startSiteDnsLookups(const QSharedPointer<SiteResolutionState> &state)
+{
+    if (m_siteResolutionState != state || state->finished) {
+        return;
+    }
+
+    while (state->activeLookups < SiteDnsLookupConcurrency
+           && state->nextHostnameIndex < state->hostnames.size()) {
+        const QString hostname = state->hostnames.at(state->nextHostnameIndex++);
+        state->activeLookups++;
+
+        const int lookupId = QHostInfo::lookupHost(hostname, this, [this, state](const QHostInfo &hostInfo) {
+            if (m_siteResolutionState != state || state->finished) {
+                return;
+            }
+
+            state->lookupIds.remove(hostInfo.lookupId());
+            state->activeLookups--;
+            state->completedLookups++;
+
+            QStringList ipv4Addresses;
+            for (const QHostAddress &address : hostInfo.addresses()) {
+                if (address.protocol() == QAbstractSocket::IPv4Protocol) {
+                    ipv4Addresses.append(address.toString());
+                }
+            }
+            ipv4Addresses.removeDuplicates();
+
+            if (hostInfo.error() != QHostInfo::NoError || ipv4Addresses.isEmpty()) {
+                state->failedLookups++;
+            } else {
+                state->resolvedIpv4Addresses.append(ipv4Addresses);
+            }
+
+            startSiteDnsLookups(state);
+        });
+        state->lookupIds.insert(lookupId);
+    }
+
+    if (state->activeLookups == 0 && state->nextHostnameIndex >= state->hostnames.size()) {
+        finishSiteDnsResolution(state, false);
+    }
+}
+
+void VpnConnection::finishSiteDnsResolution(const QSharedPointer<SiteResolutionState> &state, bool timedOut)
+{
+    if (m_siteResolutionState != state || state->finished) {
+        return;
+    }
+
+    state->finished = true;
+    const QSet<int> lookupIds = state->lookupIds;
+    for (int lookupId : lookupIds) {
+        QHostInfo::abortHostLookup(lookupId);
+    }
+    state->lookupIds.clear();
+    state->resolvedIpv4Addresses.removeDuplicates();
+
+    qDebug() << "VpnConnection: site split DNS resolution finished"
+             << "timedOut=" << timedOut
+             << "requestedHostnames=" << state->hostnames.size()
+             << "completedLookups=" << state->completedLookups
+             << "failedLookups=" << state->failedLookups
+             << "resolvedAddressCount=" << state->resolvedIpv4Addresses.size();
+
+    const DockerContainer container = state->container;
+    const QJsonObject vpnConfiguration = state->vpnConfiguration;
+    const QStringList resolvedSiteAddresses = state->resolvedIpv4Addresses;
+    m_siteResolutionState.clear();
+
+    if (m_appSettingsRepository->isSitesSplitTunnelingEnabled()
+        && m_appSettingsRepository->routeMode() != state->routeMode) {
+        qDebug() << "VpnConnection: route mode changed during DNS resolution; restarting resolution";
+        resolveSiteAddressesAndConnect(container, vpnConfiguration);
+        return;
+    }
+
+    continueConnectToVpn(container, vpnConfiguration, resolvedSiteAddresses, true);
+}
+
+void VpnConnection::cancelSiteDnsResolution()
+{
+    if (m_siteResolutionState.isNull()) {
+        return;
+    }
+
+    const auto state = m_siteResolutionState;
+    state->finished = true;
+    const QSet<int> lookupIds = state->lookupIds;
+    for (int lookupId : lookupIds) {
+        QHostInfo::abortHostLookup(lookupId);
+    }
+    state->lookupIds.clear();
+    m_siteResolutionState.clear();
+}
+#endif
+
+void VpnConnection::continueConnectToVpn(DockerContainer container, const QJsonObject &vpnConfiguration,
+                                         const QStringList &resolvedSiteAddresses,
+                                         bool useResolvedSiteAddresses)
+{
     m_vpnConfiguration = vpnConfiguration;
 
 #ifdef AMNEZIA_DESKTOP
@@ -313,7 +517,12 @@ void VpnConnection::connectToVpn(const QString &serverId, DockerContainer contai
     appendKillSwitchConfig();
 #endif
 
-    appendSplitTunnelingConfig();
+    if (!appendSplitTunnelingConfig(resolvedSiteAddresses, useResolvedSiteAddresses)) {
+        qCritical() << "VpnConnection::connectToVpn: site split tunneling has no valid IPv4 addresses";
+        setConnectionState(Vpn::ConnectionState::Error);
+        emit vpnProtocolError(ErrorCode::InternalError);
+        return;
+    }
 
 #if !defined(Q_OS_ANDROID) && !defined(Q_OS_IOS) && !defined(MACOS_NE)
     m_vpnProtocol.reset(VpnProtocol::factory(container, m_vpnConfiguration));
@@ -367,11 +576,11 @@ void VpnConnection::appendKillSwitchConfig()
     m_vpnConfiguration.insert(configKey::allowedDnsServers, QVariant(m_appSettingsRepository->getAllowedDnsServers()).toJsonValue());
 }
 
-void VpnConnection::appendSplitTunnelingConfig()
+bool VpnConnection::appendSplitTunnelingConfig(const QStringList &resolvedSiteAddresses, bool useResolvedSiteAddresses)
 {
     if (!m_appSettingsRepository) {
         qCritical() << "VpnConnection::appendSplitTunnelingConfig: repositories not initialized";
-        return;
+        return false;
     }
 
     bool allowSiteBasedSplitTunneling = true;
@@ -429,15 +638,27 @@ void VpnConnection::appendSplitTunnelingConfig()
     if (m_appSettingsRepository->isSitesSplitTunnelingEnabled()) {
         routeMode = m_appSettingsRepository->routeMode();
 
+#ifdef Q_OS_WIN
+        if (!allowSiteBasedSplitTunneling) {
+            qCritical() << "VpnConnection: site split tunneling is not supported by this VPN configuration";
+            return false;
+        }
+#endif
+
         if (allowSiteBasedSplitTunneling) {
             QStringList sites;
             const QVariantMap &m = m_appSettingsRepository->vpnSites(routeMode);
             for (auto i = m.constBegin(); i != m.constEnd(); ++i) {
-                if (NetworkUtilities::checkIpSubnetFormat(i.key())) {
-                    sites.append(i.key());
-                } else if (NetworkUtilities::checkIpSubnetFormat(i.value().toString())) {
-                    sites.append(i.value().toString());
+                if (!useResolvedSiteAddresses) {
+                    if (NetworkUtilities::checkIpSubnetFormat(i.key())) {
+                        sites.append(i.key());
+                    } else if (NetworkUtilities::checkIpSubnetFormat(i.value().toString())) {
+                        sites.append(i.value().toString());
+                    }
                 }
+            }
+            if (useResolvedSiteAddresses) {
+                sites = resolvedSiteAddresses;
             }
             sites.removeDuplicates();
             for (const auto &site : sites) {
@@ -445,11 +666,27 @@ void VpnConnection::appendSplitTunnelingConfig()
             }
 
             if (sitesJsonArray.isEmpty()) {
+#ifdef Q_OS_WIN
+                qCritical() << "VpnConnection: no valid site addresses; refusing to fall back to VpnAllSites";
+                return false;
+#else
                 routeMode = amnezia::RouteMode::VpnAllSites;
+#endif
             } else if (routeMode == amnezia::RouteMode::VpnOnlyForwardSites) {
                 // Allow traffic to Amnezia DNS
+#ifdef Q_OS_WIN
+                const QString dns1 = m_vpnConfiguration.value(configKey::dns1).toString();
+                const QString dns2 = m_vpnConfiguration.value(configKey::dns2).toString();
+                if (NetworkUtilities::checkIpSubnetFormat(dns1)) {
+                    sitesJsonArray.append(dns1);
+                }
+                if (NetworkUtilities::checkIpSubnetFormat(dns2)) {
+                    sitesJsonArray.append(dns2);
+                }
+#else
                 sitesJsonArray.append(m_vpnConfiguration.value(configKey::dns1).toString());
                 sitesJsonArray.append(m_vpnConfiguration.value(configKey::dns2).toString());
+#endif
             }
         }
     }
@@ -481,6 +718,8 @@ void VpnConnection::appendSplitTunnelingConfig()
     qDebug() << QString("App split tunneling is %1, route mode is %2")
                         .arg(m_appSettingsRepository->isAppsSplitTunnelingEnabled() ? "enabled" : "disabled")
                         .arg(appsRouteMode);
+
+    return true;
 }
 
 #ifdef Q_OS_ANDROID
@@ -537,6 +776,10 @@ void VpnConnection::reconnectToVpn() {
 
 void VpnConnection::disconnectFromVpn()
 {
+#ifdef Q_OS_WIN
+    cancelSiteDnsResolution();
+#endif
+
 #if defined(Q_OS_IOS) || defined(MACOS_NE)
     // iOS/macOS NE use IosController directly; m_vpnProtocol is not set there.
     IosController::Instance()->disconnectVpn();

--- a/client/vpnConnection.cpp
+++ b/client/vpnConnection.cpp
@@ -155,20 +155,21 @@ void VpnConnection::onConnectionStateChanged(Vpn::ConnectionState state)
                     qWarning() << "VpnConnection::onConnectionStateChanged: Failed to flush DNS";
 
                 if (!ContainerUtils::isAwgContainer(container) && container != DockerContainer::WireGuard) {
+                    const auto routeMode = static_cast<amnezia::RouteMode>(
+                        m_vpnConfiguration.value(configKey::splitTunnelType).toInt());
                     QString dns1 = m_vpnConfiguration.value(configKey::dns1).toString();
                     QString dns2 = m_vpnConfiguration.value(configKey::dns2).toString();
 
 #ifdef Q_OS_MACOS
-                    if (!m_appSettingsRepository->isSitesSplitTunnelingEnabled() || m_appSettingsRepository->routeMode() != amnezia::RouteMode::VpnAllExceptSites) {
+                    if (routeMode != amnezia::RouteMode::VpnAllExceptSites) {
                         iface->routeAddList(m_vpnProtocol->vpnGateway(), QStringList() << dns1 << dns2);
                     }
 #else
                     iface->routeAddList(m_vpnProtocol->vpnGateway(), QStringList() << dns1 << dns2);
 #endif
 
-                    if (m_appSettingsRepository->isSitesSplitTunnelingEnabled()) {
+                    if (routeMode != amnezia::RouteMode::VpnAllSites) {
                         iface->routeDeleteList(m_vpnProtocol->vpnGateway(), QStringList() << "0.0.0.0");
-                        RouteMode routeMode = m_appSettingsRepository->routeMode();
                         if (routeMode == amnezia::RouteMode::VpnOnlyForwardSites) {
                             QTimer::singleShot(1000, m_vpnProtocol.data(),
                                                [this, routeMode]() { addSitesRoutes(m_vpnProtocol->vpnGateway(), routeMode); });
@@ -475,8 +476,15 @@ void VpnConnection::finishSiteDnsResolution(const QSharedPointer<SiteResolutionS
     const QStringList resolvedSiteAddresses = state->resolvedIpv4Addresses;
     m_siteResolutionState.clear();
 
-    if (m_appSettingsRepository->isSitesSplitTunnelingEnabled()
-        && m_appSettingsRepository->routeMode() != state->routeMode) {
+    const bool siteSplitTunnelingEnabled = m_appSettingsRepository->isSitesSplitTunnelingEnabled();
+    const auto currentRouteMode = m_appSettingsRepository->routeMode();
+    if (!siteSplitTunnelingEnabled || currentRouteMode == amnezia::RouteMode::VpnAllSites) {
+        qDebug() << "VpnConnection: site split tunneling disabled or switched to full tunnel during DNS resolution";
+        continueConnectToVpn(container, vpnConfiguration, {}, false);
+        return;
+    }
+
+    if (currentRouteMode != state->routeMode) {
         qDebug() << "VpnConnection: route mode changed during DNS resolution; restarting resolution";
         resolveSiteAddressesAndConnect(container, vpnConfiguration);
         return;
@@ -635,8 +643,12 @@ bool VpnConnection::appendSplitTunnelingConfig(const QStringList &resolvedSiteAd
 
     amnezia::RouteMode routeMode = amnezia::RouteMode::VpnAllSites;
     QJsonArray sitesJsonArray;
-    if (m_appSettingsRepository->isSitesSplitTunnelingEnabled()) {
-        routeMode = m_appSettingsRepository->routeMode();
+    const bool siteSplitTunnelingEnabled = m_appSettingsRepository->isSitesSplitTunnelingEnabled();
+    const auto configuredRouteMode = m_appSettingsRepository->routeMode();
+    const bool siteSplitTunnelingActive =
+        siteSplitTunnelingEnabled && configuredRouteMode != amnezia::RouteMode::VpnAllSites;
+    if (siteSplitTunnelingActive) {
+        routeMode = configuredRouteMode;
 
 #ifdef Q_OS_WIN
         if (!allowSiteBasedSplitTunneling) {
@@ -713,7 +725,7 @@ bool VpnConnection::appendSplitTunnelingConfig(const QStringList &resolvedSiteAd
     m_vpnConfiguration.insert(configKey::splitTunnelApps, appsJsonArray);
 
     qDebug() << QString("Site split tunneling is %1, route mode is %2")
-                        .arg(m_appSettingsRepository->isSitesSplitTunnelingEnabled() ? "enabled" : "disabled")
+                        .arg(siteSplitTunnelingActive ? "enabled" : "disabled")
                         .arg(routeMode);
     qDebug() << QString("App split tunneling is %1, route mode is %2")
                         .arg(m_appSettingsRepository->isAppsSplitTunnelingEnabled() ? "enabled" : "disabled")

--- a/client/vpnConnection.h
+++ b/client/vpnConnection.h
@@ -7,6 +7,7 @@
 #include <QScopedPointer>
 #include <QRemoteObjectNode>
 #include <QTimer>
+#include <QStringList>
 
 #include "core/protocols/vpnProtocol.h"
 #include "core/utils/errorCodes.h"
@@ -73,6 +74,10 @@ protected:
     QSharedPointer<VpnProtocol> m_vpnProtocol;
 
 private:
+#ifdef Q_OS_WIN
+    struct SiteResolutionState;
+#endif
+
     SecureServersRepository* m_serversRepository;
     SecureAppSettingsRepository* m_appSettingsRepository;
 
@@ -90,12 +95,24 @@ private:
    void createAndroidConnections();
 #endif
 
-   Vpn::ConnectionState m_connectionState;
+    Vpn::ConnectionState m_connectionState;
 
-   void createProtocolConnections();
+    void createProtocolConnections();
 
-   void appendSplitTunnelingConfig();
-   void appendKillSwitchConfig();
+    bool appendSplitTunnelingConfig(const QStringList &resolvedSiteAddresses = {}, bool useResolvedSiteAddresses = false);
+    void appendKillSwitchConfig();
+    void continueConnectToVpn(DockerContainer container, const QJsonObject &vpnConfiguration,
+                              const QStringList &resolvedSiteAddresses,
+                              bool useResolvedSiteAddresses);
+
+#ifdef Q_OS_WIN
+    QSharedPointer<SiteResolutionState> m_siteResolutionState;
+
+    void resolveSiteAddressesAndConnect(DockerContainer container, const QJsonObject &vpnConfiguration);
+    void startSiteDnsLookups(const QSharedPointer<SiteResolutionState> &state);
+    void finishSiteDnsResolution(const QSharedPointer<SiteResolutionState> &state, bool timedOut);
+    void cancelSiteDnsResolution();
+#endif
 };
 
 #endif // VPNCONNECTION_H


### PR DESCRIPTION
## Summary

Resolve site-based split tunneling hostnames before starting a VPN connection on Windows and pass all unique IPv4 addresses to the VPN configuration.

This prevents a single saved or imported address from being used as the only routing source for hostnames backed by multiple or changing IP addresses.

## Root cause

Site split tunneling settings store one IPv4 address per hostname for JSON compatibility.

On Windows, WireGuard and AmneziaWG configurations apply `splitTunnelSites` while the tunnel is being configured. Their post-connect hostname resolution path is not used, so the stored single address could become the only address included in the routing configuration.

For websites using separate page, API, CDN, and video endpoints, this could result in inconsistent routing and different external IPs being observed by different parts of the website.

## Changes

- Resolve site split tunneling hostnames before connecting on Windows.
- Collect and deduplicate all returned IPv4 addresses.
- Limit DNS lookup concurrency and apply an overall timeout.
- Continue when individual hostnames fail to resolve.
- Preserve explicit IP/subnet entries.
- Stop using the persisted single IP as the sole Windows routing source.
- Preserve the existing settings and JSON format.
- Refuse to silently fall back to full-tunnel routing when no valid site addresses are available.
- Route all resolved IPv4 addresses in the post-connect path where it is used.
- Use safe value captures in asynchronous callbacks.
- Cancel outstanding DNS lookups when starting a new connection, disconnecting, or destroying the connection.
- Re-resolve the list when the route mode changes during lookup.
- Preserve the full-tunnel path if site split tunneling is disabled or switched to `VpnAllSites` while DNS lookups are in progress.
- Skip invalid exclusion-route creation when a server IPv4 or IPv6 address is empty.

## Testing

- Built the Windows Release client successfully (`AmneziaVPN.exe`).
- Built the Windows Release service successfully (`AmneziaVPN-service.exe`).
- `git diff --check` passed.
- No CTest tests are registered in the current build configuration.

Diagnostic run:

- 924 hostnames requested.
- 913 hostnames resolved successfully.
- 712 unique IPv4 addresses collected.
- 152 hostnames returned multiple IPv4 addresses.
- 11 failed DNS lookups did not cancel the connection.
- DNS resolution completed without reaching the timeout.

## Manual verification

Tested on Windows 11 x64 with a self-hosted AmneziaWG server in the Netherlands and site-based split tunneling enabled in `VpnAllExceptSites` mode.

Results:

- VPN connection completed successfully.
- YouTube remained available with the VPN connected.
- Ozon opened successfully with the exclusion list enabled.
- The previously failing episode on `griffini.ru` played without the geo-restriction error.

## Full tunnel

The normal full-tunnel configuration path is unchanged. If settings switch to full tunnel during pre-connect DNS resolution, the resolved split-tunnel list is discarded and the ordinary full-tunnel configuration is used.

During split-tunnel verification, non-excluded traffic remained available through the VPN.

## Site-based split tunneling

Windows now builds the site address list from current DNS results before configuring the tunnel. Each new connection performs a new lookup instead of relying on an old persisted address.

## Scope

- Windows site-based split tunneling only.
- No UI changes.
- No app-based split tunneling changes.
- No split-tunnel driver changes.
- No hard-coded website domains.
- No wildcard support added.
- No dependency updates.
- Non-Windows routing remains single-address.

## Risks and limitations

- Site routing remains IPv4-only.
- The user-provided domain list must still contain all required page, API, CDN, and video hostnames.
- Wildcard domain discovery is not implemented.
- DNS changes during a long-running WireGuard/AmneziaWG connection are applied after disconnecting and starting a new connection; the internal reconnect path reuses the current configuration.
- Manual verification covered one Windows system and one self-hosted AmneziaWG server.
- A separate disconnect/new-connection test and external-IP snapshot were not included in the submitted logs.

Fixes #2797
