### PR TITLE
fix: skip on-link routes during Windows route capture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ project(${PROJECT} VERSION ${AMNEZIAVPN_VERSION}
         HOMEPAGE_URL "https://amnezia.org/"
 )
 
+include(CTest)
+
 # trigger conan to kick off `conan install` globally
 find_package(OpenSSL REQUIRED)
 if (PREBUILTS_ONLY)

--- a/client/platforms/windows/daemon/windowsroutecapturepolicy.h
+++ b/client/platforms/windows/daemon/windowsroutecapturepolicy.h
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef WINDOWSROUTECAPTUREPOLICY_H
+#define WINDOWSROUTECAPTUREPOLICY_H
+
+#include <winsock2.h>
+#include <WS2tcpip.h>
+#include <ws2ipdef.h>
+#include <windows.h>
+#include <iphlpapi.h>
+
+#include <cstring>
+
+namespace WindowsRouteCapturePolicy {
+
+inline bool isVpnInterfaceRoute(const MIB_IPFORWARD_ROW2* row,
+                                unsigned long long vpnLuid) {
+  return row->InterfaceLuid.Value == vpnLuid;
+}
+
+inline bool isDefaultRoute(const MIB_IPFORWARD_ROW2* row) {
+  return row->DestinationPrefix.PrefixLength == 0;
+}
+
+inline bool isRouteCreatedByMonitor(const MIB_IPFORWARD_ROW2* row,
+                                    ULONG monitorMetric) {
+  return row->Protocol == MIB_IPPROTO_NETMGMT && row->Metric == monitorMetric;
+}
+
+inline bool isIpv6Unspecified(const IN6_ADDR& address) {
+  static const IN6_ADDR unspecified = {};
+  return std::memcmp(&address, &unspecified, sizeof(unspecified)) == 0;
+}
+
+inline bool isOnLinkRoute(const MIB_IPFORWARD_ROW2* row) {
+  // Connected routes have no gateway. Capturing them into the VPN tunnel
+  // breaks LAN, Hyper-V, WSL, and other locally attached networks.
+  if (row->NextHop.si_family == AF_UNSPEC) {
+    return true;
+  }
+
+  if (row->NextHop.si_family == AF_INET) {
+    return row->NextHop.Ipv4.sin_addr.s_addr == 0;
+  }
+
+  if (row->NextHop.si_family == AF_INET6) {
+    return isIpv6Unspecified(row->NextHop.Ipv6.sin6_addr);
+  }
+
+  return false;
+}
+
+inline bool shouldCaptureRoute(const MIB_IPFORWARD_ROW2* row,
+                               unsigned long long vpnLuid,
+                               bool routeExcluded, ULONG monitorMetric) {
+  if (isVpnInterfaceRoute(row, vpnLuid)) {
+    return false;
+  }
+  if (isDefaultRoute(row)) {
+    return false;
+  }
+  if (isRouteCreatedByMonitor(row, monitorMetric)) {
+    return false;
+  }
+  if (routeExcluded) {
+    return false;
+  }
+  // Default-route capture should only clone routed prefixes. Directly
+  // connected prefixes must stay bound to their real local interfaces.
+  if (isOnLinkRoute(row)) {
+    return false;
+  }
+
+  return true;
+}
+
+}  // namespace WindowsRouteCapturePolicy
+
+#endif  // WINDOWSROUTECAPTUREPOLICY_H

--- a/client/platforms/windows/daemon/windowsroutemonitor.cpp
+++ b/client/platforms/windows/daemon/windowsroutemonitor.cpp
@@ -8,6 +8,7 @@
 
 #include "leakdetector.h"
 #include "logger.h"
+#include "windowsroutecapturepolicy.h"
 
 namespace {
 Logger logger("WindowsRouteMonitor");
@@ -259,9 +260,12 @@ void WindowsRouteMonitor::updateCapturedRoutes(int family) {
   PMIB_IPFORWARD_TABLE2 table;
   DWORD error = GetIpForwardTable2(family, &table);
   if (error != NO_ERROR) {
-    updateCapturedRoutes(family, table);
-    FreeMibTable(table);
+    logger.error() << "Failed to fetch routing table:" << error;
+    return;
   }
+
+  updateCapturedRoutes(family, table);
+  FreeMibTable(table);
 }
 
 void WindowsRouteMonitor::updateCapturedRoutes(int family, void* ptable) {
@@ -272,23 +276,12 @@ void WindowsRouteMonitor::updateCapturedRoutes(int family, void* ptable) {
 
   for (ULONG i = 0; i < table->NumEntries; i++) {
     MIB_IPFORWARD_ROW2* row = &table->Table[i];
-    // Ignore routes into the VPN interface.
-    if (row->InterfaceLuid.Value == m_luid) {
+    bool routeExcluded = isRouteExcluded(&row->DestinationPrefix);
+    if (!WindowsRouteCapturePolicy::shouldCaptureRoute(
+            row, m_luid, routeExcluded, EXCLUSION_ROUTE_METRIC)) {
       continue;
     }
-    // Ignore the default route
-    if (row->DestinationPrefix.PrefixLength == 0) {
-      continue;
-    }
-    // Ignore routes of our own creation.
-    if ((row->Protocol == MIB_IPPROTO_NETMGMT) &&
-        (row->Metric == EXCLUSION_ROUTE_METRIC)) {
-      continue;
-    }
-    // Ignore routes which should be excluded.
-    if (isRouteExcluded(&row->DestinationPrefix)) {
-      continue;
-    }
+
     QHostAddress destination = prefixToAddress(&row->DestinationPrefix);
     if (destination.isLoopback() || destination.isBroadcast() ||
         destination.isLinkLocal() || destination.isMulticast()) {
@@ -424,11 +417,11 @@ bool WindowsRouteMonitor::addExclusionRoute(const IPAddress& prefix) {
     return false;
   }
   updateInterfaceMetrics(family);
-  updateCapturedRoutes(family, table);
   updateExclusionRoute(data, table);
+  m_exclusionRoutes[prefix] = data;
+  updateCapturedRoutes(family, table);
   FreeMibTable(table);
 
-  m_exclusionRoutes[prefix] = data;
   return true;
 }
 

--- a/service/CMakeLists.txt
+++ b/service/CMakeLists.txt
@@ -9,3 +9,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if(NOT IOS AND NOT ANDROID AND NOT MACOS_NE)
     add_subdirectory(server)
 endif()
+
+if(WIN32 AND BUILD_TESTING)
+    add_subdirectory(tests)
+endif()

--- a/service/server/CMakeLists.txt
+++ b/service/server/CMakeLists.txt
@@ -141,6 +141,7 @@ if(WIN32)
         ${CMAKE_CURRENT_SOURCE_DIR}/../../client/platforms/windows/daemon/wireguardutilswindows.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../../client/platforms/windows/daemon/windowstunnellogger.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../../client/platforms/windows/daemon/windowsroutemonitor.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../client/platforms/windows/daemon/windowsroutecapturepolicy.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../../client/platforms/windows/windowsutils.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../../client/platforms/windows/windowspingsender.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../../client/platforms/windows/windowsnetworkwatcher.h

--- a/service/tests/CMakeLists.txt
+++ b/service/tests/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.25.0 FATAL_ERROR)
+
+find_package(Qt6 REQUIRED COMPONENTS Core Test)
+qt_standard_project_setup()
+
+qt_add_executable(windows_route_capture_policy_tests
+    windows_route_capture_policy_tests.cpp
+)
+
+target_include_directories(windows_route_capture_policy_tests PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/../../client/platforms/windows/daemon
+)
+
+target_link_libraries(windows_route_capture_policy_tests PRIVATE
+    Qt6::Core
+    Qt6::Test
+    iphlpapi
+    ws2_32
+)
+
+add_test(
+    NAME windows_route_capture_policy_tests
+    COMMAND windows_route_capture_policy_tests
+)

--- a/service/tests/windows_route_capture_policy_tests.cpp
+++ b/service/tests/windows_route_capture_policy_tests.cpp
@@ -1,0 +1,159 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "windowsroutecapturepolicy.h"
+
+#include <algorithm>
+#include <initializer_list>
+
+#include <QtTest/QtTest>
+
+namespace {
+
+constexpr quint64 VPN_LUID = 42;
+constexpr quint64 LAN_LUID = 7;
+constexpr ULONG MONITOR_METRIC = 0x5e72;
+
+MIB_IPFORWARD_ROW2 makeRoute(ADDRESS_FAMILY family = AF_INET) {
+  MIB_IPFORWARD_ROW2 row;
+  InitializeIpForwardEntry(&row);
+  row.InterfaceLuid.Value = LAN_LUID;
+  row.DestinationPrefix.PrefixLength = 24;
+  row.DestinationPrefix.Prefix.si_family = family;
+  row.NextHop.si_family = family;
+  row.Protocol = MIB_IPPROTO_NETMGMT;
+  row.Metric = 10;
+  return row;
+}
+
+void setIpv4NextHop(MIB_IPFORWARD_ROW2& row, ULONG address) {
+  row.NextHop.si_family = AF_INET;
+  row.NextHop.Ipv4.sin_addr.s_addr = htonl(address);
+}
+
+void setIpv6NextHop(MIB_IPFORWARD_ROW2& row, const IN6_ADDR& address) {
+  row.NextHop.si_family = AF_INET6;
+  row.NextHop.Ipv6.sin6_addr = address;
+}
+
+IN6_ADDR ipv6Address(std::initializer_list<unsigned char> bytes) {
+  IN6_ADDR address = {};
+  std::copy(bytes.begin(), bytes.end(), address.u.Byte);
+  return address;
+}
+
+}  // namespace
+
+class WindowsRouteCapturePolicyTests final : public QObject {
+  Q_OBJECT
+
+ private slots:
+  void capturesRoutedIpv4Prefix();
+  void capturesRoutedIpv6Prefix();
+  void skipsVpnInterfaceRoutes();
+  void skipsDefaultRoutes();
+  void skipsRoutesCreatedByMonitor();
+  void capturesSameMetricRoutesNotCreatedByMonitor();
+  void skipsExcludedRoutes();
+  void skipsOnLinkIpv4Routes();
+  void skipsOnLinkIpv6Routes();
+  void skipsUnspecifiedNextHopRoutes();
+};
+
+void WindowsRouteCapturePolicyTests::capturesRoutedIpv4Prefix() {
+  auto row = makeRoute();
+  setIpv4NextHop(row, 0xc0a80101);
+
+  QVERIFY(WindowsRouteCapturePolicy::shouldCaptureRoute(
+      &row, VPN_LUID, false, MONITOR_METRIC));
+}
+
+void WindowsRouteCapturePolicyTests::capturesRoutedIpv6Prefix() {
+  auto row = makeRoute(AF_INET6);
+  row.DestinationPrefix.PrefixLength = 64;
+  setIpv6NextHop(row, ipv6Address({0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 1}));
+
+  QVERIFY(!WindowsRouteCapturePolicy::isOnLinkRoute(&row));
+  QVERIFY(WindowsRouteCapturePolicy::shouldCaptureRoute(
+      &row, VPN_LUID, false, MONITOR_METRIC));
+}
+
+void WindowsRouteCapturePolicyTests::skipsVpnInterfaceRoutes() {
+  auto row = makeRoute();
+  row.InterfaceLuid.Value = VPN_LUID;
+  setIpv4NextHop(row, 0xc0a80101);
+
+  QVERIFY(!WindowsRouteCapturePolicy::shouldCaptureRoute(
+      &row, VPN_LUID, false, MONITOR_METRIC));
+}
+
+void WindowsRouteCapturePolicyTests::skipsDefaultRoutes() {
+  auto row = makeRoute();
+  row.DestinationPrefix.PrefixLength = 0;
+  setIpv4NextHop(row, 0xc0a80101);
+
+  QVERIFY(!WindowsRouteCapturePolicy::shouldCaptureRoute(
+      &row, VPN_LUID, false, MONITOR_METRIC));
+}
+
+void WindowsRouteCapturePolicyTests::skipsRoutesCreatedByMonitor() {
+  auto row = makeRoute();
+  row.Metric = MONITOR_METRIC;
+  setIpv4NextHop(row, 0xc0a80101);
+
+  QVERIFY(!WindowsRouteCapturePolicy::shouldCaptureRoute(
+      &row, VPN_LUID, false, MONITOR_METRIC));
+}
+
+void WindowsRouteCapturePolicyTests::capturesSameMetricRoutesNotCreatedByMonitor() {
+  auto row = makeRoute();
+  row.Protocol = static_cast<NL_ROUTE_PROTOCOL>(0);
+  row.Metric = MONITOR_METRIC;
+  setIpv4NextHop(row, 0xc0a80101);
+
+  QVERIFY(!WindowsRouteCapturePolicy::isRouteCreatedByMonitor(
+      &row, MONITOR_METRIC));
+  QVERIFY(WindowsRouteCapturePolicy::shouldCaptureRoute(
+      &row, VPN_LUID, false, MONITOR_METRIC));
+}
+
+void WindowsRouteCapturePolicyTests::skipsExcludedRoutes() {
+  auto row = makeRoute();
+  setIpv4NextHop(row, 0xc0a80101);
+
+  QVERIFY(!WindowsRouteCapturePolicy::shouldCaptureRoute(
+      &row, VPN_LUID, true, MONITOR_METRIC));
+}
+
+void WindowsRouteCapturePolicyTests::skipsOnLinkIpv4Routes() {
+  auto row = makeRoute();
+  setIpv4NextHop(row, 0);
+
+  QVERIFY(WindowsRouteCapturePolicy::isOnLinkRoute(&row));
+  QVERIFY(!WindowsRouteCapturePolicy::shouldCaptureRoute(
+      &row, VPN_LUID, false, MONITOR_METRIC));
+}
+
+void WindowsRouteCapturePolicyTests::skipsOnLinkIpv6Routes() {
+  auto row = makeRoute(AF_INET6);
+  IN6_ADDR unspecified = {};
+  setIpv6NextHop(row, unspecified);
+
+  QVERIFY(WindowsRouteCapturePolicy::isOnLinkRoute(&row));
+  QVERIFY(!WindowsRouteCapturePolicy::shouldCaptureRoute(
+      &row, VPN_LUID, false, MONITOR_METRIC));
+}
+
+void WindowsRouteCapturePolicyTests::skipsUnspecifiedNextHopRoutes() {
+  auto row = makeRoute();
+  row.NextHop.si_family = AF_UNSPEC;
+
+  QVERIFY(WindowsRouteCapturePolicy::isOnLinkRoute(&row));
+  QVERIFY(!WindowsRouteCapturePolicy::shouldCaptureRoute(
+      &row, VPN_LUID, false, MONITOR_METRIC));
+}
+
+QTEST_APPLESS_MAIN(WindowsRouteCapturePolicyTests)
+
+#include "windows_route_capture_policy_tests.moc"


### PR DESCRIPTION
## Summary

Fix Windows route capture so AmneziaVPN does not clone directly connected local/on-link routes into the VPN interface during default-route capture.

When split tunneling/full-tunnel route capture is active, `WindowsRouteMonitor::updateCapturedRoutes()` currently clones non-default routes from the Windows route table to the VPN LUID with metric `0`. Connected LAN and local virtual-network routes have no gateway, so cloning them sends local traffic through `AmneziaVPN` instead of the real Ethernet/Wi-Fi/Hyper-V/WSL/VirtualBox interface.

This change keeps route capture for routed prefixes, but skips routes whose `NextHop` is on-link/unspecified.

Fixes amnezia-vpn/amnezia-client#2830

## Changes

- Add `WindowsRouteCapturePolicy`, a small testable helper for route-capture decisions.
- Skip routes from capture when they are:
  - already on the VPN interface;
  - default routes;
  - routes created by the route monitor itself;
  - explicitly excluded routes;
  - directly connected/on-link routes with no gateway (`AF_UNSPEC`, IPv4 `0.0.0.0`, or IPv6 `::`).
- Fix `WindowsRouteMonitor::updateCapturedRoutes(int family)` so it only uses the route table after `GetIpForwardTable2()` succeeds.
- Register a new exclusion route before rerunning captured-route cleanup, so the new exclusion is visible to `isRouteExcluded()` during that pass.
- Add Windows-only QtTest coverage for the route-capture policy.

## Why this does not hard-code local networks

The fix intentionally does not special-case RFC1918 ranges such as `192.168.0.0/16`, `10.0.0.0/8`, or `172.16.0.0/12`.

Local connected networks can be arbitrary: corporate routed ranges, CGNAT ranges, Hyper-V/WSL networks, VirtualBox host-only networks, public LAN prefixes, and other local adapters. Windows already marks connected routes by their missing/unspecified next hop, so the capture decision should use route semantics instead of address ranges.

## Edge cases covered by tests

`windows_route_capture_policy_tests` covers:

- routed IPv4 prefix is still captured;
- routed IPv6 prefix is still captured;
- VPN-interface routes are skipped;
- default routes are skipped;
- monitor-created routes are skipped;
- same metric with a different protocol is not accidentally skipped;
- explicitly excluded routes are skipped;
- IPv4 on-link routes (`0.0.0.0` next hop) are skipped;
- IPv6 on-link routes (`::` next hop) are skipped;
- `AF_UNSPEC` next-hop routes are skipped.

## Related PRs reviewed

- amnezia-vpn/amnezia-client#2516: overlaps with exclusion batching and ordering. It partially helps large split lists and registers batch exclusions before one capture pass, but does not skip directly connected/on-link routes.
- amnezia-vpn/amnezia-client#2555: changes `WindowsRouteMonitor` as part of locations/multi-tunnel work, but does not add an on-link route capture guard.
- amnezia-vpn/amnezia-client#2609: changes Windows route monitoring for IPv6/dual-stack, but does not address local connected route capture.
- amnezia-vpn/amnezia-client#2825: fixes Windows site split tunneling hostname resolution, but does not touch `WindowsRouteMonitor::updateCapturedRoutes()`.

## Verification

Passed:

```text
git diff --check
cl /nologo /std:c++17 /c /TP client\platforms\windows\daemon\windowsroutecapturepolicy.h
```

Not run locally:

```text
cmake -S . -B build-route-tests -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug
ctest --test-dir build-route-tests -R windows_route_capture_policy_tests
```

Reason: this machine does not have Conan available in PATH or Python modules, and project configure stops in `cmake/recipes_bootstrap.cmake` before test targets are generated:

```text
Could not find CONAN_COMMAND using the following names: conan
python -m conan --version -> No module named conan
py -m conan --version -> No module named conan
conan --version -> command not found
```

## Manual reproduction context

Observed bad routes on Windows when Amnezia split tunneling was enabled:

```text
192.168.1.0/24   -> AmneziaVPN, metric 0
192.168.1.x/32   -> AmneziaVPN, metric 0
172.x.x.0/20     -> AmneziaVPN, metric 0
```

After deleting those cloned VPN routes, LAN routing returned to the physical/local interfaces. The fix prevents connected routes from being captured in the first place.






