### PR TITLE
fix(linux): preserve IPv4 interface host and prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ project(${PROJECT} VERSION ${AMNEZIAVPN_VERSION}
         HOMEPAGE_URL "https://amnezia.org/"
 )
 
+include(CTest)
+
 # trigger conan to kick off `conan install` globally
 find_package(OpenSSL REQUIRED)
 if (PREBUILTS_ONLY)

--- a/client/platforms/linux/daemon/iputilslinux.cpp
+++ b/client/platforms/linux/daemon/iputilslinux.cpp
@@ -17,9 +17,9 @@
 
 #include <QHostAddress>
 #include <QScopeGuard>
-#include <QStringList>
 
 #include "daemon/wireguardutils.h"
+#include "ipv4interfaceaddress.h"
 #include "leakdetector.h"
 #include "logger.h"
 
@@ -163,38 +163,16 @@ bool IPUtilsLinux::setMTUAndUp(const InterfaceConfig& config) {
 }
 
 bool IPUtilsLinux::addIP4AddressToDevice(const InterfaceConfig& config) {
-  QHostAddress deviceAddress;
-  int prefixLength = -1;
-  bool prefixIsValid = false;
-
-  // WireGuard configs can contain both IPv4 and IPv6 addresses in the same
-  // comma-separated Address value. Select the IPv4 entry only.
-  for (const QString& entry : config.m_deviceIpv4Address.split(',')) {
-    const QStringList addressAndPrefix = entry.trimmed().split('/');
-    if (addressAndPrefix.size() != 2) continue;
-
-    QHostAddress candidateAddress(addressAndPrefix.at(0));
-    bool candidatePrefixIsValid = false;
-    const int candidatePrefixLength =
-        addressAndPrefix.at(1).toInt(&candidatePrefixIsValid);
-    if (candidateAddress.protocol() != QAbstractSocket::IPv4Protocol ||
-        !candidatePrefixIsValid || candidatePrefixLength < 0 ||
-        candidatePrefixLength > 32) {
-      continue;
-    }
-
-    deviceAddress = candidateAddress;
-    prefixLength = candidatePrefixLength;
-    prefixIsValid = true;
-    break;
-  }
-
-  if (!prefixIsValid || prefixLength < 0 || prefixLength > 32 ||
-      deviceAddress.protocol() != QAbstractSocket::IPv4Protocol) {
+  const auto parsedAddress =
+      parseIPv4InterfaceAddress(config.m_deviceIpv4Address);
+  if (!parsedAddress.has_value()) {
     logger.error() << "Invalid IPv4 interface address: "
                    << config.m_deviceIpv4Address;
     return false;
   }
+
+  const QHostAddress& deviceAddress = parsedAddress->address;
+  const int prefixLength = parsedAddress->prefixLength;
 
   const int interfaceIndex = if_nametoindex(WG_INTERFACE);
   if (interfaceIndex == 0) {

--- a/client/platforms/linux/daemon/iputilslinux.cpp
+++ b/client/platforms/linux/daemon/iputilslinux.cpp
@@ -5,12 +5,18 @@
 #include "iputilslinux.h"
 
 #include <arpa/inet.h>
+#include <cerrno>
+#include <cstring>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
 #include <net/if.h>
 #include <sys/ioctl.h>
+#include <sys/socket.h>
 #include <unistd.h>
 
 #include <QHostAddress>
 #include <QScopeGuard>
+#include <QStringList>
 
 #include "daemon/wireguardutils.h"
 #include "leakdetector.h"
@@ -18,6 +24,81 @@
 
 namespace {
 Logger logger("IPUtilsLinux");
+
+bool addIPv4Address(int interfaceIndex, const QHostAddress& address,
+                    int prefixLength) {
+  const QByteArray addressBytes = address.toString().toLocal8Bit();
+  struct in_addr ipv4Address = {};
+  if (inet_pton(AF_INET, addressBytes.constData(), &ipv4Address) != 1) {
+    errno = EINVAL;
+    return false;
+  }
+
+  int socketFd = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
+  if (socketFd < 0) return false;
+  auto guard = qScopeGuard([&] { close(socketFd); });
+
+  char buffer[512] = {};
+  auto* message = reinterpret_cast<struct nlmsghdr*>(buffer);
+  message->nlmsg_len = NLMSG_LENGTH(sizeof(struct ifaddrmsg));
+  message->nlmsg_type = RTM_NEWADDR;
+  message->nlmsg_flags =
+      NLM_F_REQUEST | NLM_F_CREATE | NLM_F_REPLACE | NLM_F_ACK;
+  message->nlmsg_seq = 1;
+
+  auto* interfaceAddress =
+      reinterpret_cast<struct ifaddrmsg*>(NLMSG_DATA(message));
+  interfaceAddress->ifa_family = AF_INET;
+  interfaceAddress->ifa_prefixlen = prefixLength;
+  interfaceAddress->ifa_scope = RT_SCOPE_UNIVERSE;
+  interfaceAddress->ifa_index = interfaceIndex;
+
+  const auto appendAttribute = [&](int type, const void* data, size_t size) {
+    const size_t newLength = NLMSG_ALIGN(message->nlmsg_len) + RTA_SPACE(size);
+    if (newLength > sizeof(buffer)) return false;
+
+    auto* attribute = reinterpret_cast<struct rtattr*>(
+        buffer + NLMSG_ALIGN(message->nlmsg_len));
+    attribute->rta_type = type;
+    attribute->rta_len = RTA_LENGTH(size);
+    memcpy(RTA_DATA(attribute), data, size);
+    message->nlmsg_len = newLength;
+    return true;
+  };
+
+  // IFA_LOCAL keeps the configured host address; IFA_ADDRESS describes the
+  // same address for a point-to-point WireGuard interface.
+  if (!appendAttribute(IFA_LOCAL, &ipv4Address, sizeof(ipv4Address)) ||
+      !appendAttribute(IFA_ADDRESS, &ipv4Address, sizeof(ipv4Address))) {
+    errno = EMSGSIZE;
+    return false;
+  }
+
+  struct sockaddr_nl kernelAddress = {};
+  kernelAddress.nl_family = AF_NETLINK;
+  if (sendto(socketFd, buffer, message->nlmsg_len, 0,
+             reinterpret_cast<struct sockaddr*>(&kernelAddress),
+             sizeof(kernelAddress)) < 0) {
+    return false;
+  }
+
+  char acknowledgementBuffer[1024] = {};
+  const ssize_t acknowledgementLength =
+      recv(socketFd, acknowledgementBuffer, sizeof(acknowledgementBuffer), 0);
+  if (acknowledgementLength < static_cast<ssize_t>(sizeof(struct nlmsghdr))) {
+    return acknowledgementLength >= 0;
+  }
+
+  auto* acknowledgement =
+      reinterpret_cast<struct nlmsghdr*>(acknowledgementBuffer);
+  if (acknowledgement->nlmsg_type != NLMSG_ERROR) return true;
+
+  auto* error = reinterpret_cast<struct nlmsgerr*>(NLMSG_DATA(acknowledgement));
+  if (error->error == 0) return true;
+
+  errno = -error->error;
+  return false;
+}
 }
 
 IPUtilsLinux::IPUtilsLinux(QObject* parent) : IPUtils(parent) {
@@ -72,35 +153,54 @@ bool IPUtilsLinux::setMTUAndUp(const InterfaceConfig& config) {
 }
 
 bool IPUtilsLinux::addIP4AddressToDevice(const InterfaceConfig& config) {
-  struct ifreq ifr;
-  struct sockaddr_in* ifrAddr = (struct sockaddr_in*)&ifr.ifr_addr;
+  QHostAddress deviceAddress;
+  int prefixLength = -1;
+  bool prefixIsValid = false;
 
-  // Name the interface and set family
-  strncpy(ifr.ifr_name, WG_INTERFACE, IFNAMSIZ);
-  ifr.ifr_addr.sa_family = AF_INET;
+  // WireGuard configs can contain both IPv4 and IPv6 addresses in the same
+  // comma-separated Address value. Select the IPv4 entry only.
+  for (const QString& entry : config.m_deviceIpv4Address.split(',')) {
+    const QStringList addressAndPrefix = entry.trimmed().split('/');
+    if (addressAndPrefix.size() != 2) continue;
 
-  // Get the device address to add to interface
-  QPair<QHostAddress, int> parsedAddr =
-      QHostAddress::parseSubnet(config.m_deviceIpv4Address);
-  QByteArray _deviceAddr = parsedAddr.first.toString().toLocal8Bit();
-  char* deviceAddr = _deviceAddr.data();
-  inet_pton(AF_INET, deviceAddr, &ifrAddr->sin_addr);
+    QHostAddress candidateAddress(addressAndPrefix.at(0));
+    bool candidatePrefixIsValid = false;
+    const int candidatePrefixLength =
+        addressAndPrefix.at(1).toInt(&candidatePrefixIsValid);
+    if (candidateAddress.protocol() != QAbstractSocket::IPv4Protocol ||
+        !candidatePrefixIsValid || candidatePrefixLength < 0 ||
+        candidatePrefixLength > 32) {
+      continue;
+    }
 
-  // Create IPv4 socket to perform the ioctl operations on
-  int sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
-  if (sockfd < 0) {
-    logger.error() << "Failed to create ioctl socket.";
+    deviceAddress = candidateAddress;
+    prefixLength = candidatePrefixLength;
+    prefixIsValid = true;
+    break;
+  }
+
+  if (!prefixIsValid || prefixLength < 0 || prefixLength > 32 ||
+      deviceAddress.protocol() != QAbstractSocket::IPv4Protocol) {
+    logger.error() << "Invalid IPv4 interface address: "
+                   << config.m_deviceIpv4Address;
     return false;
   }
-  auto guard = qScopeGuard([&] { close(sockfd); });
 
-  // Set ifr to interface
-  int ret = ioctl(sockfd, SIOCSIFADDR, &ifr);
-  if (ret) {
-    logger.error() << "Failed to set IPv4: " << deviceAddr
+  const int interfaceIndex = if_nametoindex(WG_INTERFACE);
+  if (interfaceIndex == 0) {
+    logger.error() << "Failed to get interface index for " << WG_INTERFACE
                    << "error:" << strerror(errno);
     return false;
   }
+
+  // QHostAddress::parseSubnet() cannot be used here: it returns the network
+  // address (for example, 10.8.0.0 for 10.8.0.4/24), not the configured host.
+  if (!addIPv4Address(interfaceIndex, deviceAddress, prefixLength)) {
+    logger.error() << "Failed to set IPv4: " << deviceAddress.toString()
+                   << "/" << prefixLength << "error:" << strerror(errno);
+    return false;
+  }
+
   return true;
 }
 

--- a/client/platforms/linux/daemon/iputilslinux.cpp
+++ b/client/platforms/linux/daemon/iputilslinux.cpp
@@ -4,6 +4,7 @@
 
 #include "iputilslinux.h"
 
+#include <algorithm>
 #include <arpa/inet.h>
 #include <cerrno>
 #include <cstring>
@@ -53,23 +54,32 @@ bool addIPv4Address(int interfaceIndex, const QHostAddress& address,
   interfaceAddress->ifa_scope = RT_SCOPE_UNIVERSE;
   interfaceAddress->ifa_index = interfaceIndex;
 
-  const auto appendAttribute = [&](int type, const void* data, size_t size) {
-    const size_t newLength = NLMSG_ALIGN(message->nlmsg_len) + RTA_SPACE(size);
-    if (newLength > sizeof(buffer)) return false;
+  const auto appendIPv4Attribute = [&](int type) {
+    constexpr size_t payloadSize = sizeof(struct in_addr);
+    const size_t attributeOffset = NLMSG_ALIGN(message->nlmsg_len);
+    const size_t attributeSize = RTA_SPACE(payloadSize);
+    if (attributeOffset > sizeof(buffer) ||
+        attributeSize > sizeof(buffer) - attributeOffset) {
+      return false;
+    }
 
     auto* attribute = reinterpret_cast<struct rtattr*>(
-        buffer + NLMSG_ALIGN(message->nlmsg_len));
+        buffer + attributeOffset);
     attribute->rta_type = type;
-    attribute->rta_len = RTA_LENGTH(size);
-    memcpy(RTA_DATA(attribute), data, size);
-    message->nlmsg_len = newLength;
+    attribute->rta_len = RTA_LENGTH(payloadSize);
+
+    const auto* source = reinterpret_cast<const char*>(&ipv4Address);
+    auto* destination = reinterpret_cast<char*>(RTA_DATA(attribute));
+    std::copy_n(source, payloadSize, destination);
+
+    message->nlmsg_len = attributeOffset + attributeSize;
     return true;
   };
 
   // IFA_LOCAL keeps the configured host address; IFA_ADDRESS describes the
   // same address for a point-to-point WireGuard interface.
-  if (!appendAttribute(IFA_LOCAL, &ipv4Address, sizeof(ipv4Address)) ||
-      !appendAttribute(IFA_ADDRESS, &ipv4Address, sizeof(ipv4Address))) {
+  if (!appendIPv4Attribute(IFA_LOCAL) ||
+      !appendIPv4Attribute(IFA_ADDRESS)) {
     errno = EMSGSIZE;
     return false;
   }

--- a/client/platforms/linux/daemon/ipv4interfaceaddress.cpp
+++ b/client/platforms/linux/daemon/ipv4interfaceaddress.cpp
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "ipv4interfaceaddress.h"
+
+#include <QStringList>
+
+std::optional<ParsedIPv4InterfaceAddress> parseIPv4InterfaceAddress(
+    const QString& configuredAddresses) {
+  for (const QString& entry : configuredAddresses.split(',')) {
+    const QStringList addressAndPrefix = entry.trimmed().split('/');
+    if (addressAndPrefix.size() != 2) continue;
+
+    QHostAddress candidateAddress(addressAndPrefix.at(0));
+    bool prefixIsValid = false;
+    const int prefixLength = addressAndPrefix.at(1).toInt(&prefixIsValid);
+    if (candidateAddress.protocol() != QAbstractSocket::IPv4Protocol ||
+        !prefixIsValid || prefixLength < 0 || prefixLength > 32) {
+      continue;
+    }
+
+    return ParsedIPv4InterfaceAddress{candidateAddress, prefixLength};
+  }
+
+  return std::nullopt;
+}

--- a/client/platforms/linux/daemon/ipv4interfaceaddress.h
+++ b/client/platforms/linux/daemon/ipv4interfaceaddress.h
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef IPV4INTERFACEADDRESS_H
+#define IPV4INTERFACEADDRESS_H
+
+#include <optional>
+
+#include <QHostAddress>
+#include <QString>
+
+struct ParsedIPv4InterfaceAddress {
+  QHostAddress address;
+  int prefixLength;
+};
+
+std::optional<ParsedIPv4InterfaceAddress> parseIPv4InterfaceAddress(
+    const QString& configuredAddresses);
+
+#endif  // IPV4INTERFACEADDRESS_H

--- a/service/server/CMakeLists.txt
+++ b/service/server/CMakeLists.txt
@@ -243,6 +243,7 @@ if(LINUX)
         ${CMAKE_CURRENT_SOURCE_DIR}/../../client/platforms/linux/linuxdependencies.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../../client/platforms/linux/linuxpingsender.h 
         ${CMAKE_CURRENT_SOURCE_DIR}/../../client/platforms/linux/daemon/iputilslinux.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../client/platforms/linux/daemon/ipv4interfaceaddress.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../../client/platforms/linux/daemon/dbustypeslinux.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../../client/platforms/linux/daemon/linuxdaemon.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../../client/platforms/linux/daemon/dnsutilslinux.h
@@ -259,6 +260,7 @@ if(LINUX)
         ${CMAKE_CURRENT_SOURCE_DIR}/../../client/platforms/linux/linuxpingsender.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../../client/platforms/linux/daemon/dnsutilslinux.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../../client/platforms/linux/daemon/iputilslinux.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../client/platforms/linux/daemon/ipv4interfaceaddress.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../../client/platforms/linux/daemon/linuxdaemon.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../../client/platforms/linux/daemon/wireguardutilslinux.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../../client/platforms/linux/daemon/linuxroutemonitor.cpp
@@ -273,6 +275,10 @@ if(LINUX)
         -ldl
     )
 
+endif()
+
+if(BUILD_TESTING AND LINUX)
+    add_subdirectory(tests)
 endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/../src/qtservice.cmake)

--- a/service/server/tests/CMakeLists.txt
+++ b/service/server/tests/CMakeLists.txt
@@ -1,0 +1,18 @@
+find_package(Qt6 REQUIRED COMPONENTS Core Network Test)
+
+qt_add_executable(ipv4interfaceaddress_test
+    ipv4interfaceaddress_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../client/platforms/linux/daemon/ipv4interfaceaddress.cpp
+)
+
+target_include_directories(ipv4interfaceaddress_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../client/platforms/linux/daemon
+)
+
+target_link_libraries(ipv4interfaceaddress_test PRIVATE
+    Qt6::Core
+    Qt6::Network
+    Qt6::Test
+)
+
+add_test(NAME ipv4interfaceaddress_test COMMAND ipv4interfaceaddress_test)

--- a/service/server/tests/ipv4interfaceaddress_test.cpp
+++ b/service/server/tests/ipv4interfaceaddress_test.cpp
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <QtTest>
+
+#include "ipv4interfaceaddress.h"
+
+class IPv4InterfaceAddressTest : public QObject {
+  Q_OBJECT
+
+ private slots:
+  void parsesIPv4FromCombinedWireGuardAddress();
+};
+
+void IPv4InterfaceAddressTest::parsesIPv4FromCombinedWireGuardAddress() {
+  // WireGuard allows IPv4 and IPv6 interface addresses in the same
+  // comma-separated Address value.
+  const QString configuredAddresses =
+      "10.8.0.4/24, 2001:db8::9e/128";
+
+  const auto parsed = parseIPv4InterfaceAddress(configuredAddresses);
+
+  // Keep the configured host (10.8.0.4), rather than normalizing it to the
+  // subnet address (10.8.0.0), and preserve its prefix length.
+  QVERIFY(parsed.has_value());
+  QCOMPARE(parsed->address, QHostAddress("10.8.0.4"));
+  QCOMPARE(parsed->prefixLength, 24);
+}
+
+QTEST_APPLESS_MAIN(IPv4InterfaceAddressTest)
+
+#include "ipv4interfaceaddress_test.moc"


### PR DESCRIPTION
## Summary

- preserve the configured IPv4 host address and prefix when configuring the Linux WireGuard interface
- use an RTM_NEWADDR netlink request to set both IFA_LOCAL and IFA_ADDRESS
- accept a comma-separated IPv4/IPv6 Address value and select the IPv4 entry

## Problem

QHostAddress::parseSubnet() normalizes a host address to its network address, while the previous SIOCSIFADDR call did not set the configured prefix. This can leave amn0 with the wrong IPv4 address/prefix and require an external helper to repair it.

## Validation

- added a QtTest regression test proving that `10.8.0.4/24, 2001:db8::9e/128` preserves the IPv4 host `10.8.0.4` and prefix `24`
- built the Linux service with Ninja
- exercised the netlink address operation in an isolated network namespace: 10.8.0.4/24 was retained as the interface address
- manually connected a real WireGuard profile on Ubuntu 24.04 with Docker network interfaces present, with the helper disabled; the VPN connected and external egress was verified

Fixes #2048