### PR TITLE
fix: avoid false ServerUserNotAllowedInSudoers on GCE (google-sudoers group)

### DIFF
--- a/client/server_scripts/check_user_in_sudo.sh
+++ b/client/server_scripts/check_user_in_sudo.sh
@@ -9,6 +9,6 @@ CUR_USER=$(whoami 2>/dev/null || echo $HOME | sed 's/.*\///');\
 echo $LANG | grep -qE '^(en_US.UTF-8|C.UTF-8|C)$' || export LC_ALL=C;\
 sudo -K;\
 cd ~;\
-if [ "$CUR_USER" = "root" ] || ( groups "$CUR_USER" | grep -E '\<(sudo|wheel)\>' ); then \
+if [ "$CUR_USER" = "root" ] || ( groups "$CUR_USER" | grep -qE '\<(sudo|wheel)\>' ); then \
   sudo -nu $CUR_USER $pm $opt > /dev/null; sudo -n $pm $opt > /dev/null;\
 fi


### PR DESCRIPTION
## Problem

`check_user_in_sudo.sh` reports the login user as **not** being in sudoers
(client surfaces **Error 209 — ServerUserNotAllowedInSudoers**) even when the
user has fully working passwordless sudo. This reproduces on any **Google Cloud
(GCE)** VM.

### Root cause

The membership test is written as:

```sh
if [ "$CUR_USER" = "root" ] || ( groups "$CUR_USER" | grep -E '\<(sudo|wheel)\>' ); then
```

`grep` here is used only as a boolean for the `if`, but **without `-q`** it also
prints the matching line — i.e. the user's **entire group list** — to stdout.

The client scans the combined script output for the word `\bsudoers\b` to decide
the sudo check failed (`installController.cpp`). On GCE the guest agent adds every
managed user to the **`google-sudoers`** group. `\bsudoers\b` matches the
`sudoers` inside `google-sudoers` (`-` is a word boundary), so the check is
treated as failed → Error 209.

So a correctly-configured sudo user (`user ALL=(ALL:ALL) NOPASSWD:ALL`, member of
`sudo`) is rejected purely because one of its group names happens to contain the
substring `sudoers`. Only `root` works, because the `root` branch skips the
`groups` call entirely.

## Fix

Add `-q` to the membership `grep` so it stays a pure exit-code test and stops
leaking the group list into the output the client parses:

```sh
if [ "$CUR_USER" = "root" ] || ( groups "$CUR_USER" | grep -qE '\<(sudo|wheel)\>' ); then
```

One character (`-q`); behaviour of the `if` is unchanged. The `sudo` probes below
already redirect stdout to `/dev/null`, so after this change the script emits no
spurious output for a valid sudo user.

## Verification

On a GCE Ubuntu 22.04 VM with a `sudo`-group user that has passwordless sudo:

- **Before:** running the script prints `user : ... sudo ... google-sudoers`, which
  matches the client's `sudoers` scan → Error 209.
- **After:** the script produces empty output → the sudo check passes and install
  proceeds. Also confirmed `root` and non-GCE users are unaffected.
