### PR TITLE
fix: make Conan recipes parse on Python < 3.12

### DIFF
--- a/recipes/amnezia-xray-bindings/conanfile.py
+++ b/recipes/amnezia-xray-bindings/conanfile.py
@@ -111,8 +111,9 @@ class AmneziaXrayBindings(ConanFile):
                 env.define("CGO_LDFLAGS", " ".join(ldflags))
                 with env.vars(self).apply():
                     at = Autotools(self)
+                    make_build_dir = build_dir.replace("\\", "/") if self._is_windows else build_dir
                     at.make(args=[
-                        f"BUILD_DIR={build_dir.replace("\\", "/") if self._is_windows else build_dir}"
+                        f"BUILD_DIR={make_build_dir}"
                     ])
 
             if is_apple_os(self) and self._is_multiarch:

--- a/recipes/hev-socks5-tunnel/conanfile.py
+++ b/recipes/hev-socks5-tunnel/conanfile.py
@@ -60,9 +60,9 @@ class HevSocks5Tunnel(ConanFile):
             self.run(
                 f"libtool -static -o {lib_path}"
                 f" {lib_path}"
-                f" {os.path.join(self.build_folder, "third-part", "lwip", "bin", "liblwip.a")}"
-                f" {os.path.join(self.build_folder, "third-part", "yaml", "bin", "libyaml.a")}"
-                f" {os.path.join(self.build_folder, "third-part", "hev-task-system", "bin", "libhev-task-system.a")}"
+                f" {os.path.join(self.build_folder, 'third-part', 'lwip', 'bin', 'liblwip.a')}"
+                f" {os.path.join(self.build_folder, 'third-part', 'yaml', 'bin', 'libyaml.a')}"
+                f" {os.path.join(self.build_folder, 'third-part', 'hev-task-system', 'bin', 'libhev-task-system.a')}"
             )
 
             include_dir = os.path.join(self.build_folder, "framework_include")

--- a/recipes/tun2socks/conanfile.py
+++ b/recipes/tun2socks/conanfile.py
@@ -114,8 +114,9 @@ class Tun2Socks(ConanFile):
                 env.define("CGO_CFLAGS", " ".join(cflags))
                 with env.vars(self).apply():
                     at = Autotools(self)
+                    make_build_dir = build_dir.replace("\\", "/") if self._is_windows else build_dir
                     at.make("tun2socks", args=[
-                        f"BUILD_DIR={build_dir.replace("\\", "/") if self._is_windows else build_dir}"
+                        f"BUILD_DIR={make_build_dir}"
                     ])
                     if self._is_windows:
                         os.rename(


### PR DESCRIPTION
### Problem

Three Conan recipes use f-string syntax that is only valid on **Python 3.12+** ([PEP 701](https://peps.python.org/pep-0701/)):

- `recipes/amnezia-xray-bindings/conanfile.py:115`
- `recipes/tun2socks/conanfile.py:118`
- `recipes/hev-socks5-tunnel/conanfile.py:63-65`

Two things are involved, both illegal before 3.12: reusing the same quote character inside an f-string expression, and using a backslash inside one.

```python
f"BUILD_DIR={build_dir.replace("\\", "/") if self._is_windows else build_dir}"
                              ^ SyntaxError
```

On an older interpreter Conan fails to load the recipe *before resolving a single dependency*, so the build cannot start at all:

```
ERROR: Error loading conanfile at '.../recipes/amnezia-xray-bindings/conanfile.py'
  File ".../conanfile.py", line 115
    f"BUILD_DIR={build_dir.replace("\\", "/") if self._is_windows else build_dir}"
                                     ^
SyntaxError: unexpected character after line continuation character
CMake Error at cmake/conan_provider.cmake:504 (message):
  Conan install failed='1'
```

This is **not platform specific** — it affects any host with Python < 3.12. It is invisible in CI only because `ubuntu-latest` ships Python 3.12+. Debian 12 (bookworm) ships Python 3.11, remains widely deployed, and was the base for Raspberry Pi OS through 2025.

### Fix

Hoist the expressions out of the f-strings, and use single quotes for the nested string literals. Behaviour is identical on every Python version; no functional change.

### Verification

`python3 -m py_compile` on **Python 3.11.2** (aarch64, Debian 12):

| recipe | before | after |
|---|---|---|
| `amnezia-xray-bindings` | SyntaxError | OK |
| `tun2socks` | SyntaxError | OK |
| `hev-socks5-tunnel` | SyntaxError | OK |

With these applied, `deploy/build.sh` proceeds normally and Conan builds the full dependency graph from source — `go/1.26.0`, `openssl/3.6.x`, `libssh/0.11.3@amnezia`, `awg-go/0.2.19`, `openvpn/2.7.0`, `tun2socks/2.6.0`, `amnezia-xray-bindings/1.2.0` and the rest — on `arch=armv8`.


Related to #1324

