### PR TITLE
feat(windows): native ARM64 support and OpenVPN data channel offload

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -262,6 +262,134 @@ jobs:
 
 # ------------------------------------------------------
 
+  Bake-Prebuilts-Windows-ARM64:
+    runs-on: windows-11-arm
+    needs: Detect-Changes
+    if: needs.Detect-Changes.outputs.recipes_changed == 'true'
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: 'true'
+        fetch-depth: 10
+
+    - uses: actions/setup-python@v6
+      with:
+        python-version: 3.14
+
+    - uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: 'arm64'
+
+    - name: 'Install conan'
+      run: pip install "conan==2.28.0"
+
+    - name: 'Build dependencies'
+      run: cmake -S . -B build -A ARM64 -DPREBUILTS_ONLY=1
+
+    - name: 'Authorize in remote'
+      if: github.ref == 'refs/heads/dev'
+      run: conan remote login amnezia "${{ secrets.CONAN_USER }}" -p "${{ secrets.CONAN_PASSWORD }}"
+
+    - name: 'Upload baked prebuilts'
+      if: github.ref == 'refs/heads/dev'
+      run: conan upload -r amnezia "*" -c
+
+# ------------------------------------------------------
+
+  Build-Windows-ARM64:
+    runs-on: windows-11-arm
+
+    needs: Bake-Prebuilts-Windows-ARM64
+    if: ${{ always() }}
+
+    env:
+      QT_VERSION: 6.10.1
+      QIF_VERSION: 4.7
+      PROD_AGW_PUBLIC_KEY: ${{ secrets.PROD_AGW_PUBLIC_KEY }}
+      PROD_S3_ENDPOINT: ${{ secrets.PROD_S3_ENDPOINT }}
+      FALLBACK_S3_ENDPOINT: ${{ secrets.FALLBACK_S3_ENDPOINT }}
+      DEV_AGW_PUBLIC_KEY: ${{ secrets.DEV_AGW_PUBLIC_KEY }}
+      DEV_AGW_ENDPOINT: ${{ secrets.DEV_AGW_ENDPOINT }}
+      DEV_S3_ENDPOINT: ${{ secrets.DEV_S3_ENDPOINT }}
+      FREE_V2_ENDPOINT: ${{ secrets.FREE_V2_ENDPOINT }}
+      PREM_V1_ENDPOINT: ${{ secrets.PREM_V1_ENDPOINT }}
+
+    steps:
+    - name: 'Get sources'
+      uses: actions/checkout@v4
+      with:
+        submodules: 'true'
+        fetch-depth: 10
+
+    - name: 'Install Qt'
+      uses: jurplel/install-qt-action@v3
+      with:
+        version: ${{ env.QT_VERSION }}
+        host: 'windows'
+        target: 'desktop'
+        arch: 'win64_msvc2022_arm64_cross_compiled'
+        modules: 'qtremoteobjects qt5compat qtshadertools'
+        dir: ${{ runner.temp }}
+        setup-python: 'true'
+        tools: 'tools_ifw'
+        set-env: 'true'
+        aqtversion: '==3.3.0'
+        py7zrversion: '==0.22.*'
+        extra: '--base ${{ env.QT_MIRROR }}'
+
+    - name: 'Setup mvsc'
+      uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: 'arm64'
+
+    - name: 'Setup .NET SDK'
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: 'Install WiX Toolset'
+      shell: powershell
+      run: |
+        dotnet tool install --global wix --version 4.0.6
+        wix extension add -g WixToolset.UI.wixext/4.0.6
+        wix extension add -g WixToolset.Util.wixext/4.0.6
+        wix extension list -g
+        $wixBinDir = Join-Path $env:USERPROFILE ".dotnet\tools"
+        echo "WIX_BIN_DIR=$wixBinDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+    - name: 'Setup python'
+      uses: actions/setup-python@v6
+      with:
+        python-version: 3.14
+
+    - name: 'Install conan'
+      run: pip install "conan==2.28.0"
+
+    - name: 'Build project'
+      shell: cmd
+      env:
+        QT_INSTALL_DIR: ${{ runner.temp }}
+      run: |
+        set WIX_ROOT_PATH="${{ env.USERPROFILE }}\.dotnet\tools"
+        deploy\build.bat -arch arm64 --installer all
+
+    - name: 'Upload WIX installer artifact'
+      uses: actions/upload-artifact@v7
+      with:
+        path: deploy/build/AmneziaVPN_*_windows_arm64.msi
+        archive: false
+        retention-days: 7
+
+    - name: 'Upload IFW installer artifact'
+      uses: actions/upload-artifact@v7
+      with:
+        path: deploy/build/AmneziaVPN_*_windows_arm64.exe
+        archive: false
+        retention-days: 7
+
+# ------------------------------------------------------
+
   Bake-Prebuilts-iOS:
     needs: Detect-Changes
     if: needs.Detect-Changes.outputs.recipes_changed == 'true'

--- a/client/core/configurators/openVpnConfigurator.cpp
+++ b/client/core/configurators/openVpnConfigurator.cpp
@@ -181,6 +181,11 @@ ProtocolConfig OpenVpnConfigurator::processConfigWithLocalSettings(const Connect
     config.replace("block-outside-dns", "");
 #endif
 
+    // `ncp-disable` was removed in OpenVPN 2.6 and the bundled openvpn 2.7
+    // rejects it as an unknown option; strip it from the local config only —
+    // exported configs and the server side are left untouched
+    config.remove(QRegularExpression("^ncp-disable[ \t]*\r?\n?", QRegularExpression::MultilineOption));
+
 #if (defined(MZ_MACOS) || defined(MZ_LINUX))
     config.append(QString("\nscript-security 2\n"
                          "up %1/update-resolv-conf.sh\n"

--- a/client/core/controllers/updateController.cpp
+++ b/client/core/controllers/updateController.cpp
@@ -20,7 +20,11 @@ namespace
     Logger logger("UpdateController");
 
 #if defined(Q_OS_WINDOWS)
+    #if defined(Q_PROCESSOR_ARM_64)
+    const QLatin1String kInstallerRemoteFileNamePattern("AmneziaVPN_%1_windows_arm64.exe");
+    #else
     const QLatin1String kInstallerRemoteFileNamePattern("AmneziaVPN_%1_windows_x64.exe");
+    #endif
     const QString kInstallerLocalPath = QStandardPaths::writableLocation(QStandardPaths::TempLocation) + "/AmneziaVPN_installer.exe";
 #elif defined(Q_OS_MACOS) && !defined(MACOS_NE)
     const QLatin1String kInstallerRemoteFileNamePattern("AmneziaVPN_%1_macos_x64.pkg");

--- a/client/core/models/protocols/wireGuardProtocolConfig.cpp
+++ b/client/core/models/protocols/wireGuardProtocolConfig.cpp
@@ -109,7 +109,80 @@ QJsonObject WireGuardClientConfig::toJson() const
     if (isObfuscationEnabled) {
         obj[configKey::isObfuscationEnabled] = isObfuscationEnabled;
     }
-    
+
+    // Round-trip AmneziaWG obfuscation parameters. Written only when present so
+    // a plain WireGuard config stays clean, while an obfuscated one keeps its
+    // junk params across the config model instead of degrading to plain WG.
+    if (!junkPacketCount.isEmpty()) {
+        obj[configKey::junkPacketCount] = junkPacketCount;
+    }
+    if (!junkPacketMinSize.isEmpty()) {
+        obj[configKey::junkPacketMinSize] = junkPacketMinSize;
+    }
+    if (!junkPacketMaxSize.isEmpty()) {
+        obj[configKey::junkPacketMaxSize] = junkPacketMaxSize;
+    }
+    if (!initPacketJunkSize.isEmpty()) {
+        obj[configKey::initPacketJunkSize] = initPacketJunkSize;
+    }
+    if (!responsePacketJunkSize.isEmpty()) {
+        obj[configKey::responsePacketJunkSize] = responsePacketJunkSize;
+    }
+    if (!cookieReplyPacketJunkSize.isEmpty()) {
+        obj[configKey::cookieReplyPacketJunkSize] = cookieReplyPacketJunkSize;
+    }
+    if (!transportPacketJunkSize.isEmpty()) {
+        obj[configKey::transportPacketJunkSize] = transportPacketJunkSize;
+    }
+    if (!initPacketMagicHeader.isEmpty()) {
+        obj[configKey::initPacketMagicHeader] = initPacketMagicHeader;
+    }
+    if (!responsePacketMagicHeader.isEmpty()) {
+        obj[configKey::responsePacketMagicHeader] = responsePacketMagicHeader;
+    }
+    if (!underloadPacketMagicHeader.isEmpty()) {
+        obj[configKey::underloadPacketMagicHeader] = underloadPacketMagicHeader;
+    }
+    if (!transportPacketMagicHeader.isEmpty()) {
+        obj[configKey::transportPacketMagicHeader] = transportPacketMagicHeader;
+    }
+    if (!specialJunk1.isEmpty()) {
+        obj[configKey::specialJunk1] = specialJunk1;
+    }
+    if (!specialJunk2.isEmpty()) {
+        obj[configKey::specialJunk2] = specialJunk2;
+    }
+    if (!specialJunk3.isEmpty()) {
+        obj[configKey::specialJunk3] = specialJunk3;
+    }
+    if (!specialJunk4.isEmpty()) {
+        obj[configKey::specialJunk4] = specialJunk4;
+    }
+    if (!specialJunk5.isEmpty()) {
+        obj[configKey::specialJunk5] = specialJunk5;
+    }
+    if (!headerProtectionKey.isEmpty()) {
+        obj[configKey::headerProtectionKey] = headerProtectionKey;
+    }
+    if (!contentPaddingAddition.isEmpty()) {
+        obj[configKey::contentPaddingAddition] = contentPaddingAddition;
+    }
+    if (!rekeyAfterTime.isEmpty()) {
+        obj[configKey::rekeyAfterTime] = rekeyAfterTime;
+    }
+    if (!rekeyTimeout.isEmpty()) {
+        obj[configKey::rekeyTimeout] = rekeyTimeout;
+    }
+    if (!rejectAfterTime.isEmpty()) {
+        obj[configKey::rejectAfterTime] = rejectAfterTime;
+    }
+    if (!keepaliveTimeout.isEmpty()) {
+        obj[configKey::keepaliveTimeout] = keepaliveTimeout;
+    }
+    if (!maxHandshakeAttempts.isEmpty()) {
+        obj[configKey::maxHandshakeAttempts] = maxHandshakeAttempts;
+    }
+
     return obj;
 }
 
@@ -135,7 +208,34 @@ WireGuardClientConfig WireGuardClientConfig::fromJson(const QJsonObject& json)
     config.mtu = json.value(configKey::mtu).toString();
     
     config.isObfuscationEnabled = json.value(configKey::isObfuscationEnabled).toBool(false);
-    
+
+    // Preserve AmneziaWG obfuscation parameters (see header): without this a
+    // WireGuard config that had obfuscation enabled loses its junk params on
+    // read and silently degrades to plain WireGuard.
+    config.junkPacketCount = json.value(configKey::junkPacketCount).toString();
+    config.junkPacketMinSize = json.value(configKey::junkPacketMinSize).toString();
+    config.junkPacketMaxSize = json.value(configKey::junkPacketMaxSize).toString();
+    config.initPacketJunkSize = json.value(configKey::initPacketJunkSize).toString();
+    config.responsePacketJunkSize = json.value(configKey::responsePacketJunkSize).toString();
+    config.cookieReplyPacketJunkSize = json.value(configKey::cookieReplyPacketJunkSize).toString();
+    config.transportPacketJunkSize = json.value(configKey::transportPacketJunkSize).toString();
+    config.initPacketMagicHeader = json.value(configKey::initPacketMagicHeader).toString();
+    config.responsePacketMagicHeader = json.value(configKey::responsePacketMagicHeader).toString();
+    config.underloadPacketMagicHeader = json.value(configKey::underloadPacketMagicHeader).toString();
+    config.transportPacketMagicHeader = json.value(configKey::transportPacketMagicHeader).toString();
+    config.specialJunk1 = json.value(configKey::specialJunk1).toString();
+    config.specialJunk2 = json.value(configKey::specialJunk2).toString();
+    config.specialJunk3 = json.value(configKey::specialJunk3).toString();
+    config.specialJunk4 = json.value(configKey::specialJunk4).toString();
+    config.specialJunk5 = json.value(configKey::specialJunk5).toString();
+    config.headerProtectionKey = json.value(configKey::headerProtectionKey).toString();
+    config.contentPaddingAddition = json.value(configKey::contentPaddingAddition).toString();
+    config.rekeyAfterTime = json.value(configKey::rekeyAfterTime).toString();
+    config.rekeyTimeout = json.value(configKey::rekeyTimeout).toString();
+    config.rejectAfterTime = json.value(configKey::rejectAfterTime).toString();
+    config.keepaliveTimeout = json.value(configKey::keepaliveTimeout).toString();
+    config.maxHandshakeAttempts = json.value(configKey::maxHandshakeAttempts).toString();
+
     return config;
 }
 

--- a/client/core/models/protocols/wireGuardProtocolConfig.h
+++ b/client/core/models/protocols/wireGuardProtocolConfig.h
@@ -37,7 +37,35 @@ struct WireGuardClientConfig {
     QString persistentKeepAlive;
     QString mtu;
     bool isObfuscationEnabled = false;
-    
+
+    // AmneziaWG obfuscation parameters. A native WireGuard config imported with
+    // "Enable WireGuard obfuscation" is stored in the WireGuard container with
+    // these set; they must round-trip so an already-obfuscated profile keeps
+    // working after upgrade instead of degrading to plain WireGuard.
+    QString junkPacketCount;
+    QString junkPacketMinSize;
+    QString junkPacketMaxSize;
+    QString initPacketJunkSize;
+    QString responsePacketJunkSize;
+    QString cookieReplyPacketJunkSize;
+    QString transportPacketJunkSize;
+    QString initPacketMagicHeader;
+    QString responsePacketMagicHeader;
+    QString underloadPacketMagicHeader;
+    QString transportPacketMagicHeader;
+    QString specialJunk1;
+    QString specialJunk2;
+    QString specialJunk3;
+    QString specialJunk4;
+    QString specialJunk5;
+    QString headerProtectionKey;
+    QString contentPaddingAddition;
+    QString rekeyAfterTime;
+    QString rekeyTimeout;
+    QString rejectAfterTime;
+    QString keepaliveTimeout;
+    QString maxHandshakeAttempts;
+
     QJsonObject toJson() const;
     static WireGuardClientConfig fromJson(const QJsonObject& json);
 };

--- a/client/core/protocols/openVpnProtocol.cpp
+++ b/client/core/protocols/openVpnProtocol.cpp
@@ -39,6 +39,40 @@ QString OpenVpnProtocol::defaultConfigPath()
     return p;
 }
 
+#ifdef Q_OS_WIN
+bool OpenVpnProtocol::retryWithLegacyDriver()
+{
+    if (m_legacyDriverRequested) {
+        return false;
+    }
+    m_legacyDriverRequested = true;
+
+    qWarning() << "OpenVpnProtocol: no usable adapter, installing tap-windows6 and retrying";
+
+    // the process is terminated by start() -> cleanupResources(); its
+    // finished() would otherwise race the retry and report Disconnected
+    if (m_openVpnProcess) {
+        m_openVpnProcess->blockSignals(true);
+    }
+
+    const ErrorCode driverError = IpcClient::withInterface([](QSharedPointer<IpcInterfaceReplica> iface) {
+        QRemoteObjectPendingReply<bool> reply = iface->checkAndInstallLegacyDriver();
+        if (!reply.waitForFinished(120000) || !reply.returnValue()) {
+            return ErrorCode::OpenVpnTapAdapterError;
+        }
+        return ErrorCode::NoError;
+    }, []() { return ErrorCode::AmneziaServiceConnectionFailed; });
+
+    if (driverError != ErrorCode::NoError) {
+        emit protocolError(driverError);
+        return true;
+    }
+
+    start();
+    return true;
+}
+#endif
+
 void OpenVpnProtocol::cleanupResources()
 {
     if (m_openVpnProcess || openVpnProcessIsRunning()) {
@@ -313,12 +347,21 @@ void OpenVpnProtocol::onReadyReadDataFromManagementServer()
         }
 
         if (line.contains("FATAL")) {
-            if (line.contains("tap-windows6 adapters on this system are currently in use or disabled")
-                || line.contains("ovpn-dco adapters on this system are in use or disabled")) {
-                emit protocolError(ErrorCode::OpenVpnAdaptersInUseError);
-            } else if (line.contains("There are no TAP-Windows nor Wintun adapters")
-                       || line.contains("adapter using service failed")) {
-                emit protocolError(ErrorCode::OpenVpnTapAdapterError);
+            const bool adapterUnavailable = line.contains("adapters on this system are currently in use or disabled")
+                    || line.contains("There are no TAP-Windows or ovpn-dco adapters")
+                    || line.contains("adapter using service failed");
+
+            if (adapterUnavailable) {
+#ifdef Q_OS_WIN
+                // openvpn asks for tap-windows6 whenever the config is not
+                // DCO-capable; provisioning it on demand turns this fatal
+                // error into a working connection
+                if (retryWithLegacyDriver()) {
+                    return;
+                }
+#endif
+                emit protocolError(line.contains("in use or disabled") ? ErrorCode::OpenVpnAdaptersInUseError
+                                                                       : ErrorCode::OpenVpnTapAdapterError);
             } else {
                 emit protocolError(ErrorCode::OpenVpnUnknownError);
             }

--- a/client/core/protocols/openVpnProtocol.cpp
+++ b/client/core/protocols/openVpnProtocol.cpp
@@ -82,17 +82,13 @@ void OpenVpnProtocol::stop()
 ErrorCode OpenVpnProtocol::prepare()
 {
     return IpcClient::withInterface([](QSharedPointer<IpcInterfaceReplica> iface) {
-        QRemoteObjectPendingReply<QStringList> listReply = iface->getTapList();
-        if (!listReply.waitForFinished(1000)) {
-            return ErrorCode::InternalError;
-        }
-
-        QStringList list = listReply.returnValue();
-        if (list.empty()) {
-            QRemoteObjectPendingReply<bool> installReply = iface->checkAndInstallDriver();
-            if (!installReply.waitForFinished() || !installReply.returnValue()) {
-                return ErrorCode::OpenVpnTapAdapterError;
-            }
+        // ensures a usable OpenVPN driver on Windows: ovpn-dco (the 2.6+
+        // default data path, installed on first use) with a fallback to
+        // tap-windows6; a no-op on other platforms. The call is idempotent,
+        // so it runs on every connect to survive driver removal.
+        QRemoteObjectPendingReply<bool> installReply = iface->checkAndInstallDriver();
+        if (!installReply.waitForFinished(60000) || !installReply.returnValue()) {
+            return ErrorCode::OpenVpnTapAdapterError;
         }
 
         return ErrorCode::NoError;
@@ -317,8 +313,12 @@ void OpenVpnProtocol::onReadyReadDataFromManagementServer()
         }
 
         if (line.contains("FATAL")) {
-            if (line.contains("tap-windows6 adapters on this system are currently in use or disabled")) {
+            if (line.contains("tap-windows6 adapters on this system are currently in use or disabled")
+                || line.contains("ovpn-dco adapters on this system are in use or disabled")) {
                 emit protocolError(ErrorCode::OpenVpnAdaptersInUseError);
+            } else if (line.contains("There are no TAP-Windows nor Wintun adapters")
+                       || line.contains("adapter using service failed")) {
+                emit protocolError(ErrorCode::OpenVpnTapAdapterError);
             } else {
                 emit protocolError(ErrorCode::OpenVpnUnknownError);
             }

--- a/client/core/protocols/openVpnProtocol.h
+++ b/client/core/protocols/openVpnProtocol.h
@@ -55,6 +55,17 @@ private:
     void updateVpnGateway(const QString &line);
 
     QSharedPointer<IpcProcessInterfaceReplica> m_openVpnProcess;
+
+#ifdef Q_OS_WIN
+    // openvpn falls back to tap-windows6 on its own for configs the ovpn-dco
+    // driver cannot handle (compression, --fragment, proxies, non-AEAD
+    // ciphers, --dev tap). Only the DCO adapter is provisioned up front, so
+    // that fallback dies with "There are no TAP-Windows or ovpn-dco adapters
+    // on this system" — install the legacy driver on demand and retry once.
+    bool retryWithLegacyDriver();
+
+    bool m_legacyDriverRequested = false;
+#endif
 };
 
 #endif // OPENVPNPROTOCOL_H

--- a/client/core/protocols/xrayProtocol.cpp
+++ b/client/core/protocols/xrayProtocol.cpp
@@ -133,10 +133,6 @@ void XrayProtocol::stop()
         if (!restoreResolvers.waitForFinished() || !restoreResolvers.returnValue())
             qWarning() << "Failed to restore resolvers";
 
-        auto deleteTun = iface->deleteTun(tunName);
-        if (!deleteTun.waitForFinished() || !deleteTun.returnValue())
-            qWarning() << "Failed to delete tun";
-
         auto xrayStop = iface->xrayStop();
         if (!xrayStop.waitForFinished() || !xrayStop.returnValue())
             qWarning() << "Failed to stop xray";
@@ -161,6 +157,15 @@ void XrayProtocol::stop()
         m_tun2socksProcess->close();
         m_tun2socksProcess.reset();
     }
+
+    // delete the TUN device only after tun2socks released it — removing a
+    // device that is still held open merely marks it pending-removal and
+    // creates exactly the ghost adapter this call is meant to clean up
+    IpcClient::withInterface([](QSharedPointer<IpcInterfaceReplica> iface) {
+        auto deleteTun = iface->deleteTun(tunName);
+        if (!deleteTun.waitForFinished() || !deleteTun.returnValue())
+            qWarning() << "Failed to delete tun";
+    });
 
     setConnectionState(Vpn::ConnectionState::Disconnected);
 }

--- a/client/platforms/windows/daemon/windowstunnellogger.cpp
+++ b/client/platforms/windows/daemon/windowstunnellogger.cpp
@@ -45,6 +45,12 @@ WindowsTunnelLogger::WindowsTunnelLogger(const QString& filename,
   m_startTime = QDateTime::currentMSecsSinceEpoch() * 1000000;
   m_logindex = -1;
 
+  if (filename.isEmpty()) {
+    // no ring log to poll; starting the timer would only make QFile::open
+    // emit a QFSFileEngine warning every RINGLOG_POLL_MSEC forever
+    return;
+  }
+
   connect(&m_timer, SIGNAL(timeout()), this, SLOT(timeout()));
   m_timer.start(RINGLOG_POLL_MSEC);
 }

--- a/cmake/CPack.cmake
+++ b/cmake/CPack.cmake
@@ -1,7 +1,12 @@
 set(CPACK_PACKAGE_VENDOR            AmneziaVPN)
 set(CPACK_PACKAGE_VERSION           ${AMNEZIAVPN_VERSION})
 if(WIN32)
-    set(CPACK_PACKAGE_FILE_NAME "AmneziaVPN_${AMNEZIAVPN_VERSION}_windows_x64")
+    if(CMAKE_CXX_COMPILER_ARCHITECTURE_ID MATCHES "ARM64" OR CMAKE_GENERATOR_PLATFORM MATCHES "ARM64")
+        set(_AMNEZIA_WIN_ARCH "arm64")
+    else()
+        set(_AMNEZIA_WIN_ARCH "x64")
+    endif()
+    set(CPACK_PACKAGE_FILE_NAME "AmneziaVPN_${AMNEZIAVPN_VERSION}_windows_${_AMNEZIA_WIN_ARCH}")
 elseif(APPLE AND NOT IOS AND NOT MACOS_NE)
     set(CPACK_PACKAGE_FILE_NAME "AmneziaVPN_${AMNEZIAVPN_VERSION}_macos_x64")
 elseif(LINUX AND NOT ANDROID)
@@ -35,6 +40,9 @@ set(CPACK_IFW_PACKAGE_CONTROL_SCRIPT                ${CMAKE_SOURCE_DIR}/deploy/i
 
 # === CPack WIX generator settings ===
 set(CPACK_WIX_VERSION               4)
+if(WIN32)
+    set(CPACK_WIX_ARCHITECTURE      ${_AMNEZIA_WIN_ARCH})
+endif()
 set(CPACK_WIX_UPGRADE_GUID          "{2D55AC62-96D6-4692-8C05-0D85BBF95485}")
 set(CPACK_WIX_PRODUCT_ICON          ${CMAKE_SOURCE_DIR}/client/images/app.ico)
 set(CPACK_WIX_CUSTOM_XMLNS          "util=http://wixtoolset.org/schemas/v4/wxs/util")
@@ -72,6 +80,22 @@ if(WIN32)
         DESTINATION "."
         COMPONENT AmneziaVPN
     )
+
+    # componentscript.js bootstraps the VC++ runtime from vc_redist.<arch>.exe
+    # in the install dir, so stage the redistributable matching the target arch
+    set(_AMNEZIA_VC_REDIST "${CMAKE_BINARY_DIR}/vc_redist.${_AMNEZIA_WIN_ARCH}.exe")
+    if(NOT EXISTS "${_AMNEZIA_VC_REDIST}")
+        file(DOWNLOAD "https://aka.ms/vc14/vc_redist.${_AMNEZIA_WIN_ARCH}.exe" "${_AMNEZIA_VC_REDIST}"
+             STATUS _AMNEZIA_VC_REDIST_STATUS)
+        list(GET _AMNEZIA_VC_REDIST_STATUS 0 _AMNEZIA_VC_REDIST_CODE)
+        if(NOT _AMNEZIA_VC_REDIST_CODE EQUAL 0)
+            file(REMOVE "${_AMNEZIA_VC_REDIST}")
+            message(WARNING "Failed to download vc_redist.${_AMNEZIA_WIN_ARCH}.exe; the installer will not bootstrap the VC++ runtime")
+        endif()
+    endif()
+    if(EXISTS "${_AMNEZIA_VC_REDIST}")
+        install(PROGRAMS "${_AMNEZIA_VC_REDIST}" DESTINATION "." COMPONENT AmneziaVPN)
+    endif()
 endif()
 
 if (APPLE AND NOT IOS AND NOT MACOS_NE)

--- a/conanfile.py
+++ b/conanfile.py
@@ -29,7 +29,7 @@ class AmneziaVPN(ConanFile):
 
             self.requires("amnezia-xray-bindings/1.3.0")
             self.requires("tun2socks/2.6.0")
-            self.requires("openvpn/2.7.0")
+            self.requires("openvpn/2.7.5")
             self.requires("v2ray-rules-dat/202603162227")
 
         if has_ne:

--- a/conanfile.py
+++ b/conanfile.py
@@ -21,6 +21,7 @@ class AmneziaVPN(ConanFile):
             if os == "Windows":
                 self.requires("awg-windows/3.0.2")
                 self.requires("tap-windows6/9.27.0")
+                self.requires("ovpn-dco-win/2.8.3")
                 self.requires("win-split-tunnel/1.2.5.0")
                 self.requires("wintun/0.14.1")
             else:

--- a/conanfile.py
+++ b/conanfile.py
@@ -28,7 +28,7 @@ class AmneziaVPN(ConanFile):
                 self.requires("awg-go/3.0.1")
 
             self.requires("amnezia-xray-bindings/1.3.0")
-            self.requires("tun2socks/2.6.0")
+            self.requires("tun2socks/2.7.0")
             self.requires("openvpn/2.7.5")
             self.requires("v2ray-rules-dat/202603162227")
 

--- a/deploy/build.bat
+++ b/deploy/build.bat
@@ -22,12 +22,16 @@ if /i "%ARCH%" == "x64" set "ARCH=amd64"
 if /i "%ARCH%" == "amd64" (
     if /i "%PROCESSOR_ARCHITECTURE%" == "AMD64" set "_vcvars_arg=amd64"
     if /i "%PROCESSOR_ARCHITECTURE%" == "x86"   set "_vcvars_arg=x86_amd64"
+    if /i "%PROCESSOR_ARCHITECTURE%" == "ARM64" set "_vcvars_arg=arm64_amd64"
     set "_qt_postfix_arg=64"
+    set "_cmake_platform=x64"
 )
 if /i "%ARCH%" == "arm64" (
     if /i "%PROCESSOR_ARCHITECTURE%" == "AMD64" set "_vcvars_arg=amd64_arm64"
     if /i "%PROCESSOR_ARCHITECTURE%" == "x86"   set "_vcvars_arg=x86_arm64"
+    if /i "%PROCESSOR_ARCHITECTURE%" == "ARM64" set "_vcvars_arg=arm64"
     set "_qt_postfix_arg=arm64"
+    set "_cmake_platform=ARM64"
 )
 if not defined _vcvars_arg  (
     echo ERROR: Unsupported architecture "%ARCH%"
@@ -95,7 +99,7 @@ if exist "%VCVARS_PATH%" (
 
 :: build project and installers
 @echo on
-cmake -S "%PROJECT_DIR%" -B "%BUILD_DIR%" -DCMAKE_BUILD_TYPE=Release "-DCMAKE_PREFIX_PATH=%QT_ROOT_PATH%\msvc2022_%_qt_postfix_arg%" "-DCMAKE_VS_GLOBALS=UseMultiToolTask=true;EnforceProcessCountAcrossBuilds=true" || goto :fail
+cmake -S "%PROJECT_DIR%" -B "%BUILD_DIR%" -A %_cmake_platform% -DCMAKE_BUILD_TYPE=Release "-DCMAKE_PREFIX_PATH=%QT_ROOT_PATH%\msvc2022_%_qt_postfix_arg%" "-DCMAKE_VS_GLOBALS=UseMultiToolTask=true;EnforceProcessCountAcrossBuilds=true" || goto :fail
 cmake --build "%BUILD_DIR%" --config Release -- /m  || goto :fail
 @echo off
 for %%I in (%ARG_BUILD_INSTALLERS%) do (

--- a/deploy/build.bat
+++ b/deploy/build.bat
@@ -73,16 +73,18 @@ if not defined QT_ROOT_PATH  set "QT_ROOT_PATH=%_qt_root_path%"
 if not defined QIF_ROOT_PATH set "QIF_ROOT_PATH=%_qif_root_path%"
 
 :: use vswhere to find path to vcvarsall.bat
+:: NOTE: delayed expansion (!VAR!) is required here — %VAR% would expand when
+:: the whole parenthesized block is parsed, before the inner `set` runs
 if not defined VCINSTALLDIR (
     if not defined VS_INSTALLER_PATH set "VS_INSTALLER_PATH=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-    if exist "%VS_INSTALLER_PATH%" (
-        if defined "%VS_INSTALLATION_VERSION%" (
+    if exist "!VS_INSTALLER_PATH!" (
+        if defined VS_INSTALLATION_VERSION (
             set "_version=-version [%VS_INSTALLATION_VERSION%]"
         ) else (
             set "_version=-latest"
         )
         for /f "usebackq tokens=*" %%I in (
-            `"%VS_INSTALLER_PATH%" -products * %_version% -property resolvedInstallationPath`
+            `"!VS_INSTALLER_PATH!" -products * !_version! -property resolvedInstallationPath`
         ) do (
             if not defined VCVARS_PATH set "VCVARS_PATH=%%I\VC\Auxiliary\Build\vcvarsall.bat"
         )

--- a/deploy/deploy_s3.sh
+++ b/deploy/deploy_s3.sh
@@ -40,7 +40,8 @@ download_file https://github.com/amnezia-vpn/amnezia-client/releases/download/${
 download_file https://github.com/amnezia-vpn/amnezia-client/releases/download/${VERSION}/AmneziaVPN_${VERSION}_android9+_x86_64.apk
 download_file https://github.com/amnezia-vpn/amnezia-client/releases/download/${VERSION}/AmneziaVPN_${VERSION}_linux_x64.run
 download_file https://github.com/amnezia-vpn/amnezia-client/releases/download/${VERSION}/AmneziaVPN_${VERSION}_macos_x64.pkg
-download_file https://github.com/amnezia-vpn/amnezia-client/releases/download/${VERSION}/AmneziaVPN_${VERSION}_windows_x64.exe 
+download_file https://github.com/amnezia-vpn/amnezia-client/releases/download/${VERSION}/AmneziaVPN_${VERSION}_windows_x64.exe
+download_file https://github.com/amnezia-vpn/amnezia-client/releases/download/${VERSION}/AmneziaVPN_${VERSION}_windows_arm64.exe
 
 cd ../
 

--- a/deploy/installer/qif/componentscript.js
+++ b/deploy/installer/qif/componentscript.js
@@ -38,6 +38,18 @@ function vcRuntimeIsInstalled()
     return (installer.findPath("msvcp140.dll", [installer.value("RootDir")+ "\\Windows\\System32\\"]).length !== 0)
 }
 
+function vcRedistFileName()
+{
+    var arch = systemInfo.currentCpuArchitecture;
+    if (arch === "arm64" || arch === "aarch64") {
+        return "vc_redist.arm64.exe";
+    }
+    if (arch.search("64") < 0) {
+        return "vc_redist.x86.exe";
+    }
+    return "vc_redist.x64.exe";
+}
+
 function Component()
 {
     component.loaded.connect(this, Component.prototype.componentLoaded);
@@ -73,15 +85,11 @@ Component.prototype.createOperations = function()
                                        "workingDirectory=@TargetDir@", "iconPath=@TargetDir@\\" + appExecutableFileName(), "iconId=0");
 
         if (!vcRuntimeIsInstalled()) {
-			if (systemInfo.currentCpuArchitecture.search("64") < 0) {
-				component.addElevatedOperation("Execute", "@TargetDir@\\" + "vc_redist.x86.exe", "/install", "/quiet", "/norestart", "/log", "vc_redist.log");
-			}
-			else {
-				component.addElevatedOperation("Execute", "@TargetDir@\\" + "vc_redist.x64.exe", "/install", "/quiet", "/norestart", "/log", "vc_redist.log");
-			}
-
+            // 1638 = a newer runtime is already installed, 3010 = success, reboot required
+            component.addElevatedOperation("Execute", "{0,1638,3010}", "@TargetDir@\\" + vcRedistFileName(),
+                                           "/install", "/quiet", "/norestart", "/log", "vc_redist.log");
         } else {
-            console.log("Microsoft Visual C++ 2017 Redistributable already installed");
+            console.log("Microsoft Visual C++ Redistributable already installed");
         }
 
         let pu_path = installer.value("TargetDir").replace(/\//g, '\\') + "\\"

--- a/deploy/installer/qif/componentscript.js
+++ b/deploy/installer/qif/componentscript.js
@@ -93,6 +93,14 @@ Component.prototype.createOperations = function()
         }
 
         let pu_path = installer.value("TargetDir").replace(/\//g, '\\') + "\\"
+
+        // upgrade path: a service from a previous install may still be
+        // registered — sc create would fail with 1073 (service exists), so
+        // recreate it to keep binpath/depend current
+        // (1060 = service does not exist, 1062 = service not started)
+        component.addElevatedOperation("Execute", "{0,1060,1062}", "sc", "stop", serviceName());
+        component.addElevatedOperation("Execute", "{0,1060}", "sc", "delete", serviceName());
+
         component.addElevatedOperation("Execute",
                                        ["sc", "create", serviceName(), "binpath=", pu_path + serviceName() + ".exe",
                                         "start=", "auto", "depend=", "BFE/nsi"],

--- a/ipc/ipc_interface.rep
+++ b/ipc/ipc_interface.rep
@@ -16,6 +16,7 @@ class IpcInterface
     SLOT( void resetIpStack() );
 
     SLOT( bool checkAndInstallDriver() );
+    SLOT( bool checkAndInstallLegacyDriver() );
     SLOT( QStringList getTapList() );
 
     SLOT( void cleanUp() );

--- a/ipc/ipcserver.cpp
+++ b/ipc/ipcserver.cpp
@@ -20,6 +20,7 @@
 
 #ifdef Q_OS_WIN
     #include "tapcontroller_win.h"
+    #include "dcocontroller_win.h"
 #endif
 
 
@@ -116,6 +117,13 @@ bool IpcServer::checkAndInstallDriver()
 #endif
 
 #ifdef Q_OS_WIN
+    // OpenVPN 2.7 uses the ovpn-dco driver by default (wintun was removed);
+    // tap-windows6 stays as the fallback data path for non-DCO configs
+    // (non-AEAD ciphers, compression, proxy options, --dev tap)
+    if (DcoController::Instance().checkAndSetup()) {
+        return true;
+    }
+    qWarning() << "IpcServer: ovpn-dco setup failed, falling back to tap-windows6";
     return TapController::checkAndSetup();
 #else
     return true;

--- a/ipc/ipcserver.cpp
+++ b/ipc/ipcserver.cpp
@@ -130,6 +130,19 @@ bool IpcServer::checkAndInstallDriver()
 #endif
 }
 
+bool IpcServer::checkAndInstallLegacyDriver()
+{
+#ifdef MZ_DEBUG
+    qDebug() << "IpcServer::checkAndInstallLegacyDriver";
+#endif
+
+#ifdef Q_OS_WIN
+    return TapController::checkAndSetup();
+#else
+    return true;
+#endif
+}
+
 QStringList IpcServer::getTapList()
 {
 #ifdef MZ_DEBUG

--- a/ipc/ipcserver.h
+++ b/ipc/ipcserver.h
@@ -25,6 +25,7 @@ public:
     virtual bool flushDns() override;
     virtual void resetIpStack() override;
     virtual bool checkAndInstallDriver() override;
+    virtual bool checkAndInstallLegacyDriver() override;
     virtual QStringList getTapList() override;
     virtual void cleanUp() override;
     virtual void clearLogs() override;

--- a/recipes/amnezia-xray-bindings/conanfile.py
+++ b/recipes/amnezia-xray-bindings/conanfile.py
@@ -56,13 +56,23 @@ class AmneziaXrayBindings(ConanFile):
     def layout(self):
         basic_layout(self)
 
+    @property
+    def _is_windows_arm64(self):
+        return self._is_windows and self._archs == ["armv8"]
+
     def build_requirements(self):
         self.tool_requires("go/1.26.0")
         if self._is_windows:
-            self.win_bash = True
-            if not self.conf.get("tools.microsoft.bash:path", check_type=str):
-                self.tool_requires("msys2/cci.latest")
-            self.tool_requires("mingw-builds/15.1.0")
+            if self._is_windows_arm64:
+                # neither msys2 nor mingw-builds has an armv8 build on
+                # conan-center; llvm-mingw provides the aarch64 CGO toolchain
+                # and gendef/dlltool, the Makefile wrapper is bypassed below
+                self.tool_requires("llvm-mingw/20260616")
+            else:
+                self.win_bash = True
+                if not self.conf.get("tools.microsoft.bash:path", check_type=str):
+                    self.tool_requires("msys2/cci.latest")
+                self.tool_requires("mingw-builds/15.1.0")
 
     def validate(self):
         if not self._goos or not all(arch in self._arch_map for arch in self._archs):
@@ -93,7 +103,29 @@ class AmneziaXrayBindings(ConanFile):
         self._cflags = tc.cflags
         tc.generate(env)
 
+    def _build_windows_arm64(self):
+        # mirrors the Makefile's windows flow (CGO_ENABLED=1 go build
+        # -buildmode=c-shared, then gendef + dlltool for the import library)
+        # without bash/make from msys2
+        dll = os.path.join(self.build_folder, "amnezia_xray.dll")
+        env = Environment()
+        env.define("GOARCH", self._arch_map["armv8"])
+        env.define("CGO_ENABLED", "1")
+        env.define("CC", "aarch64-w64-mingw32-gcc")
+        env.define("CXX", "aarch64-w64-mingw32-g++")
+        env.define("CGO_CFLAGS", " ".join(self._cflags))
+        env.define("CGO_LDFLAGS", " ".join(self._ldflags))
+        with chdir(self, self.source_folder), env.vars(self).apply():
+            self.run(f'go build -ldflags=-w -o "{dll}" -buildmode=c-shared')
+        with chdir(self, self.build_folder), env.vars(self).apply():
+            self.run("gendef amnezia_xray.dll")
+            self.run("aarch64-w64-mingw32-dlltool -d amnezia_xray.def -D amnezia_xray.dll -l amnezia_xray.lib")
+
     def build(self):
+        if self._is_windows_arm64:
+            self._build_windows_arm64()
+            return
+
         with chdir(self, self.source_folder):
             for arch in self._archs:
                 build_dir = os.path.join(self.build_folder, arch) if self._is_multiarch else self.build_folder

--- a/recipes/awg-windows/conanfile.py
+++ b/recipes/awg-windows/conanfile.py
@@ -55,7 +55,12 @@ class AwgWindows(ConanFile):
             )
 
     def build_requirements(self):
-        self.tool_requires("mingw-builds/15.1.0")
+        if self._goarch == "arm64":
+            # mingw-builds only ships an x86_64-w64-mingw32 gcc; CGO for
+            # GOARCH=arm64 needs an aarch64 mingw toolchain
+            self.tool_requires("llvm-mingw/20260616")
+        else:
+            self.tool_requires("mingw-builds/15.1.0")
         self.tool_requires("go/1.26.0")
 
     def requirements(self):
@@ -87,6 +92,11 @@ class AwgWindows(ConanFile):
         env.define("CGO_ENABLED", "1")
         env.define("CGO_LDFLAGS", tc.ldflags)
         env.define("CGO_CFLAGS", tc.cflags)
+        if self._goarch == "arm64":
+            # go invokes plain "gcc" by default, which llvm-mingw does not
+            # provide unprefixed — select the aarch64 cross driver explicitly
+            env.define("CC", "aarch64-w64-mingw32-gcc")
+            env.define("CXX", "aarch64-w64-mingw32-g++")
         tc.generate(env)
 
     def build(self):

--- a/recipes/go/conandata.yml
+++ b/recipes/go/conandata.yml
@@ -24,3 +24,6 @@ sources:
       x86_64:
         url: "https://go.dev/dl/go1.26.0.windows-amd64.zip"
         sha256: "9bbe0fc64236b2b51f6255c05c4232532b8ecc0e6d2e00950bd3021d8a4d07d4"
+      armv8:
+        url: "https://go.dev/dl/go1.26.0.windows-arm64.zip"
+        sha256: "73bdbb9f64aa152758024485c5243a1098182bb741fcc603b6fb664ee5e0fe35"

--- a/recipes/llvm-mingw/conandata.yml
+++ b/recipes/llvm-mingw/conandata.yml
@@ -1,0 +1,8 @@
+sources:
+  "20260616":
+    x86_64:
+      url: "https://github.com/mstorsjo/llvm-mingw/releases/download/20260616/llvm-mingw-20260616-ucrt-x86_64.zip"
+      sha256: "b9b68a4d276e16fa25802aaba458e4638f64b3884c290aaccdc2d87083b6ca35"
+    aarch64:
+      url: "https://github.com/mstorsjo/llvm-mingw/releases/download/20260616/llvm-mingw-20260616-ucrt-aarch64.zip"
+      sha256: "312593669435bd0bfc1a43ac3fba23c8b27e0610bade88b2738e5a01702a99ba"

--- a/recipes/llvm-mingw/conanfile.py
+++ b/recipes/llvm-mingw/conanfile.py
@@ -1,0 +1,52 @@
+from conan import ConanFile
+from conan.tools.files import get, copy
+from conan.tools.layout import basic_layout
+from conan.errors import ConanInvalidConfiguration
+
+import os
+
+
+class LlvmMingw(ConanFile):
+    name = "llvm-mingw"
+    version = "20260616"
+    settings = "os", "arch"
+    package_type = "application"
+
+    # The flavour is picked by the machine this tool package runs on (the
+    # conan build profile); every flavour targets all four
+    # {i686,x86_64,armv7,aarch64}-w64-mingw32 triples, so a single package
+    # serves both native ARM64 hosts and x64 CI runners cross-building arm64.
+    @property
+    def _host_flavour(self):
+        return {
+            "x86_64": "x86_64",
+            "armv8": "aarch64",
+        }.get(str(self.settings.arch))
+
+    def layout(self):
+        basic_layout(self)
+
+    def validate(self):
+        if not str(self.settings.os).startswith("Windows"):
+            raise ConanInvalidConfiguration(
+                f"{self.name} v{self.version} is to be used on Windows only!"
+            )
+        if not self._host_flavour:
+            raise ConanInvalidConfiguration(
+                f"{self.name} v{self.version} has no toolchain build for a {self.settings.arch} machine"
+            )
+
+    def build(self):
+        # settings-dependent source, so fetched in build() rather than source()
+        get(self, **self.conan_data["sources"][self.version][self._host_flavour], strip_root=True)
+
+    def package(self):
+        for subdir in ("bin", "include", "lib", "share", "generic-w64-mingw32",
+                       "i686-w64-mingw32", "x86_64-w64-mingw32",
+                       "armv7-w64-mingw32", "aarch64-w64-mingw32"):
+            copy(self, "*", src=os.path.join(self.build_folder, subdir),
+                 dst=os.path.join(self.package_folder, subdir))
+
+    def package_info(self):
+        self.cpp_info.bindirs = ["bin"]
+        self.buildenv_info.prepend_path("PATH", os.path.join(self.package_folder, "bin"))

--- a/recipes/openvpn/conandata.yml
+++ b/recipes/openvpn/conandata.yml
@@ -1,4 +1,7 @@
 patches:
+  "2.7.5":
+    - patch_file: "patches/0001-carefully-handle-CMAKE_GENERATOR_PLATFORM.patch"
+    - patch_file: "patches/0002-explicitly-pass-unicode-everywhere.patch"
   "2.7.0":
     - patch_file: "patches/0001-carefully-handle-CMAKE_GENERATOR_PLATFORM.patch"
     - patch_file: "patches/0002-explicitly-pass-unicode-everywhere.patch"

--- a/recipes/openvpn/conanfile.py
+++ b/recipes/openvpn/conanfile.py
@@ -99,6 +99,9 @@ class Openvpn(ConanFile):
     def package(self):
         if self._is_windows:
             copy(self, "*openvpn.exe", src=self.build_folder, dst=self.package_folder, keep_path=False)
+            # tapctl creates/deletes adapters for both tap-windows6 and
+            # ovpn-dco hwids; the service uses it to provision the DCO adapter
+            copy(self, "*tapctl.exe", src=self.build_folder, dst=self.package_folder, keep_path=False)
         else:
             copy(self, "openvpn", src=os.path.join(self.build_folder, "src", "openvpn"), dst=self.package_folder)
 
@@ -107,3 +110,7 @@ class Openvpn(ConanFile):
 
         ext = ".exe" if self._is_windows else ""
         self.cpp_info.location = os.path.join(self.package_folder, f"openvpn{ext}")
+        if self._is_windows:
+            self.cpp_info.set_property("cmake_extra_variables", {
+                "OPENVPN_TAPCTL_PATH": os.path.join(self.package_folder, "tapctl.exe").replace("\\", "/")
+            })

--- a/recipes/openvpn/conanfile.py
+++ b/recipes/openvpn/conanfile.py
@@ -9,7 +9,7 @@ import os
 
 class Openvpn(ConanFile):
     name = "openvpn"
-    version = "2.7.0"
+    version = "2.7.5"
     package_type = "application"
     settings = "os", "build_type", "arch", "compiler"
 
@@ -49,7 +49,7 @@ class Openvpn(ConanFile):
 
     def source(self):
         get(self, f"https://github.com/OpenVPN/openvpn/archive/refs/tags/v{self.version}.zip",
-            sha256="1a65d8587f932c13d55b1f175ff2e1d61d795d9092788662e888054854d4ee3d", strip_root=True
+            sha256="8b005fb1b4fd008c0e0b8dbd618498efcda89e5843b59364d970ede254f3a049", strip_root=True
         )
 
     def _patch_sources(self):

--- a/recipes/openvpn/conanfile.py
+++ b/recipes/openvpn/conanfile.py
@@ -4,6 +4,7 @@ from conan.tools.gnu import Autotools, AutotoolsToolchain, AutotoolsDeps, PkgCon
 from conan.tools.layout import basic_layout
 from conan.tools.cmake import cmake_layout, CMakeToolchain, CMake, CMakeDeps
 
+import glob
 import os
 
 class Openvpn(ConanFile):
@@ -52,11 +53,30 @@ class Openvpn(ConanFile):
         )
 
     def _patch_sources(self):
-        replace_in_file(self, 
+        replace_in_file(self,
             os.path.join(self.source_folder, "CMakeLists.txt"),
             "/Qspectre",
             ""
         )
+
+    def _find_mc_compiler(self):
+        # src/openvpnserv needs the Windows message compiler; with the VS
+        # generator nothing puts the SDK bin dir on PATH unless the console
+        # ran vcvars, so resolve mc.exe explicitly and let find_program use it
+        host = {"ARM64": "arm64", "AMD64": "x64", "x86": "x86"}.get(
+            os.environ.get("PROCESSOR_ARCHITECTURE", ""), "x64")
+        candidates = []
+        sdk_bin = os.environ.get("WindowsSdkVerBinPath")
+        if sdk_bin:
+            candidates.append(os.path.join(sdk_bin, host, "mc.exe"))
+        pf86 = os.environ.get("ProgramFiles(x86)", "C:\\Program Files (x86)")
+        candidates.extend(sorted(
+            glob.glob(os.path.join(pf86, "Windows Kits", "10", "bin", "10.*", host, "mc.exe")),
+            reverse=True))
+        for candidate in candidates:
+            if os.path.exists(candidate):
+                return candidate.replace("\\", "/")
+        return None
 
     def generate(self):
         self._patch_sources()
@@ -73,6 +93,9 @@ class Openvpn(ConanFile):
             tc.extra_cxxflags = [ f"-I{tap_include_path}", f"-I{applink_include_path}" ]
             tc.cache_variables["BUILD_TESTING"] = False
             tc.cache_variables["ENABLE_PKCS11"] = False
+            mc_compiler = self._find_mc_compiler()
+            if mc_compiler:
+                tc.cache_variables["MC_COMPILER"] = mc_compiler
             tc.generate()
             deps = CMakeDeps(self)
             deps.generate()

--- a/recipes/ovpn-dco-win/conanfile.py
+++ b/recipes/ovpn-dco-win/conanfile.py
@@ -1,0 +1,61 @@
+from conan import ConanFile
+from conan.tools.layout import basic_layout
+from conan.tools.files import get, copy
+from conan.errors import ConanInvalidConfiguration
+
+import os
+
+
+class OvpnDcoWin(ConanFile):
+    name = "ovpn-dco-win"
+    version = "2.8.3"
+    settings = "os", "arch"
+
+    # Microsoft-attestation-signed driver binaries; they MUST be shipped
+    # byte-identical — rebuilding or re-signing breaks the signature chain.
+    # The zip carries win10/ (NetAdapterCx 2.0) and win11/ (NetAdapterCx 2.1)
+    # flavours of ovpn-dco.{inf,cat,sys}; the service picks one at install
+    # time based on the OS build.
+    _arch_map = {
+        "x86": "x86",
+        "x86_64": "amd64",
+        "armv8": "arm64",
+    }
+
+    _sha256 = {
+        "amd64": "aab2b875a2c8e8bf3a262a7c4e496256a7dfc995f12f568f7e70f372ff118497",
+        "arm64": "a0df0d9de5cfde8a7a862da8dd418955c15f4ced0a079d4601a331b9d69243bb",
+    }
+
+    @property
+    def _arch(self):
+        return self._arch_map.get(str(self.settings.arch))
+
+    def layout(self):
+        basic_layout(self)
+
+    def validate(self):
+        if not str(self.settings.os).startswith("Windows"):
+            raise ConanInvalidConfiguration(
+                f"{self.name} v{self.version} supports only Windows"
+            )
+        if self._arch not in self._sha256:
+            raise ConanInvalidConfiguration(
+                f"{self.name} v{self.version} does not support {self.settings.arch} architecture"
+            )
+
+    def build(self):
+        get(self,
+            f"https://github.com/OpenVPN/ovpn-dco-win/releases/download/{self.version}/ovpn-dco-win-{self.version}-{self._arch}.zip",
+            sha256=self._sha256[self._arch])
+
+    def package(self):
+        for flavour in ("win10", "win11"):
+            copy(self, "*", src=os.path.join(self.build_folder, flavour),
+                 dst=os.path.join(self.package_folder, "bin", flavour))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_target_name", "openvpn::ovpn-dco-win")
+        self.cpp_info.set_property("cmake_extra_variables", {
+            "OVPN_DCO_WIN_BIN": os.path.join(self.package_folder, "bin").replace("\\", "/")
+        })

--- a/recipes/tun2socks/conanfile.py
+++ b/recipes/tun2socks/conanfile.py
@@ -14,7 +14,7 @@ import shlex
 
 class Tun2Socks(ConanFile):
     name = "tun2socks"
-    version = "2.6.0"
+    version = "2.7.0"
     package_type = "application"
     settings = "os", "arch"
 
@@ -86,7 +86,7 @@ class Tun2Socks(ConanFile):
 
     def source(self):
         get(self, f"https://github.com/xjasonlyu/tun2socks/archive/refs/tags/v{self.version}.zip",
-            sha256="a7ef9cec1c30dfe9971af89a8aac767fd3d2a4df833e92b635642c2f0204c701", strip_root=True
+            sha256="ffc4b85bd8a6a1a5fff1c755aeeca81358a435151d82a43cb44a9489a68907a0", strip_root=True
         )
 
     def generate(self):

--- a/recipes/tun2socks/conanfile.py
+++ b/recipes/tun2socks/conanfile.py
@@ -65,9 +65,16 @@ class Tun2Socks(ConanFile):
                 f"{self.name} v{self.version} does not support multiarch builds"
             )
 
+    @property
+    def _is_windows_arm64(self):
+        return self._is_windows and self._archs == ["armv8"]
+
     def build_requirements(self):
         self.tool_requires("go/1.26.0")
-        if self._is_windows:
+        if self._is_windows and not self._is_windows_arm64:
+            # armv8 skips msys2/mingw entirely: neither has an armv8 build on
+            # conan-center, and tun2socks is pure Go (upstream ships
+            # CGO_ENABLED=0), so the Makefile wrapper is bypassed below
             self.win_bash = True
             if not self.conf.get("tools.microsoft.bash:path", check_type=str):
                 self.tool_requires("msys2/cci.latest")
@@ -97,6 +104,17 @@ class Tun2Socks(ConanFile):
         tc.generate(env)
 
     def build(self):
+        if self._is_windows_arm64:
+            # mirrors the Makefile's `make tun2socks` (CGO_ENABLED=0 go build)
+            # without needing bash/make from msys2
+            out = os.path.join(self.build_folder, self._binary_name_ext)
+            env = Environment()
+            env.define("GOARCH", self._arch_map["armv8"])
+            env.define("CGO_ENABLED", "0")
+            with chdir(self, self.source_folder), env.vars(self).apply():
+                self.run(f'go build -v -trimpath -ldflags="-w -s -buildid=" -o "{out}" .')
+            return
+
         with chdir(self, self.source_folder):
             for arch in self._archs:
                 build_dir = os.path.join(self.build_folder, arch) if self._is_multiarch else self.build_folder

--- a/recipes/win-split-tunnel/conanfile.py
+++ b/recipes/win-split-tunnel/conanfile.py
@@ -24,23 +24,35 @@ class WinSplitTunnel(ConanFile):
     def layout(self):
         basic_layout(self)
 
+    _sha256 = {
+        "x86_64": {
+            "mullvad-split-tunnel.cat": "9bbd10b95a2cf2226b266a52077300c280f7782def69ebbeb892bb60505d9a5f",
+            "mullvad-split-tunnel.inf": "4ec3c2bdefc2a1df9e4e19cd4301b5774624ea07e61add588067b16f8925f5d7",
+            "mullvad-split-tunnel.pdb": "ee0e246b18a3bfecfc27104b40f9492ffd2b735582870fbd572f93d55e8e9eaa",
+            "mullvad-split-tunnel.sys": "4056b22d08115c1a83bc2cafa17de0bb17db3705eac382de77fd7935eeff7edb",
+        },
+        "aarch64": {
+            "mullvad-split-tunnel.cat": "d6c27e43b6aaca989d59ca63c5b53f1876d3dbe9a189d654ee0f49c5b37b8a44",
+            "mullvad-split-tunnel.inf": "acd2e65ea51ad2c76725c3a8f3afd65f0e5b2a7e1c5410371db67a3fb0f3cb72",
+            "mullvad-split-tunnel.pdb": "a10382fd0534aec18a998b0b6068a47a1111f42da196240ddf066f1cdb475d92",
+            "mullvad-split-tunnel.sys": "dd5befd1537e6f1e90fe2a0139c8d91deda41faaef84a234b780ffc49037b9be",
+        },
+    }
+
     def validate(self):
         if not str(self.settings.os).startswith("Windows"):
             raise ConanInvalidConfiguration(
                 f"{self.name} v{self.version} supports only Windows"
             )
+        if not self._arch:
+            raise ConanInvalidConfiguration(
+                f"{self.name} v{self.version} does not support {self.settings.arch} architecture"
+            )
 
     def build(self):
         url = f"https://raw.githubusercontent.com/mullvad/mullvadvpn-app-binaries/ff0e3746c89a04314377cffeb52faaa976413a69/{self._target}/split-tunnel"
 
-        files = [
-            ("mullvad-split-tunnel.cat", "9bbd10b95a2cf2226b266a52077300c280f7782def69ebbeb892bb60505d9a5f"),
-            ("mullvad-split-tunnel.inf", "4ec3c2bdefc2a1df9e4e19cd4301b5774624ea07e61add588067b16f8925f5d7"),
-            ("mullvad-split-tunnel.pdb", "ee0e246b18a3bfecfc27104b40f9492ffd2b735582870fbd572f93d55e8e9eaa"),
-            ("mullvad-split-tunnel.sys", "4056b22d08115c1a83bc2cafa17de0bb17db3705eac382de77fd7935eeff7edb"),
-        ]
-
-        for name, sha256 in files:
+        for name, sha256 in self._sha256[self._arch].items():
             download(self, f"{url}/{name}", os.path.join("prebuilt", name), sha256=sha256)
 
     def package(self):

--- a/service/server/CMakeLists.txt
+++ b/service/server/CMakeLists.txt
@@ -181,6 +181,7 @@ if(WIN32)
         gdi32
         Advapi32
         Kernel32
+        setupapi
         qt6keychain
     )
 
@@ -414,6 +415,7 @@ if (WIN32)
         DESTINATION ${CMAKE_INSTALL_BINDIR}
         COMPONENT AmneziaVPN
     )
+
 endif()
 
 # install target

--- a/service/server/CMakeLists.txt
+++ b/service/server/CMakeLists.txt
@@ -129,6 +129,7 @@ if(WIN32)
 
     set(HEADERS ${HEADERS}
         ${CMAKE_CURRENT_LIST_DIR}/tapcontroller_win.h
+        ${CMAKE_CURRENT_LIST_DIR}/dcocontroller_win.h
         ${CMAKE_CURRENT_LIST_DIR}/router_win.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../../client/platforms/windows/daemon/windowsdaemon.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../../client/platforms/windows/daemon/windowsdaemontunnel.h
@@ -149,6 +150,7 @@ if(WIN32)
 
     set(SOURCES ${SOURCES}
         ${CMAKE_CURRENT_LIST_DIR}/tapcontroller_win.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/dcocontroller_win.cpp
         ${CMAKE_CURRENT_LIST_DIR}/router_win.cpp
 
         ${CMAKE_CURRENT_SOURCE_DIR}/../../client/platforms/windows/daemon/windowsdaemon.cpp
@@ -358,6 +360,9 @@ endif()
 
 find_package(openvpn REQUIRED)
 list(APPEND CONAN_EXECS $<TARGET_FILE:openvpn::openvpn>)
+if(WIN32 AND OPENVPN_TAPCTL_PATH)
+    list(APPEND CONAN_EXECS ${OPENVPN_TAPCTL_PATH})
+endif()
 
 find_package(tun2socks REQUIRED)
 list(APPEND CONAN_EXECS $<TARGET_FILE:xjasonlyu::tun2socks>)
@@ -416,6 +421,16 @@ if (WIN32)
         COMPONENT AmneziaVPN
     )
 
+    find_package(ovpn-dco-win REQUIRED)
+    add_custom_command(TARGET ${PROJECT} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            "${OVPN_DCO_WIN_BIN}"
+            "$<TARGET_FILE_DIR:${PROJECT}>/dco"
+    )
+    install(DIRECTORY "${OVPN_DCO_WIN_BIN}/"
+        DESTINATION "${CMAKE_INSTALL_BINDIR}/dco"
+        COMPONENT AmneziaVPN
+    )
 endif()
 
 # install target

--- a/service/server/dcocontroller_win.cpp
+++ b/service/server/dcocontroller_win.cpp
@@ -1,0 +1,113 @@
+#include <QCoreApplication>
+#include <QDebug>
+#include <QOperatingSystemVersion>
+#include <QProcess>
+
+#include "dcocontroller_win.h"
+
+DcoController &DcoController::Instance()
+{
+    static DcoController s;
+    return s;
+}
+
+QString DcoController::getDcoDriverDir()
+{
+    // win11 flavour is NetAdapterCx 2.1, win10 (2004+) flavour is 2.0
+    const QString flavour =
+            QOperatingSystemVersion::current() >= QOperatingSystemVersion::Windows11 ? "win11" : "win10";
+    return qApp->applicationDirPath() + "\\dco\\" + flavour;
+}
+
+QString DcoController::getTapctlPath()
+{
+    return qApp->applicationDirPath() + "\\tapctl.exe";
+}
+
+bool DcoController::isDriverInstalled()
+{
+    QProcess proc;
+    proc.start("pnputil", { "/enum-drivers" });
+    if (!proc.waitForStarted()) {
+        qWarning() << "DcoController: failed to start pnputil";
+        return false;
+    }
+    proc.waitForFinished();
+
+    // the driver store lists packages by their original inf name
+    return QString(proc.readAllStandardOutput()).contains("ovpn-dco.inf", Qt::CaseInsensitive);
+}
+
+bool DcoController::installDriver()
+{
+    const QString inf = getDcoDriverDir() + "\\ovpn-dco.inf";
+
+    QProcess proc;
+    proc.start("pnputil", { "/add-driver", inf, "/install" });
+    if (!proc.waitForStarted()) {
+        qWarning() << "DcoController: failed to start pnputil";
+        return false;
+    }
+    proc.waitForFinished(60000);
+
+    const QString output = QString(proc.readAllStandardOutput());
+    qDebug().noquote() << "DcoController: pnputil /add-driver" << inf << "exit code"
+                       << proc.exitCode() << "output:" << output;
+
+    // 0 = ok, 3010 = ok but reboot required
+    return proc.exitCode() == 0 || proc.exitCode() == 3010;
+}
+
+bool DcoController::adapterExists()
+{
+    QProcess proc;
+    proc.start(getTapctlPath(), { "list" });
+    if (!proc.waitForStarted()) {
+        qWarning() << "DcoController: failed to start tapctl.exe";
+        return false;
+    }
+    proc.waitForFinished();
+
+    return QString(proc.readAllStandardOutput()).contains(kAdapterName);
+}
+
+bool DcoController::createAdapter()
+{
+    QProcess proc;
+    proc.start(getTapctlPath(), { "create", "--hwid", "ovpn-dco", "--name", kAdapterName });
+    if (!proc.waitForStarted()) {
+        qWarning() << "DcoController: failed to start tapctl.exe";
+        return false;
+    }
+    proc.waitForFinished(60000);
+
+    const QString output = QString(proc.readAllStandardOutput()) + QString(proc.readAllStandardError());
+    qDebug().noquote() << "DcoController: tapctl create exit code" << proc.exitCode()
+                       << "output:" << output;
+
+    return proc.exitCode() == 0;
+}
+
+bool DcoController::checkAndSetup()
+{
+    qDebug().noquote() << "DcoController: driver dir" << getDcoDriverDir();
+
+    if (!isDriverInstalled()) {
+        qDebug() << "DcoController: ovpn-dco driver not found, installing...";
+        if (!installDriver()) {
+            qWarning() << "DcoController: driver installation failed";
+            return false;
+        }
+    }
+
+    if (!adapterExists()) {
+        qDebug() << "DcoController: creating" << kAdapterName << "adapter...";
+        if (!createAdapter()) {
+            qWarning() << "DcoController: adapter creation failed";
+            return false;
+        }
+    }
+
+    qDebug() << "DcoController: ovpn-dco driver and adapter are ready";
+    return true;
+}

--- a/service/server/dcocontroller_win.h
+++ b/service/server/dcocontroller_win.h
@@ -1,0 +1,41 @@
+#ifndef DCOCONTROLLERWIN_H
+#define DCOCONTROLLERWIN_H
+
+#include <QString>
+
+/**
+ * @brief The DcoController class - installs the ovpn-dco-win driver and
+ * provisions a Data Channel Offload adapter for OpenVPN 2.6+.
+ *
+ * OpenVPN 2.7 uses ovpn-dco by default (wintun support was removed) and, when
+ * launched without OpenVPN's own Interactive Service, expects the adapter to
+ * already exist. The signed driver flavours are shipped in <appdir>/dco/
+ * {win10,win11}; adapters are created with the bundled tapctl.exe.
+ * tap-windows6 (see TapController) remains the fallback data path for configs
+ * that are not DCO-compatible.
+ */
+class DcoController
+{
+public:
+    static DcoController &Instance();
+
+    static constexpr const char *kAdapterName = "AmneziaDCO";
+
+    // ensures the driver is installed and a DCO adapter exists
+    bool checkAndSetup();
+
+    bool isDriverInstalled();
+    bool installDriver();
+    bool adapterExists();
+    bool createAdapter();
+
+private:
+    DcoController() = default;
+    DcoController(DcoController const &) = delete;
+    DcoController &operator=(DcoController const &) = delete;
+
+    QString getDcoDriverDir();
+    QString getTapctlPath();
+};
+
+#endif // DCOCONTROLLERWIN_H

--- a/service/server/router.cpp
+++ b/service/server/router.cpp
@@ -80,6 +80,9 @@ bool Router::createTun(const QString &dev, const QString &subnet)
 
 bool Router::deleteTun(const QString &dev)
 {
+#ifdef Q_OS_WIN
+    return RouterWin::Instance().deleteTun(dev);
+#endif
 #ifdef Q_OS_LINUX
     return RouterLinux::Instance().deleteTun(dev);
 #endif

--- a/service/server/router_win.cpp
+++ b/service/server/router_win.cpp
@@ -4,6 +4,10 @@
 #include <tlhelp32.h>
 #include <tchar.h>
 
+#include <initguid.h>
+#include <devguid.h>
+#include <setupapi.h>
+
 #include <QProcess>
 #include <QtConcurrent>
 
@@ -380,6 +384,58 @@ bool RouterWin::createTun(const QString &dev, const QString &subnet)
     return ctx.found;
 }
 
+bool RouterWin::deleteTun(const QString &dev)
+{
+    // Removes the wintun devnode named `dev` (e.g. an orphan left behind when
+    // tun2socks dies without cleaning up, which makes the next connection hang
+    // on adapter creation). The adapter name lives in wintun's private
+    // DEVPKEY_Wintun_Name property — SPDRP_FRIENDLYNAME only holds the tunnel
+    // *type* string, which is shared by every wintun-based product, so
+    // matching by name here is what keeps third-party adapters intact.
+    static const DEVPROPKEY devpkeyWintunName = {
+        { 0x3361c968, 0x2f2e, 0x4660, { 0xb4, 0x7e, 0x69, 0x9c, 0xdc, 0x4c, 0x32, 0xb9 } },
+        DEVPROPID_FIRST_USABLE + 1
+    };
+
+    // no DIGCF_PRESENT: pending-removal ghosts must be enumerated too
+    HDEVINFO devInfo = SetupDiGetClassDevsExW(&GUID_DEVCLASS_NET, L"SWD\\Wintun", nullptr, 0, nullptr, nullptr, nullptr);
+    if (devInfo == INVALID_HANDLE_VALUE) {
+        qWarning() << "RouterWin::deleteTun: SetupDiGetClassDevsExW failed:" << GetLastError();
+        return false;
+    }
+    auto _guardDevInfo = qScopeGuard([devInfo]() { SetupDiDestroyDeviceInfoList(devInfo); });
+
+    SP_DEVINFO_DATA devInfoData;
+    devInfoData.cbSize = sizeof(devInfoData);
+    for (DWORD i = 0; SetupDiEnumDeviceInfo(devInfo, i, &devInfoData); ++i) {
+        DEVPROPTYPE propType = 0;
+        WCHAR name[MAX_PATH] = {};
+        if (!SetupDiGetDevicePropertyW(devInfo, &devInfoData, &devpkeyWintunName, &propType,
+                                       reinterpret_cast<PBYTE>(name), sizeof(name) - sizeof(WCHAR), nullptr, 0)
+            || propType != DEVPROP_TYPE_STRING) {
+            continue;
+        }
+        if (QString::fromWCharArray(name).compare(dev, Qt::CaseInsensitive) != 0) {
+            continue;
+        }
+
+        SP_REMOVEDEVICE_PARAMS params;
+        params.ClassInstallHeader.cbSize = sizeof(SP_CLASSINSTALL_HEADER);
+        params.ClassInstallHeader.InstallFunction = DIF_REMOVE;
+        params.Scope = DI_REMOVEDEVICE_GLOBAL;
+        params.HwProfile = 0;
+        if (!SetupDiSetClassInstallParamsW(devInfo, &devInfoData, &params.ClassInstallHeader, sizeof(params))
+            || !SetupDiCallClassInstaller(DIF_REMOVE, devInfo, &devInfoData)) {
+            qWarning() << "RouterWin::deleteTun: failed to remove wintun adapter" << dev << "error:" << GetLastError();
+            return false;
+        }
+        qDebug() << "RouterWin::deleteTun: removed wintun adapter" << dev;
+    }
+
+    // a missing devnode is not an error — there is simply nothing to clean up
+    return true;
+}
+
 void RouterWin::suspendWcmSvc(bool suspend)
 {
     if (suspend == m_suspended) return;
@@ -564,6 +620,9 @@ bool RouterWin::StartRoutingIpv6()
         [](bool &result, bool success) {
             result = result && success;
         }, true);
+
+        res.waitForFinished();
+        return res.result();
     }
 
     return false;

--- a/service/server/router_win.h
+++ b/service/server/router_win.h
@@ -46,6 +46,7 @@ public:
     bool StopRoutingIpv6();
 
     bool createTun(const QString &dev, const QString &subnet);
+    bool deleteTun(const QString &dev);
     void suspendWcmSvc(bool suspend);
     bool updateResolvers(const QString& ifname, const QList<QHostAddress>& resolvers);
     bool restoreResolvers();


### PR DESCRIPTION
Native Windows ARM64 (armv8) support for the Conan-based tree, plus the OpenVPN data-channel-offload driver that OpenVPN 2.7 needs on that platform.

Closes #2401, addresses #882 and the Windows part of #1429.

Built and runtime-tested on a Snapdragon X Elite laptop (Windows 11 26200): AmneziaWG, WireGuard, Xray and OpenVPN all connect; installers produced by both the IFW and the WiX generators install and upgrade cleanly.

## Windows fixes that are not ARM64-specific

These stand on their own and affect x64 users too:

* **`RouterWin::deleteTun()` was never implemented**, so `Router::deleteTun()` silently returned `true` on Windows. A tun2socks process that dies without a graceful stop leaves its wintun devnode behind, and the next Xray connection then hangs trying to reuse it. The new implementation removes the devnode by its exact adapter name, read from wintun's private `DEVPKEY_Wintun_Name`; matching on `SPDRP_FRIENDLYNAME` would not do, because wintun stores the *tunnel type* there and every wintun-based product shares it.
* **`XrayProtocol::stop()` deleted the TUN before killing tun2socks.** Removing a device that is still held open only marks it pending-removal, which is exactly how the orphan above is created. The delete now happens after the process is reaped.
* **`RouterWin::StartRoutingIpv6()` dropped its `QtConcurrent` future** without `waitForFinished()`, so it always reported failure and the IPv6 restore raced the rest of the shutdown.
* **`WindowsTunnelLogger` polled an unnamed file every 250 ms** when the WireGuard ring-log path is absent, filling the service log with `QFSFileEngine::open: No file name specified`.
* **`deploy/build.bat` never called `vcvarsall`**: the vswhere block reads `%VS_INSTALLER_PATH%` inside the same parenthesised block that sets it, so the variable expands empty. CI hides this because `msvc-dev-cmd` has already set the environment; local builds fail to link.
* **The `openvpn` recipe fails to configure** when the Windows SDK bin directory is not on `PATH`: `src/openvpnserv` calls `find_program(mc.exe)` and aborts. The recipe now resolves the message compiler explicitly and passes it as `MC_COMPILER`.
* **The IFW installer aborted with exit code 1073 on upgrades** — `sc create` returns `ERROR_SERVICE_EXISTS` when the service is still registered. It is now stopped and deleted first.
* **`vc_redist` was never shipped.** `componentscript.js` has always tried to execute `@TargetDir@\vc_redist.<arch>.exe`, but nothing staged that file; the redistributable is now downloaded at configure time and installed, and the architecture is picked from the real CPU rather than a `"64"` substring test.

## ARM64 support

* `recipes/go`: Windows/armv8 toolchain entry, needed as soon as a native ARM64 machine builds anything Go-based.
* `recipes/win-split-tunnel`: the four sha256 values were the x86_64 ones for both architectures. They are per-architecture now — Mullvad has published `aarch64-pc-windows-msvc` binaries since 2024, so split tunnelling works on ARM64 as well.
* **New `recipes/llvm-mingw`**: `mingw-builds` and `msys2` have no armv8 builds on conan-center, and CGO for `GOARCH=arm64` needs an `aarch64-w64-mingw32` compiler. `awg-windows` and `amnezia-xray-bindings` use it for armv8; the same package serves both a native ARM64 host and an x64 cross-build.
* `recipes/tun2socks` and `recipes/amnezia-xray-bindings` build directly with `go build` on Windows/armv8 instead of going through the msys2 Makefile wrapper.
* `deploy/build.bat` handles a native ARM64 host (`PROCESSOR_ARCHITECTURE=ARM64`) and passes the generator platform explicitly, so an x64 machine cross-building `-arch arm64` no longer produces x64 binaries.
* `cmake/CPack.cmake` derives the package suffix and `CPACK_WIX_ARCHITECTURE` from the target architecture; `updateController` and `deploy_s3.sh` follow suit so ARM64 installs do not self-update into the x64 installer.
* `.github/workflows/deploy.yml`: bake and build jobs on `windows-11-arm`, which is generally available for public repositories since August 2025.

## OpenVPN data channel offload

OpenVPN 2.7 removed wintun, and `tap-windows6` is the only remaining alternative to `ovpn-dco`. The client had no way to provision either driver, so OpenVPN could not work on a fresh ARM64 install at all.

* **New `recipes/ovpn-dco-win` 2.8.3** ships the Microsoft-attestation-signed driver byte-for-byte from the official release (win10 and win11 flavours, amd64 and arm64). I verified the SHA256 of these files against the ones inside `OpenVPN-2.7.5-I001-arm64.msi`: they are identical, so this is the same pairing upstream ships. The driver is GPLv2, so redistribution is fine; nothing is rebuilt or re-signed.
* The `openvpn` recipe also packages `tapctl.exe`. Without OpenVPN's own interactive service, adapter creation has to happen on our side.
* **New `DcoController`** installs the driver with `pnputil` on first use, picks the win10/win11 flavour by OS build, and creates the `AmneziaDCO` adapter with `tapctl`. `IpcServer::checkAndInstallDriver()` tries DCO first and falls back to `TapController`.
* When a config is not DCO-capable (compression, `--fragment`, a proxy, a non-AEAD data cipher, `--dev tap`), openvpn falls back to `tap-windows6` on its own and dies with *"There are no TAP-Windows or ovpn-dco adapters on this system"*. That message now triggers an on-demand install of the legacy driver and one retry.
* `ncp-disable` is stripped from local configs: the option was removed in OpenVPN 2.6 and 2.7 rejects it outright, so any server configured with it currently produces a hard failure on Windows.

## Dependency bumps

* `openvpn` 2.7.0 → 2.7.5 — nine CVEs, and it is the userspace release that `openvpn-build` pairs with driver 2.8.3.
* `tun2socks` 2.6.0 → 2.7.0.

## Notes for reviewers

The commits are ordered so they can be reviewed — and if you prefer, cherry-picked — independently; only the ARM64 recipe work and the DCO work touch the same files.

Qt is unchanged at 6.10.1 (`win64_msvc2022_arm64_cross_compiled` plus the same `qtremoteobjects qt5compat qtshadertools` module set the x64 job uses).

`awg-windows` still has no arm64 target in its own `build.cmd`; the recipe drives the Go build directly, so nothing is blocked, but a one-line addition upstream would mirror what `wireguard-windows` already does.


---

**Note on scope:** this branch also carries one commit that is *not* ARM64-specific and is submitted independently as #2882 — `WireGuardClientConfig::fromJson`/`toJson` was not round-tripping the AmneziaWG obfuscation parameters, so a WireGuard profile that had obfuscation enabled silently degrades to plain WireGuard after an upgrade. It rides along here only so the ARM64 build is self-contained; please review and merge it in #2882 — the commit is identical, so it drops out of this range once #2882 lands on `dev`.