### PR TITLE
Preserve AmneziaWG obfuscation params in WireGuardClientConfig (fixes obfuscation lost on upgrade)

### DIFF
--- a/client/core/models/protocols/wireGuardProtocolConfig.cpp
+++ b/client/core/models/protocols/wireGuardProtocolConfig.cpp
@@ -109,7 +109,80 @@ QJsonObject WireGuardClientConfig::toJson() const
     if (isObfuscationEnabled) {
         obj[configKey::isObfuscationEnabled] = isObfuscationEnabled;
     }
-    
+
+    // Round-trip AmneziaWG obfuscation parameters. Written only when present so
+    // a plain WireGuard config stays clean, while an obfuscated one keeps its
+    // junk params across the config model instead of degrading to plain WG.
+    if (!junkPacketCount.isEmpty()) {
+        obj[configKey::junkPacketCount] = junkPacketCount;
+    }
+    if (!junkPacketMinSize.isEmpty()) {
+        obj[configKey::junkPacketMinSize] = junkPacketMinSize;
+    }
+    if (!junkPacketMaxSize.isEmpty()) {
+        obj[configKey::junkPacketMaxSize] = junkPacketMaxSize;
+    }
+    if (!initPacketJunkSize.isEmpty()) {
+        obj[configKey::initPacketJunkSize] = initPacketJunkSize;
+    }
+    if (!responsePacketJunkSize.isEmpty()) {
+        obj[configKey::responsePacketJunkSize] = responsePacketJunkSize;
+    }
+    if (!cookieReplyPacketJunkSize.isEmpty()) {
+        obj[configKey::cookieReplyPacketJunkSize] = cookieReplyPacketJunkSize;
+    }
+    if (!transportPacketJunkSize.isEmpty()) {
+        obj[configKey::transportPacketJunkSize] = transportPacketJunkSize;
+    }
+    if (!initPacketMagicHeader.isEmpty()) {
+        obj[configKey::initPacketMagicHeader] = initPacketMagicHeader;
+    }
+    if (!responsePacketMagicHeader.isEmpty()) {
+        obj[configKey::responsePacketMagicHeader] = responsePacketMagicHeader;
+    }
+    if (!underloadPacketMagicHeader.isEmpty()) {
+        obj[configKey::underloadPacketMagicHeader] = underloadPacketMagicHeader;
+    }
+    if (!transportPacketMagicHeader.isEmpty()) {
+        obj[configKey::transportPacketMagicHeader] = transportPacketMagicHeader;
+    }
+    if (!specialJunk1.isEmpty()) {
+        obj[configKey::specialJunk1] = specialJunk1;
+    }
+    if (!specialJunk2.isEmpty()) {
+        obj[configKey::specialJunk2] = specialJunk2;
+    }
+    if (!specialJunk3.isEmpty()) {
+        obj[configKey::specialJunk3] = specialJunk3;
+    }
+    if (!specialJunk4.isEmpty()) {
+        obj[configKey::specialJunk4] = specialJunk4;
+    }
+    if (!specialJunk5.isEmpty()) {
+        obj[configKey::specialJunk5] = specialJunk5;
+    }
+    if (!headerProtectionKey.isEmpty()) {
+        obj[configKey::headerProtectionKey] = headerProtectionKey;
+    }
+    if (!contentPaddingAddition.isEmpty()) {
+        obj[configKey::contentPaddingAddition] = contentPaddingAddition;
+    }
+    if (!rekeyAfterTime.isEmpty()) {
+        obj[configKey::rekeyAfterTime] = rekeyAfterTime;
+    }
+    if (!rekeyTimeout.isEmpty()) {
+        obj[configKey::rekeyTimeout] = rekeyTimeout;
+    }
+    if (!rejectAfterTime.isEmpty()) {
+        obj[configKey::rejectAfterTime] = rejectAfterTime;
+    }
+    if (!keepaliveTimeout.isEmpty()) {
+        obj[configKey::keepaliveTimeout] = keepaliveTimeout;
+    }
+    if (!maxHandshakeAttempts.isEmpty()) {
+        obj[configKey::maxHandshakeAttempts] = maxHandshakeAttempts;
+    }
+
     return obj;
 }
 
@@ -135,7 +208,34 @@ WireGuardClientConfig WireGuardClientConfig::fromJson(const QJsonObject& json)
     config.mtu = json.value(configKey::mtu).toString();
     
     config.isObfuscationEnabled = json.value(configKey::isObfuscationEnabled).toBool(false);
-    
+
+    // Preserve AmneziaWG obfuscation parameters (see header): without this a
+    // WireGuard config that had obfuscation enabled loses its junk params on
+    // read and silently degrades to plain WireGuard.
+    config.junkPacketCount = json.value(configKey::junkPacketCount).toString();
+    config.junkPacketMinSize = json.value(configKey::junkPacketMinSize).toString();
+    config.junkPacketMaxSize = json.value(configKey::junkPacketMaxSize).toString();
+    config.initPacketJunkSize = json.value(configKey::initPacketJunkSize).toString();
+    config.responsePacketJunkSize = json.value(configKey::responsePacketJunkSize).toString();
+    config.cookieReplyPacketJunkSize = json.value(configKey::cookieReplyPacketJunkSize).toString();
+    config.transportPacketJunkSize = json.value(configKey::transportPacketJunkSize).toString();
+    config.initPacketMagicHeader = json.value(configKey::initPacketMagicHeader).toString();
+    config.responsePacketMagicHeader = json.value(configKey::responsePacketMagicHeader).toString();
+    config.underloadPacketMagicHeader = json.value(configKey::underloadPacketMagicHeader).toString();
+    config.transportPacketMagicHeader = json.value(configKey::transportPacketMagicHeader).toString();
+    config.specialJunk1 = json.value(configKey::specialJunk1).toString();
+    config.specialJunk2 = json.value(configKey::specialJunk2).toString();
+    config.specialJunk3 = json.value(configKey::specialJunk3).toString();
+    config.specialJunk4 = json.value(configKey::specialJunk4).toString();
+    config.specialJunk5 = json.value(configKey::specialJunk5).toString();
+    config.headerProtectionKey = json.value(configKey::headerProtectionKey).toString();
+    config.contentPaddingAddition = json.value(configKey::contentPaddingAddition).toString();
+    config.rekeyAfterTime = json.value(configKey::rekeyAfterTime).toString();
+    config.rekeyTimeout = json.value(configKey::rekeyTimeout).toString();
+    config.rejectAfterTime = json.value(configKey::rejectAfterTime).toString();
+    config.keepaliveTimeout = json.value(configKey::keepaliveTimeout).toString();
+    config.maxHandshakeAttempts = json.value(configKey::maxHandshakeAttempts).toString();
+
     return config;
 }
 

--- a/client/core/models/protocols/wireGuardProtocolConfig.h
+++ b/client/core/models/protocols/wireGuardProtocolConfig.h
@@ -37,7 +37,35 @@ struct WireGuardClientConfig {
     QString persistentKeepAlive;
     QString mtu;
     bool isObfuscationEnabled = false;
-    
+
+    // AmneziaWG obfuscation parameters. A native WireGuard config imported with
+    // "Enable WireGuard obfuscation" is stored in the WireGuard container with
+    // these set; they must round-trip so an already-obfuscated profile keeps
+    // working after upgrade instead of degrading to plain WireGuard.
+    QString junkPacketCount;
+    QString junkPacketMinSize;
+    QString junkPacketMaxSize;
+    QString initPacketJunkSize;
+    QString responsePacketJunkSize;
+    QString cookieReplyPacketJunkSize;
+    QString transportPacketJunkSize;
+    QString initPacketMagicHeader;
+    QString responsePacketMagicHeader;
+    QString underloadPacketMagicHeader;
+    QString transportPacketMagicHeader;
+    QString specialJunk1;
+    QString specialJunk2;
+    QString specialJunk3;
+    QString specialJunk4;
+    QString specialJunk5;
+    QString headerProtectionKey;
+    QString contentPaddingAddition;
+    QString rekeyAfterTime;
+    QString rekeyTimeout;
+    QString rejectAfterTime;
+    QString keepaliveTimeout;
+    QString maxHandshakeAttempts;
+
     QJsonObject toJson() const;
     static WireGuardClientConfig fromJson(const QJsonObject& json);
 };


### PR DESCRIPTION
# Preserve AmneziaWG obfuscation params in WireGuardClientConfig (fixes obfuscation lost on upgrade)

## Problem it solves

An existing WireGuard profile that had **"Enable WireGuard obfuscation"** turned on stops passing traffic after the app is updated — with no change to the profile, the server, or the network. The connection still "connects" (handshake completes), but nothing behind the tunnel is reachable; on a DPI network the server's replies stop a few seconds after the handshake. Re-importing the same config with the obfuscation checkbox makes it work again, which is exactly the surprising part: **the upgrade silently strips obfuscation from an already-working profile.**

## Root cause

When a native WireGuard config is imported with obfuscation enabled (`ImportController::processNativeWireGuardConfig`), the AmneziaWG parameters (`Jc`/`Jmin`/`Jmax`, `S1`–`S4`, `H1`–`H4`, `I1`–`I5`, header protection key, content padding, awg timers) are stored **inside the WireGuard container** alongside the `isObfuscationEnabled` flag.

`WireGuardClientConfig::fromJson`/`toJson` (`client/core/models/protocols/wireGuardProtocolConfig.cpp`) only round-trips `isObfuscationEnabled` and **drops every actual parameter**. So the first time the profile passes through the typed config model (i.e. on the next launch / after an upgrade), the junk parameters are gone and the config that reaches the daemon and the tunnel is **plain WireGuard**. `AwgClientConfig` round-trips these fields; `WireGuardClientConfig` was missing them.

Downstream this also means `localSocketController` never forwards the awg params (the `else if` there requires the full `Jc…H4` set to be defined), so the tunnel comes up unobfuscated.

## Steps to reproduce

1. Import a **native WireGuard** `.conf` and enable **"Enable WireGuard obfuscation"** on import.
2. Connect — it works (obfuscated). `awg showconf <tunnel>` shows `Jc`, `Jmin`, `Jmax`, `I1`, etc.
3. Update the app to a build that reads the profile through the current config model (or simply relaunch so the profile is re-serialized through `WireGuardClientConfig`).
4. Connect to the same profile again.

**Expected:** still obfuscated, still works.
**Actual:** the tunnel now runs plain WireGuard — `awg showconf` shows no `Jc`/`I1`. On a network that blocks WireGuard by DPI, the handshake completes and a few packets flow, then the server's replies stop (~4 s in) and nothing behind the tunnel is reachable; `rx_bytes` freezes while `tx_bytes` keeps growing.

Verified on Windows ARM64: an obfuscated profile that works on 4.8 stops passing traffic on 5.0 with the **same `tunnel.dll`, same routing, same keys**; a NIC packet capture showed plain-WireGuard frames after the model round-trip, and `awg showconf` on the still-working 4.8 tunnel showed the obfuscation params 5.0 had dropped.

## Fix

Add the AmneziaWG obfuscation fields to `WireGuardClientConfig` and round-trip them in `fromJson`/`toJson`, mirroring `AwgClientConfig`. Values are written only when present, so a genuinely plain WireGuard config emits no obfuscation keys and is unaffected.

## Testing

- Obfuscated native-WireGuard profile that regressed after the upgrade now keeps working **without re-import**: obfuscation params survive the round-trip, `awg showconf` shows `jc`/`jmin`/`jmax`/`i1`, `rx_bytes` grows steadily instead of freezing, RDP/traffic behind the tunnel works.
- Plain WireGuard config (no obfuscation) unchanged — no obfuscation keys emitted, behaviour identical to before.
