### PR TITLE
fix: require Qt 6.9, the actual minimum for the QML UI

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -38,7 +38,10 @@ if(WIN32 OR (APPLE AND NOT IOS) OR (LINUX AND NOT ANDROID))
     set(PACKAGES ${PACKAGES} Widgets)
 endif()
 
-find_package(Qt6 REQUIRED COMPONENTS ${PACKAGES})
+# Qt 6.9 minimum: client/ui/qml/Controls2 uses the ContextMenu attached type,
+# introduced in Qt 6.9. Older Qt configures, compiles and links without warnings,
+# then fails at runtime when the QML engine loads the UI.
+find_package(Qt6 6.9 REQUIRED COMPONENTS ${PACKAGES})
 
 set(LIBS ${LIBS}
     Qt6::Core Qt6::Gui


### PR DESCRIPTION
`client/ui/qml/Controls2` uses the `ContextMenu` attached type, [introduced in Qt 6.9](https://doc.qt.io/qt-6/qml-qtquick-controls-contextmenu.html), in three files — `TextFieldWithHeaderType.qml:147`, `TextAreaType.qml:96`, `TextAreaWithFooterType.qml:82`.

`find_package(Qt6 REQUIRED COMPONENTS ...)` declared no minimum version, so Qt 6.8 and older configure, compile and link without a single warning, and fail only when the QML engine loads the UI:

```
QQmlApplicationEngine failed to load component
qrc:/ui/qml/main2.qml:213:9: Type CaptchaDialogType unavailable
qrc:/ui/qml/Controls2/CaptchaDialogType.qml:222:13: Type TextFieldWithHeaderType unavailable
qrc:/ui/qml/Controls2/TextFieldWithHeaderType.qml:147:25: Non-existent attached object
```

The result is a client that builds successfully and cannot open its main window.

**Verified both directions on aarch64:**

| Qt | Result |
|---|---|
| 6.8.2 (Debian 13 trixie) | QML fails to load, as above |
| 6.10.2 (Ubuntu 26.04) | UI loads — `Started AmneziaVPN version 5.0.0.2` |

This is not architecture-specific — it affects any build against distro Qt older than 6.9. It shows up on ARM64 Linux first because Qt publishes no official aarch64 Linux desktop binaries, so distro Qt is the only option there, and several distros still ship 6.8 or older. Related: #1324.

CI is unaffected: the workflows install Qt 6.10.1, comfortably above the floor.

With this change, an unsuitable Qt fails at configure time with both versions named:

```
Could not find a configuration file for package "Qt6" that is compatible
with requested version "6.9".
  .../Qt6Config.cmake, version: 6.8.2
```
