### PR TITLE
fix: build and run on distro Qt by dropping 6.5+ API dependencies

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -38,7 +38,7 @@ if(WIN32 OR (APPLE AND NOT IOS) OR (LINUX AND NOT ANDROID))
     set(PACKAGES ${PACKAGES} Widgets)
 endif()
 
-find_package(Qt6 REQUIRED COMPONENTS ${PACKAGES})
+find_package(Qt6 6.4 REQUIRED COMPONENTS ${PACKAGES})
 
 set(LIBS ${LIBS}
     Qt6::Core Qt6::Gui
@@ -246,12 +246,23 @@ if(WIN32)
     set(deploy_tool_options "--force-openssl --force")
 endif()
 
-qt_generate_deploy_qml_app_script(
-    TARGET ${PROJECT}
-    OUTPUT_SCRIPT QT_DEPLOY_SCRIPT
-    NO_UNSUPPORTED_PLATFORM_ERROR
-    DEPLOY_TOOL_OPTIONS ${deploy_tool_options}
-)
+# DEPLOY_TOOL_OPTIONS was added in Qt 6.7; passing it to an older Qt fails at
+# configure time with an unknown-keyword error. It is empty on every platform
+# except Windows, so older Qt simply omits it and behaves identically.
+if(Qt6_VERSION VERSION_GREATER_EQUAL 6.7)
+    qt_generate_deploy_qml_app_script(
+        TARGET ${PROJECT}
+        OUTPUT_SCRIPT QT_DEPLOY_SCRIPT
+        NO_UNSUPPORTED_PLATFORM_ERROR
+        DEPLOY_TOOL_OPTIONS ${deploy_tool_options}
+    )
+else()
+    qt_generate_deploy_qml_app_script(
+        TARGET ${PROJECT}
+        OUTPUT_SCRIPT QT_DEPLOY_SCRIPT
+        NO_UNSUPPORTED_PLATFORM_ERROR
+    )
+endif()
 install(SCRIPT ${QT_DEPLOY_SCRIPT}
     COMPONENT AmneziaVPN
 )

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -246,9 +246,16 @@ if(WIN32)
     set(deploy_tool_options "--force-openssl --force")
 endif()
 
-# DEPLOY_TOOL_OPTIONS was added in Qt 6.7; passing it to an older Qt fails at
-# configure time with an unknown-keyword error. It is empty on every platform
-# except Windows, so older Qt simply omits it and behaves identically.
+# This macro's signature changed twice, and passing a keyword an older Qt does
+# not know fails at configure time with "Unexpected arguments". Read off the Qt
+# sources rather than the docs, which describe only the current signature:
+#
+#   6.4  accepts TARGET / FILENAME_VARIABLE, and no multi-value options at all
+#   6.5  renamed FILENAME_VARIABLE to OUTPUT_SCRIPT
+#   6.7  added DEPLOY_TOOL_OPTIONS
+#
+# DEPLOY_TOOL_OPTIONS is empty on every platform except Windows, so omitting it
+# on older Qt changes nothing.
 if(Qt6_VERSION VERSION_GREATER_EQUAL 6.7)
     qt_generate_deploy_qml_app_script(
         TARGET ${PROJECT}
@@ -256,10 +263,16 @@ if(Qt6_VERSION VERSION_GREATER_EQUAL 6.7)
         NO_UNSUPPORTED_PLATFORM_ERROR
         DEPLOY_TOOL_OPTIONS ${deploy_tool_options}
     )
-else()
+elseif(Qt6_VERSION VERSION_GREATER_EQUAL 6.5)
     qt_generate_deploy_qml_app_script(
         TARGET ${PROJECT}
         OUTPUT_SCRIPT QT_DEPLOY_SCRIPT
+        NO_UNSUPPORTED_PLATFORM_ERROR
+    )
+else()
+    qt_generate_deploy_qml_app_script(
+        TARGET ${PROJECT}
+        FILENAME_VARIABLE QT_DEPLOY_SCRIPT
         NO_UNSUPPORTED_PLATFORM_ERROR
     )
 endif()

--- a/client/ui/qml/Components/QuestionDrawer.qml
+++ b/client/ui/qml/Components/QuestionDrawer.qml
@@ -1,5 +1,3 @@
-pragma ComponentBehavior: Bound
-
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts

--- a/client/ui/qml/Components/SubscriptionExpiredDrawer.qml
+++ b/client/ui/qml/Components/SubscriptionExpiredDrawer.qml
@@ -1,5 +1,3 @@
-pragma ComponentBehavior: Bound
-
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts

--- a/client/ui/qml/Controls2/ContextMenuType.qml
+++ b/client/ui/qml/Controls2/ContextMenuType.qml
@@ -4,8 +4,6 @@ import QtQuick.Controls
 Menu {
     property var textObj
 
-    popupType: Popup.Native
-
     property Item inputBlocker: null
 
     Component {

--- a/client/ui/qml/Controls2/TextAreaType.qml
+++ b/client/ui/qml/Controls2/TextAreaType.qml
@@ -93,7 +93,18 @@ Rectangle {
 
                 wrapMode: Text.Wrap
 
-                ContextMenu.menu: contextMenu
+                // Opens the context menu explicitly instead of via the ContextMenu
+                // attached type, which requires Qt 6.9. Only RightButton is accepted,
+                // so left press/drag still reaches the TextArea for cursor placement,
+                // selection and flicking.
+                MouseArea {
+                    anchors.fill: parent
+                    acceptedButtons: Qt.RightButton
+                    onPressed: {
+                        textArea.forceActiveFocus()
+                        contextMenu.popup()
+                    }
+                }
 
                 ContextMenuType {
                     id: contextMenu

--- a/client/ui/qml/Controls2/TextAreaWithFooterType.qml
+++ b/client/ui/qml/Controls2/TextAreaWithFooterType.qml
@@ -79,7 +79,18 @@ Rectangle {
 
                 wrapMode: Text.Wrap
 
-                ContextMenu.menu: contextMenu
+                // Opens the context menu explicitly instead of via the ContextMenu
+                // attached type, which requires Qt 6.9. Only RightButton is accepted,
+                // so left press/drag still reaches the TextArea for cursor placement,
+                // selection and flicking.
+                MouseArea {
+                    anchors.fill: parent
+                    acceptedButtons: Qt.RightButton
+                    onPressed: {
+                        textArea.forceActiveFocus()
+                        contextMenu.popup()
+                    }
+                }
 
                 ContextMenuType {
                     id: contextMenu

--- a/client/ui/qml/Controls2/TextFieldWithHeaderType.qml
+++ b/client/ui/qml/Controls2/TextFieldWithHeaderType.qml
@@ -144,7 +144,18 @@ Item {
                             }
                         }
 
-                        ContextMenu.menu: contextMenu
+                        // Opens the context menu explicitly instead of via the ContextMenu
+                        // attached type, which requires Qt 6.9. Only RightButton is
+                        // accepted, so left press/drag still reaches the TextField for
+                        // cursor placement and selection.
+                        MouseArea {
+                            anchors.fill: parent
+                            acceptedButtons: Qt.RightButton
+                            onPressed: {
+                                textField.forceActiveFocus()
+                                contextMenu.popup()
+                            }
+                        }
 
                         ContextMenuType {
                             id: contextMenu

--- a/service/server/CMakeLists.txt
+++ b/service/server/CMakeLists.txt
@@ -447,11 +447,22 @@ install(RUNTIME_DEPENDENCY_SET service_deps
     DESTINATION "${RUNTIME_DEPS_DIR}"
 )
 
-qt_generate_deploy_app_script(
-    TARGET ${PROJECT}
-    OUTPUT_SCRIPT QT_DEPLOY_SCRIPT
-    NO_UNSUPPORTED_PLATFORM_ERROR
-)
+# Qt 6.5 renamed FILENAME_VARIABLE to OUTPUT_SCRIPT here too -- verified against
+# the Qt 6.4 sources, where this macro accepts only TARGET, FILENAME_VARIABLE and
+# NO_UNSUPPORTED_PLATFORM_ERROR. See the fuller note in client/CMakeLists.txt.
+if(Qt6_VERSION VERSION_GREATER_EQUAL 6.5)
+    qt_generate_deploy_app_script(
+        TARGET ${PROJECT}
+        OUTPUT_SCRIPT QT_DEPLOY_SCRIPT
+        NO_UNSUPPORTED_PLATFORM_ERROR
+    )
+else()
+    qt_generate_deploy_app_script(
+        TARGET ${PROJECT}
+        FILENAME_VARIABLE QT_DEPLOY_SCRIPT
+        NO_UNSUPPORTED_PLATFORM_ERROR
+    )
+endif()
 install(SCRIPT ${QT_DEPLOY_SCRIPT}
     COMPONENT AmneziaVPN
 )


### PR DESCRIPTION
The client required Qt 6.9 without ever declaring it, so on older Qt it built cleanly and then failed at runtime. Every version-gated API involved turned out to be avoidable, so this removes the dependencies rather than raising the minimum.

Five blockers, in the order a build hits them:

| API | Requires | Change |
|---|---|---|
| `OUTPUT_SCRIPT` (was `FILENAME_VARIABLE`) | 6.5 | branch on `Qt6_VERSION` |
| `DEPLOY_TOOL_OPTIONS` | 6.7 | passed only on ≥ 6.7 |
| `popupType: Popup.Native` | 6.8 | removed |
| `ContextMenu.menu` attached type | 6.9 | explicit `MouseArea` + `Menu.popup()` |
| `pragma ComponentBehavior: Bound` | 6.5 | removed from two files — see below |

There are **two** deploy-script call sites, not one: `client/CMakeLists.txt` uses `qt_generate_deploy_qml_app_script` (Qt6QmlMacros) and `service/server/CMakeLists.txt` uses `qt_generate_deploy_app_script` (Qt6CoreMacros). They live in different Qt modules and changed signature together.

The keyword sets were read off the Qt 6.4 sources rather than the documentation, which describes only the current signature — Qt 6.4 accepts `TARGET` / `FILENAME_VARIABLE` and no multi-value options at all.

### The context menu

`ContextMenu.menu` is replaced by a `MouseArea` accepting only `Qt.RightButton`, so left press and drag still reach the text control for cursor placement, selection and flicking. Confirmed by hand on a real display: the menu opens on right-click, Cut/Copy enable and disable with the selection, and normal editing is unaffected.

### One decision worth the team's call

`QuestionDrawer.qml` and `SubscriptionExpiredDrawer.qml` carry `pragma ComponentBehavior: Bound`, and `DrawerType2` instantiates their content through an always-active `Loader` — outside its creation context, which Qt 6.4 rejects:

```
Cannot instantiate bound component outside its creation context
```

The `Loader` then reports status `Error` and its `item` stays null, so the drawer opens with no text and no buttons. The confirmation dialogs in the server, protocol and config removal flows cannot be acted on. Isolated reproduction, same code on both versions:

| | Qt 6.4.2 | Qt 6.10.2 |
|---|---|---|
| Loader status | 3 (Error) | 1 (Ready) |
| `item` | null | created |

The pragma can be dropped from these two files without any behaviour change: it was added in b457ef9a together with qualifying every reference (`text: headerText` → `text: root.headerText`), so the files already satisfy what it enforces. Verified identical results on 6.4.2 and 6.10.2 after removal.

That said, it does remove a lint guard — a future edit could introduce unqualified access in those two files without a compile-time error. **Happy to restore the pragma and set the minimum at 6.5 instead if you prefer that trade.** `AwgTextField.qml` keeps its pragma either way, since it is used as a direct type and never instantiated through a `Loader`.

### Declaring the minimum

`find_package(Qt6 ...)` had no version constraint, which is why an unsupported Qt produced a runtime QML failure instead of a configure-time error. It now declares `6.4`, so falling below the supported minimum fails immediately and names both versions:

```
Could not find a configuration file for package "Qt6" that is compatible
with requested version "6.4".
```

6.4.2, 6.8.2 and 6.10.2 were each built and run; 6.5 through 6.7 were not tested, as no distro to hand ships them. The floor is set to the lowest version actually exercised. If you would rather it track the oldest Qt you intend to support, that number is easy to change — the point is that it is declared rather than implicit.

### Verification

Raspberry Pi 5, aarch64. Built and run on each:

| Qt | Source | Build | Runs |
|---|---|---|---|
| 6.4.2 | Debian 12 bookworm | client + service | ✅ |
| 6.8.2 | Debian 13 trixie, native | client + service | ✅ + right-click menu confirmed on a real display |
| 6.10.2 | Ubuntu 26.04 | — | ✅ |

"Runs" means the QML engine loads and the client reaches `Started AmneziaVPN version 5.0.0.2`; before these changes it failed with `QQmlApplicationEngine failed to load component`.

CI is unaffected — the workflows install Qt 6.10.1, which takes the same branches as today.

Related: #1324, where ARM64 Linux users are affected first because Qt publishes no official aarch64 desktop binaries, making distro Qt the only option there.
