### PR TITLE
fix: keep CIDR prefix length when normalizing split tunneling entries

### DIFF
--- a/client/core/controllers/ipSplitTunnelingController.cpp
+++ b/client/core/controllers/ipSplitTunnelingController.cpp
@@ -144,6 +144,14 @@ QString IpSplitTunnelingController::normalizeHostname(const QString &hostname) c
     normalized.replace("https://", "");
     normalized.replace("http://", "");
     normalized.replace("ftp://", "");
+
+    // A CIDR range is not a URL: the part after the slash is a prefix length,
+    // not a path. Stripping it turns 91.108.4.0/22 into 91.108.4.0, which is
+    // later routed as a /32 host route, so the rest of the subnet misses the tunnel.
+    if (NetworkUtilities::ipAddressWithSubnetRegExp().exactMatch(normalized)) {
+        return normalized;
+    }
+
     normalized = normalized.split("/", Qt::SkipEmptyParts).first();
     return normalized;
 }


### PR DESCRIPTION
## Problem

`normalizeHostname()` strips everything after the first slash. It exists to drop the path from a URL, but it runs on every entry, CIDR ranges included, and it runs before validation. So `91.108.4.0/22` gets stored as `91.108.4.0`.

Downstream in `localsocketcontroller.cpp:224-229`, any address without a slash gets a `/32`:

```cpp
} else {
    QJsonObject range;
    range.insert("address", ipRange);
    range.insert("range", 32);
    range.insert("isIpv6", false);
    jsAllowedIPAddesses.append(range);
}
```

A /22 subnet ends up as a host route to its own network address, which nothing talks to, and the rest of the subnet skips the tunnel. Both entry points hit this: `addSite()` at line 68 and `importSitesFromJson()` at line 215. An imported list of ranges lands in settings with every prefix gone.

## Regression

4.8.21.0 had no `normalizeHostname()`. `sitesController.cpp:45-46` stored the hostname as it was typed. The route building code in `localsocketcontroller.cpp` is identical in both versions, so only the input path changed.

## Fix

Return CIDR ranges unchanged and leave URL handling alone.

## Testing

Ran the normalization logic against the regexp for /16, /20, /22, /26 and /32 subnets, a bare IPv4 address, a domain, URLs with paths, and a malformed prefix like `1.2.3.4/999`. Subnets keep their prefix. URLs still lose the path. The malformed one falls back to the bare address, as before.

Verified on macOS 26.5.2 with AmneziaVPN 5.0.0: a list of 2960 subnets imported from iplist.opencck.org was stored with all prefixes stripped, and the routing table showed no exclusion routes beyond the VPN endpoint itself.

## Note for users

Lists imported by an affected build are already stored without prefixes, and upgrading does not bring them back. The list has to be imported again.

Related: #2904, #2907
