### PR TITLE
fix: restore ios condition for paste menu item to avoid clipboard permission prompt

### DIFF
--- a/client/ui/qml/Controls2/ContextMenuType.qml
+++ b/client/ui/qml/Controls2/ContextMenuType.qml
@@ -63,8 +63,8 @@ Menu {
     }
     MenuItem {
         text: qsTr("&Paste")
-        // Fix calling paste from clipboard when launching app on android
-        enabled: Qt.platform.os === "android" ? true : textObj.canPaste
+        // Fix calling paste from clipboard when launching app on android/ios
+        enabled: (Qt.platform.os === "android" || Qt.platform.os === "ios") ? true : textObj.canPaste
         onTriggered: textObj.paste()
     }
 


### PR DESCRIPTION
<img width="196.333333" height="426.666667" alt="Image" src="https://github.com/user-attachments/assets/de59c278-78aa-4150-a0db-a09b9344bfd4" />

## Problem

On iOS the system clipboard permission alert ("would like to paste from ...") appears throughout the app without any explicit paste action from the user. Fixes #2954.

## Cause

`ContextMenuType` is instantiated eagerly for every text field (`TextFieldWithHeaderType`, `TextAreaType`, `TextAreaWithFooterType`). The `enabled` binding of its Paste item evaluates `textObj.canPaste` at creation time, which reads the system clipboard — and on iOS 16+ any programmatic clipboard read triggers the system paste permission alert. (Qt reads it by value: `QIOSMimeData::formats()` → `[pb pasteboardTypes]`, `retrieveData()` → `[pb dataForPasteboardType:]`.)

This was fixed in #1868 by not evaluating `canPaste` on iOS (same approach as the earlier Android fix #919). The fix was accidentally reverted in d78202c6 (#2093), where `ContextMenuType.qml` was rewritten for Qt 6.9 native context menus starting from a pre-#1868 version of the file. It shipped broken in 4.8.12.6+ and the line survived the recent iOS rework in #2916, so it is still present on `dev`.

Note this is orthogonal to the new native path added in #2916: `IosContextMenu::present()` reads `canPaste` only when the menu is actually opened by the user, which is fine. The problem is the QML `MenuItem` binding, which is evaluated when the text field is created.

## Fix

Restore the iOS condition alongside Android, exactly matching #1868:

```qml
// Fix calling paste from clipboard when launching app on android/ios
enabled: (Qt.platform.os === "android" || Qt.platform.os === "ios") ? true : textObj.canPaste
```

The Paste item stays always enabled on iOS/Android; the clipboard is only read when the user actually pastes, at which point the iOS alert is expected.

## Testing

- [x] iOS: with text in the clipboard, navigate through pages with text fields — no system paste alert appears
- [x] iOS: Paste from a text field's context menu still works
- [x] Desktop platforms unaffected (`canPaste` logic unchanged there)