### PR TITLE
feat(tv): make the D-pad focus indicator visible on Android TV

### DIFF
--- a/client/ui/qml/Components/AdLabel.qml
+++ b/client/ui/qml/Components/AdLabel.qml
@@ -104,14 +104,13 @@ Rectangle {
                 anchors.fill: parent
                 radius: 12
                 color: AmneziaStyle.color.transparent
-                border.width: root.activeFocus ? 1 : 0
-                border.color: AmneziaStyle.color.paleGray
 
-                Behavior on color {
-                    PropertyAnimation { duration: 200 }
+                FocusIndicatorType {
+                    control: root
+                    baseRadius: chevronBackground.radius
                 }
 
-                Behavior on border.width {
+                Behavior on color {
                     PropertyAnimation { duration: 200 }
                 }
             }

--- a/client/ui/qml/Components/ConnectButton.qml
+++ b/client/ui/qml/Components/ConnectButton.qml
@@ -77,14 +77,14 @@ Button {
                 verticalOffset: 0
                 radius: 10
                 samples: 25
-                color: root.buttonActiveFocus ? AmneziaStyle.color.paleGray : AmneziaStyle.color.goldenApricot
+                color: root.buttonActiveFocus ? AmneziaStyle.focus.borderColor : AmneziaStyle.color.goldenApricot
                 source: backgroundCircle
             }
 
             ShapePath {
                 fillColor: AmneziaStyle.color.transparent
-                strokeColor: AmneziaStyle.color.paleGray
-                strokeWidth: root.buttonActiveFocus ? 1 : 0
+                strokeColor: AmneziaStyle.focus.borderColor
+                strokeWidth: root.buttonActiveFocus ? AmneziaStyle.focus.borderWidth : 0
                 capStyle: ShapePath.RoundCap
 
                 PathAngleArc {

--- a/client/ui/qml/Components/ServersListView.qml
+++ b/client/ui/qml/Components/ServersListView.qml
@@ -99,6 +99,10 @@ ListViewType {
 
                     visible: ServersUiController.serverHasOutdatedAwgContainer(serverId)
 
+                    // purely informational, it has no action; without this the
+                    // D-pad stops on it on the way to the settings button
+                    isFocusable: false
+
                     hoverEnabled: false
                     image: "qrc:/images/controls/alert-circle.svg"
                     imageColor: AmneziaStyle.color.goldenApricot

--- a/client/ui/qml/Controls2/BasicButtonType.qml
+++ b/client/ui/qml/Controls2/BasicButtonType.qml
@@ -18,9 +18,7 @@ Button {
     property string textColor: AmneziaStyle.color.midnightBlack
 
     property string borderColor: AmneziaStyle.color.paleGray
-    property string borderFocusedColor: AmneziaStyle.color.paleGray
     property int borderWidth: 0
-    property int borderFocusedWidth: 1
 
     property string leftImageSource
     property string rightImageSource
@@ -67,20 +65,23 @@ Button {
         id: focusBorder
 
         color: AmneziaStyle.color.transparent
-        border.color: root.activeFocus ? root.borderFocusedColor : AmneziaStyle.color.transparent
-        border.width: root.activeFocus ? root.borderFocusedWidth : 0
 
         anchors.fill: parent
 
         radius: 16
 
+        FocusIndicatorType {
+            control: root
+            baseRadius: focusBorder.radius
+        }
+
         Rectangle {
             id: background
 
             anchors.fill: focusBorder
-            anchors.margins: root.activeFocus ? 2 : 0
+            anchors.margins: root.activeFocus ? AmneziaStyle.focus.backgroundInset : 0
 
-            radius: root.activeFocus ? 14 : 16
+            radius: 16 - anchors.margins
             color: {
                 if (root.enabled) {
                     if (root.pressed) {

--- a/client/ui/qml/Controls2/CaptchaDialogType.qml
+++ b/client/ui/qml/Controls2/CaptchaDialogType.qml
@@ -275,7 +275,6 @@ Popup {
                 textColor: AmneziaStyle.color.paleGray
                 borderWidth: 1
                 borderColor: AmneziaStyle.color.mutedGray
-                borderFocusedColor: AmneziaStyle.color.paleGray
 
                 clickedFunc: function() {
                     root.close()

--- a/client/ui/qml/Controls2/CardType.qml
+++ b/client/ui/qml/Controls2/CardType.qml
@@ -21,8 +21,8 @@ RadioButton {
 
     property string pressedBorderColor: AmneziaStyle.color.softGoldenApricot
     property string selectedBorderColor: AmneziaStyle.color.goldenApricot
+    property string focusBorderColor: AmneziaStyle.focus.borderColor
     property string defaultBodredColor: AmneziaStyle.color.transparent
-    property string focusBorderColor: AmneziaStyle.color.paleGray
     property int borderWidth: 0
 
     implicitWidth: content.implicitWidth
@@ -88,13 +88,19 @@ RadioButton {
 
         border.width: {
             if (root.enabled) {
-                if(root.checked || root.activeFocus) {
+                if (root.checked || root.activeFocus) {
                     return 1
                 }
                 return root.pressed ? 1 : 0
             } else {
                 return 0
             }
+        }
+
+        FocusIndicatorType {
+            control: root
+            baseRadius: 16
+            active: root.activeFocus && AmneziaStyle.focus.isOnTv
         }
 
         Behavior on color {

--- a/client/ui/qml/Controls2/CheckBoxType.qml
+++ b/client/ui/qml/Controls2/CheckBoxType.qml
@@ -25,7 +25,6 @@ CheckBox {
     property string checkedBorderColor: AmneziaStyle.color.goldenApricot
     property string checkedBorderDisabledColor: AmneziaStyle.color.deepBrown
 
-    property string borderFocusedColor: AmneziaStyle.color.paleGray
 
     property string checkedImageColor: AmneziaStyle.color.goldenApricot
     property string pressedImageColor: AmneziaStyle.color.burntOrange
@@ -65,9 +64,13 @@ CheckBox {
 
     background: Rectangle {
         color: AmneziaStyle.color.transparent
-        border.color: root.focus ? borderFocusedColor : AmneziaStyle.color.transparent
-        border.width: 1
         radius: 16
+
+        FocusIndicatorType {
+            control: root
+            baseRadius: 16
+            active: root.focus
+        }
     }
 
     indicator: Rectangle {

--- a/client/ui/qml/Controls2/DropDownType.qml
+++ b/client/ui/qml/Controls2/DropDownType.qml
@@ -30,9 +30,6 @@ Item {
     property string rootButtonBackgroundHoveredColor: AmneziaStyle.color.onyxBlack
     property string rootButtonBackgroundPressedColor: AmneziaStyle.color.onyxBlack
 
-    property string borderFocusedColor: AmneziaStyle.color.paleGray
-    property int borderFocusedWidth: 1
-
     property string rootButtonHoveredBorderColor: AmneziaStyle.color.charcoalGray
     property string rootButtonDefaultBorderColor: AmneziaStyle.color.slateGray
     property string rootButtonPressedBorderColor: AmneziaStyle.color.paleGray
@@ -114,18 +111,20 @@ Item {
         id: focusBorder
 
         color: AmneziaStyle.color.transparent
-        border.color: root.activeFocus ? root.borderFocusedColor : AmneziaStyle.color.transparent
-        border.width: root.activeFocus ? root.borderFocusedWidth : 0
         anchors.fill: rootButtonContent
         radius: 16
 
+        FocusIndicatorType {
+            control: root
+            baseRadius: focusBorder.radius
+        }
 
         Rectangle {
             id: rootButtonBackground
 
             anchors.fill: focusBorder
-            anchors.margins: root.activeFocus ? 2 : 0
-            radius: root.activeFocus ? 14 : 16
+            anchors.margins: root.activeFocus ? AmneziaStyle.focus.backgroundInset : 0
+            radius: 16 - anchors.margins
 
             color: {
                 if (root.enabled) {

--- a/client/ui/qml/Controls2/FocusIndicatorType.qml
+++ b/client/ui/qml/Controls2/FocusIndicatorType.qml
@@ -1,0 +1,36 @@
+import QtQuick
+
+import Style 1.0
+
+// Focus affordance drawn over a control. Off a TV it stays the hairline outline
+// the desktop UI has always used; on a TV it becomes a thick accent outline with
+// a tinted fill so the selected control is readable from across the room.
+//
+// Drop it in as the last child of the control's background and point `control`
+// at the item whose activeFocus should drive it.
+Rectangle {
+    id: indicator
+
+    property Item control: parent
+    property int baseRadius: 16
+    // Overridable so a container can light up while focus sits on a small child
+    // of its own, e.g. the chevron inside a settings row.
+    property bool active: control ? control.activeFocus : false
+
+    // stays inside the control's own bounds so a surrounding Flickable or
+    // ListView with clip: true cannot cut the outline off
+    anchors.fill: parent
+    radius: baseRadius
+    z: 100
+
+    visible: opacity > 0
+    opacity: active ? 1 : 0
+
+    color: AmneziaStyle.focus.overlayColor
+    border.color: AmneziaStyle.focus.borderColor
+    border.width: AmneziaStyle.focus.borderWidth
+
+    Behavior on opacity {
+        PropertyAnimation { duration: 200 }
+    }
+}

--- a/client/ui/qml/Controls2/HorizontalRadioButton.qml
+++ b/client/ui/qml/Controls2/HorizontalRadioButton.qml
@@ -19,9 +19,9 @@ RadioButton {
 
     property string pressedBorderColor: AmneziaStyle.color.charcoalGray
     property string checkedBorderColor: AmneziaStyle.color.goldenApricot
+    property string borderFocusedColor: AmneziaStyle.focus.borderColor
     property string defaultBodredColor: AmneziaStyle.color.transparent
     property string checkedDisabledBorderColor: AmneziaStyle.color.mutedBrown
-    property string borderFocusedColor: AmneziaStyle.color.paleGray
     property int borderWidth: 0
 
     implicitWidth: content.implicitWidth
@@ -89,10 +89,16 @@ RadioButton {
         }
 
         border.width: {
-            if(root.checked || root.activeFocus) {
+            if (root.checked || root.activeFocus) {
                 return 1
             }
             return root.pressed ? 1 : 0
+        }
+
+        FocusIndicatorType {
+            control: root
+            baseRadius: 16
+            active: root.activeFocus && AmneziaStyle.focus.isOnTv
         }
 
         Behavior on color {

--- a/client/ui/qml/Controls2/ImageButtonType.qml
+++ b/client/ui/qml/Controls2/ImageButtonType.qml
@@ -20,15 +20,14 @@ Button {
     property alias backgroundColor: background.color
     property alias backgroundRadius: background.radius
 
-    property string borderFocusedColor: AmneziaStyle.color.paleGray
-    property int borderFocusedWidth: 1
-
     hoverEnabled: true
 
     icon.source: image
     icon.color: root.enabled ? imageColor : disableImageColor
 
     property bool isFocusable: true
+    // Off when an enclosing control draws the focus indicator for the whole row
+    property bool showFocusIndicator: true
 
     Keys.onTabPressed: {
         FocusController.nextKeyTabItem()
@@ -65,8 +64,6 @@ Button {
         id: background
 
         anchors.fill: parent
-        border.color: root.activeFocus ? root.borderFocusedColor : AmneziaStyle.color.transparent
-        border.width: root.activeFocus ? root.borderFocusedWidth : 0
 
         color: {
             if (root.enabled) {
@@ -81,8 +78,11 @@ Button {
         Behavior on color {
             PropertyAnimation { duration: 200 }
         }
-        Behavior on border.color {
-            PropertyAnimation { duration: 200 }
+
+        FocusIndicatorType {
+            control: root
+            baseRadius: background.radius
+            active: root.activeFocus && root.showFocusIndicator
         }
     }
 

--- a/client/ui/qml/Controls2/LabelWithButtonType.qml
+++ b/client/ui/qml/Controls2/LabelWithButtonType.qml
@@ -36,9 +36,6 @@ Item {
     property string descriptionDisabledColor: AmneziaStyle.color.charcoalGray
     property real textOpacity: 1.0
 
-    property string borderFocusedColor: AmneziaStyle.color.paleGray
-    property int borderFocusedWidth: 1
-
     property string rightImageColor: AmneziaStyle.color.paleGray
     property string leftImageColor: ""
 
@@ -256,6 +253,7 @@ Item {
 
         ImageButtonType {
             id: eyeImage
+            showFocusIndicator: !AmneziaStyle.focus.isOnTv
             visible: buttonImageSource !== ""
 
             implicitWidth: 40
@@ -293,6 +291,7 @@ Item {
 
         ImageButtonType {
             id: rightImage
+            showFocusIndicator: !AmneziaStyle.focus.isOnTv
 
             implicitWidth: 40
             implicitHeight: 40
@@ -327,12 +326,18 @@ Item {
         anchors.fill: root
         color: AmneziaStyle.color.transparent
 
-        border.color: root.activeFocus ? root.borderFocusedColor : AmneziaStyle.color.transparent
-        border.width: root.activeFocus ? root.borderFocusedWidth : 0
-
-
         Behavior on color {
             PropertyAnimation { duration: 200 }
+        }
+
+        FocusIndicatorType {
+            control: root
+            // the border this replaces was square
+            baseRadius: AmneziaStyle.focus.isOnTv ? 12 : 0
+            // The row's own focusable target is one of the small buttons on its
+            // right; on a TV highlight the whole row so the selection is findable.
+            active: root.activeFocus
+                    || (AmneziaStyle.focus.isOnTv && (rightImage.activeFocus || eyeImage.activeFocus))
         }
     }
 

--- a/client/ui/qml/Controls2/SwitcherType.qml
+++ b/client/ui/qml/Controls2/SwitcherType.qml
@@ -20,9 +20,6 @@ Switch {
     property string defaultIndicatorColor: AmneziaStyle.color.transparent
     property string checkedDisabledIndicatorColor: AmneziaStyle.color.deepBrown
 
-    property string borderFocusedColor: AmneziaStyle.color.paleGray
-    property int borderFocusedWidth: 1
-
     property string checkedIndicatorBorderColor: AmneziaStyle.color.richBrown
     property string defaultIndicatorBorderColor: AmneziaStyle.color.charcoalGray
     property string checkedDisabledIndicatorBorderColor: AmneziaStyle.color.deepBrown
@@ -64,10 +61,28 @@ Switch {
     hoverEnabled: enabled ? true : false
     focusPolicy: Qt.TabFocus
 
+    // this row's content sits tight against the control's own edges, unlike the
+    // list rows, so the focus outline would run right along the label; add the
+    // missing air on top of whatever padding the style already applies
+    topPadding: padding + AmneziaStyle.focus.contentPadding / 2
+    bottomPadding: padding + AmneziaStyle.focus.contentPadding / 2
+
+    // the switch itself is small; outline the whole row instead
+    background: Rectangle {
+        color: AmneziaStyle.color.transparent
+
+        FocusIndicatorType {
+            control: root
+            baseRadius: 12
+            active: root.activeFocus && AmneziaStyle.focus.isOnTv
+        }
+    }
+
     indicator: Rectangle {
         id: switcher
 
         anchors.right: parent.right
+        anchors.rightMargin: AmneziaStyle.focus.contentPadding
         anchors.verticalCenter: parent.verticalCenter
 
         implicitWidth: 52
@@ -77,8 +92,10 @@ Switch {
         color: root.checked ? (root.enabled ? root.checkedIndicatorColor : root.checkedDisabledIndicatorColor)
                             : root.defaultIndicatorColor
 
-        border.color: root.activeFocus ? root.borderFocusedColor : (root.checked ? (root.enabled ? root.checkedIndicatorBorderColor : root.checkedDisabledIndicatorBorderColor)
-                            : root.defaultIndicatorBorderColor)
+        border.color: (root.activeFocus && !AmneziaStyle.focus.isOnTv)
+                            ? AmneziaStyle.focus.borderColor
+                            : (root.checked ? (root.enabled ? root.checkedIndicatorBorderColor : root.checkedDisabledIndicatorBorderColor)
+                                            : root.defaultIndicatorBorderColor)
 
         Behavior on color {
             PropertyAnimation { duration: 200 }
@@ -121,6 +138,7 @@ Switch {
 
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
+        anchors.leftMargin: AmneziaStyle.focus.contentPadding
 
         ListItemTitleType {
             Layout.fillWidth: true

--- a/client/ui/qml/Controls2/TabButtonType.qml
+++ b/client/ui/qml/Controls2/TabButtonType.qml
@@ -12,8 +12,6 @@ TabButton {
 
     property string textColor: AmneziaStyle.color.paleGray
 
-    property string borderFocusedColor: AmneziaStyle.color.paleGray
-    property int borderFocusedWidth: 1
 
     property bool isSelected: false
 
@@ -53,8 +51,13 @@ TabButton {
         anchors.fill: parent
         color: AmneziaStyle.color.transparent
 
-        border.color: root.activeFocus ? root.borderFocusedColor : AmneziaStyle.color.transparent
-        border.width: root.activeFocus ? root.borderFocusedWidth : 0
+        FocusIndicatorType {
+            control: root
+            baseRadius: AmneziaStyle.focus.isOnTv ? 8 : 0
+            // stays under the tab's own underline, the way the border it
+            // replaces used to
+            z: 0
+        }
 
         Rectangle {
             width: parent.width

--- a/client/ui/qml/Controls2/TabImageButtonType.qml
+++ b/client/ui/qml/Controls2/TabImageButtonType.qml
@@ -40,8 +40,6 @@ TabButton {
         FocusController.nextKeyRightItem()
     }
     
-    property string borderFocusedColor: AmneziaStyle.color.paleGray
-    property int borderFocusedWidth: 1
 
     property var clickedFunc
 
@@ -56,9 +54,10 @@ TabButton {
         color: AmneziaStyle.color.transparent
         radius: 10
 
-        border.color: root.activeFocus ? root.borderFocusedColor : AmneziaStyle.color.transparent
-        border.width: root.activeFocus ? root.borderFocusedWidth : 0
-
+        FocusIndicatorType {
+            control: root
+            baseRadius: background.radius
+        }
     }
 
     MouseArea {

--- a/client/ui/qml/Controls2/TextAreaType.qml
+++ b/client/ui/qml/Controls2/TextAreaType.qml
@@ -13,7 +13,7 @@ Rectangle {
 
     property string borderHoveredColor: AmneziaStyle.color.charcoalGray
     property string borderNormalColor: AmneziaStyle.color.slateGray
-    property string borderFocusedColor: AmneziaStyle.color.paleGray
+    property string borderFocusedColor: AmneziaStyle.focus.borderColor
 
     height: 148
     color: AmneziaStyle.color.onyxBlack

--- a/client/ui/qml/Controls2/TextAreaWithFooterType.qml
+++ b/client/ui/qml/Controls2/TextAreaWithFooterType.qml
@@ -17,7 +17,7 @@ Rectangle {
 
     property string borderHoveredColor: AmneziaStyle.color.charcoalGray
     property string borderNormalColor: AmneziaStyle.color.slateGray
-    property string borderFocusedColor: AmneziaStyle.color.paleGray
+    property string borderFocusedColor: AmneziaStyle.focus.borderColor
 
     property string firstButtonImage
     property string secondButtonImage

--- a/client/ui/qml/Controls2/TextFieldWithHeaderType.qml
+++ b/client/ui/qml/Controls2/TextFieldWithHeaderType.qml
@@ -31,7 +31,7 @@ Item {
     property bool textFieldEditable: true
 
     property string borderColor: AmneziaStyle.color.slateGray
-    property string borderFocusedColor: AmneziaStyle.color.paleGray
+    property string borderFocusedColor: AmneziaStyle.focus.borderColor
 
     property string backgroundColor: AmneziaStyle.color.onyxBlack
     property string backgroundDisabledColor: AmneziaStyle.color.transparent

--- a/client/ui/qml/Controls2/VerticalRadioButton.qml
+++ b/client/ui/qml/Controls2/VerticalRadioButton.qml
@@ -26,8 +26,6 @@ RadioButton {
     property string descriptionColor: AmneziaStyle.color.mutedGray
     property string descriptionDisabledColor: AmneziaStyle.color.charcoalGray
 
-    property string borderFocusedColor: AmneziaStyle.color.paleGray
-    property int borderFocusedWidth: 1
 
     property string imageSource
     property bool showImage
@@ -66,13 +64,25 @@ RadioButton {
 
     hoverEnabled: true
 
+    // the radio dot is small; outline the whole row instead
+    background: Rectangle {
+        color: AmneziaStyle.color.transparent
+
+        FocusIndicatorType {
+            control: root
+            baseRadius: 16
+            active: root.focus && AmneziaStyle.focus.isOnTv
+        }
+    }
+
     indicator: Rectangle {
         id: background
 
         anchors.verticalCenter: parent.verticalCenter
 
-        border.color: root.focus ? root.borderFocusedColor : AmneziaStyle.color.transparent
-        border.width: root.focus ? root.borderFocusedWidth : 0
+        border.color: (root.focus && !AmneziaStyle.focus.isOnTv) ? AmneziaStyle.focus.borderColor
+                                                                    : AmneziaStyle.color.transparent
+        border.width: (root.focus && !AmneziaStyle.focus.isOnTv) ? AmneziaStyle.focus.borderWidth : 0
 
         implicitWidth: 56
         implicitHeight: 56

--- a/client/ui/qml/Modules/Style/AmneziaStyle.qml
+++ b/client/ui/qml/Modules/Style/AmneziaStyle.qml
@@ -3,6 +3,8 @@ pragma Singleton
 import QtQuick
 
 QtObject {
+    id: root
+
     property QtObject color: QtObject {
         readonly property color transparent: 'transparent'
         readonly property color paleGray: '#D7D8DB'
@@ -33,7 +35,29 @@ QtObject {
         readonly property color translucentRichBrown: Qt.rgba(99/255, 51/255, 3/255, 0.26)
         readonly property color translucentSlateGray: Qt.rgba(85/255, 86/255, 92/255, 0.13)
         readonly property color translucentOnyxBlack: Qt.rgba(28/255, 29/255, 33/255, 0.13)
+        readonly property color faintGoldenApricot: Qt.rgba(251/255, 178/255, 106/255, 0.14)
 
         readonly property string goldenApricotString: '#FBB26A'
+    }
+
+    // Appearance of the keyboard/D-pad focus indicator. On a TV the control is
+    // several metres away and a 1px hairline in the same tone as the control is
+    // not readable, so there the indicator switches to a thick accent outline
+    // with a tinted fill. Set from main2.qml.
+    property QtObject focus: QtObject {
+        property bool isOnTv: false
+
+        readonly property color borderColor: isOnTv ? root.color.goldenApricot
+                                                    : root.color.paleGray
+        readonly property int borderWidth: isOnTv ? 3 : 1
+        // off a TV the outline shares the control's own tone, so the control is
+        // shrunk a little to leave a dark gap that makes the outline readable
+        readonly property int backgroundInset: isOnTv ? 0 : 2
+        // breathing room for controls whose content sits flush against their own
+        // edge, so the outline does not run straight through the label
+        readonly property int contentPadding: isOnTv ? 16 : 0
+        // kept light: the fill sits over the control's own label
+        readonly property color overlayColor: isOnTv ? root.color.faintGoldenApricot
+                                                     : root.color.transparent
     }
 }

--- a/client/ui/qml/Pages2/PageHome.qml
+++ b/client/ui/qml/Pages2/PageHome.qml
@@ -50,6 +50,42 @@ PageType {
         root.updateApiProtocolState()
     }
 
+    // Nothing holds the focus when the app opens, so on a TV the first press of
+    // the remote is spent only on entering the focus chain and the screen gives
+    // no feedback until then. Start on the connect button instead, the way
+    // PageSetupWizardStart already does for TV.
+    //
+    // PageType's own timer puts the focus back on the invisible default item
+    // shortly after the page shows, so it is off here; and the handler below is
+    // a Connections rather than an onVisibleChanged override, so PageType keeps
+    // its own handler.
+    enableTimer: !SettingsController.isOnTv()
+
+    Connections {
+        target: root
+
+        function onVisibleChanged() {
+            if (root.visible && SettingsController.isOnTv()) {
+                connectButtonFocusTimer.restart()
+            }
+        }
+    }
+
+    Timer {
+        id: connectButtonFocusTimer
+
+        interval: 250
+        repeat: true
+        running: SettingsController.isOnTv()
+
+        onTriggered: {
+            connectButton.forceActiveFocus()
+            if (connectButton.activeFocus) {
+                stop()
+            }
+        }
+    }
+
     Connections {
         target: ServersUiController
 

--- a/client/ui/qml/main2.qml
+++ b/client/ui/qml/main2.qml
@@ -75,6 +75,12 @@ Window  {
 
     title: "AmneziaVPN"
 
+    Component.onCompleted: {
+        // On a TV the UI is driven by a remote and read from across the room, so
+        // the focus indicator has to be far more prominent than on desktop.
+        AmneziaStyle.focus.isOnTv = Qt.platform.os === "android" && SettingsController.isOnTv()
+    }
+
     Item { // This item is needed for focus handling
         id: defaultFocusItem
         objectName: "defaultFocusItem"

--- a/client/ui/qml/qml.qrc
+++ b/client/ui/qml/qml.qrc
@@ -33,6 +33,7 @@
         <file>Controls2/DrawerType2.qml</file>
         <file>Controls2/DropDownType.qml</file>
         <file>Controls2/FlickableType.qml</file>
+        <file>Controls2/FocusIndicatorType.qml</file>
         <file>Controls2/Header2Type.qml</file>
         <file>Controls2/BaseHeaderType.qml</file>
         <file>Controls2/HeaderTypeWithButton.qml</file>


### PR DESCRIPTION
On Android TV the focus indicator is a 1px paleGray outline. On the light buttons that is the same colour as the button itself, so it is invisible, and on dark rows it is a hairline you cannot see from the couch. Settings rows are worse: a row with a chevron is not focusable itself (isFocusable in LabelWithButtonType), so the focus target is the 40x40 icon and nothing shows which row you are on.

#946 asked for exactly this and was closed once arrow key handling landed, but the visual side was never done. Related: #1282.

Changes:

- new Controls2/FocusIndicatorType.qml and an AmneziaStyle.focus group holding the indicator colour, width, fill and padding
- on a TV the indicator becomes a 3px goldenApricot outline with a faint fill of the same colour, and controls whose focus target is a small child of a wider row (settings rows, the killswitch, radio buttons) light up as a whole
- SwitcherType also gets the padding the list rows already have, its label sits flush against the control edge and the outline would run across it

The focus chain is unchanged, Tab and the arrow keys visit the same items in the same order. TV is detected with the existing SettingsController.isOnTv(). Off a TV every control renders as before.

While testing this I noticed the app opens with nothing focused at all, so on a TV the first press of the remote only enters the focus chain and the connect button lights up on the second. Fixed here too: PageHome now starts with the focus on the connect button, the same way PageSetupWizardStart already does for TV.

One more dead stop: the outdated container icon in a server row has no action, but ImageButtonType is focusable by default, so the D-pad stopped on it on the way to the settings button. It is skipped now. This one is not limited to a TV, it also removes the stop from keyboard navigation on desktop.

| Before | After |
| --- | --- |
| ![subscription key row, before](https://raw.githubusercontent.com/WkdXeqtr/amnezia-client/pr-screens-tv-focus/screens/pr_Premium_2_before.png) | ![subscription key row, after](https://raw.githubusercontent.com/WkdXeqtr/amnezia-client/pr-screens-tv-focus/screens/pr_Premium_2_after.png) |
| ![protocol row, before](https://raw.githubusercontent.com/WkdXeqtr/amnezia-client/pr-screens-tv-focus/screens/pr_SelfHosted_4_before.png) | ![protocol row, after](https://raw.githubusercontent.com/WkdXeqtr/amnezia-client/pr-screens-tv-focus/screens/pr_SelfHosted_4_after.png) |
| ![light button, before](https://raw.githubusercontent.com/WkdXeqtr/amnezia-client/pr-screens-tv-focus/screens/pr_SelfHosted_9_before.png) | ![light button, after](https://raw.githubusercontent.com/WkdXeqtr/amnezia-client/pr-screens-tv-focus/screens/pr_SelfHosted_9_after.png) |
| ![killswitch row, before](https://raw.githubusercontent.com/WkdXeqtr/amnezia-client/pr-screens-tv-focus/screens/pr_SelfHosted_7_before.png) | ![killswitch row, after](https://raw.githubusercontent.com/WkdXeqtr/amnezia-client/pr-screens-tv-focus/screens/pr_SelfHosted_7_after.png) |
| ![server row, before](https://raw.githubusercontent.com/WkdXeqtr/amnezia-client/pr-screens-tv-focus/screens/tv_row_before.png) | ![server row, after](https://raw.githubusercontent.com/WkdXeqtr/amnezia-client/pr-screens-tv-focus/screens/tv_row_after.png) |
| ![settings button in a server row, before](https://raw.githubusercontent.com/WkdXeqtr/amnezia-client/pr-screens-tv-focus/screens/tv_gear_before.png) | ![settings button in a server row, after](https://raw.githubusercontent.com/WkdXeqtr/amnezia-client/pr-screens-tv-focus/screens/tv_gear_after.png) |
| ![connect button, before](https://raw.githubusercontent.com/WkdXeqtr/amnezia-client/pr-screens-tv-focus/screens/tv_ring_before.png) | ![connect button, after](https://raw.githubusercontent.com/WkdXeqtr/amnezia-client/pr-screens-tv-focus/screens/tv_ring_after.png) |
| ![tab bar, before](https://raw.githubusercontent.com/WkdXeqtr/amnezia-client/pr-screens-tv-focus/screens/tv_tab_before.png) | ![tab bar, after](https://raw.githubusercontent.com/WkdXeqtr/amnezia-client/pr-screens-tv-focus/screens/tv_tab_after.png) |
