### PR TITLE
Added StartupWMClass line to the Desktop Entry

### DIFF
--- a/deploy/data/linux/AmneziaVPN.desktop
+++ b/deploy/data/linux/AmneziaVPN.desktop
@@ -8,3 +8,4 @@ Exec=AmneziaVPN
 Icon=/usr/share/pixmaps/AmneziaVPN.png
 Categories=Network;Qt;Security;
 Terminal=false
+StartupWMClass=AmneziaVPN


### PR DESCRIPTION
AmneziaVPN.desktop file does not contain `StartupWMClass` option, thus some desktop environments cannot correctly work with it.