### PR TITLE
fix(i18n): restore the Russian translations dropped from ru_RU.ts

### DIFF
--- a/client/translations/amneziavpn_ru_RU.ts
+++ b/client/translations/amneziavpn_ru_RU.ts
@@ -2,49 +2,88 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="ru_RU">
 <context>
+    <name>AllowedDnsController</name>
+    <message>
+        <source>The address does not look like a valid IP address</source>
+        <translation type="vanished">Адрес не похож на корректный IP-адрес</translation>
+    </message>
+    <message>
+        <source>New DNS server added: %1</source>
+        <translation type="vanished">Добавлен новый DNS сервер: %1</translation>
+    </message>
+    <message>
+        <source>DNS server already exists: %1</source>
+        <translation type="vanished">DNS сервер уже существует: %1</translation>
+    </message>
+    <message>
+        <source>DNS server removed: %1</source>
+        <translation type="vanished">DNS сервер удален: %1</translation>
+    </message>
+    <message>
+        <source>Can&apos;t open file: %1</source>
+        <translation type="vanished">Невозможно открыть файл: %1</translation>
+    </message>
+    <message>
+        <source>Failed to parse JSON data from file: %1</source>
+        <translation type="vanished">Не удалось разобрать JSON-данные из файла: %1</translation>
+    </message>
+    <message>
+        <source>The JSON data is not an array in file: %1</source>
+        <translation type="vanished">JSON-данные не являются массивом в файле: %1</translation>
+    </message>
+    <message>
+        <source>Import completed</source>
+        <translation type="vanished">Импорт завершён</translation>
+    </message>
+    <message>
+        <source>Export completed</source>
+        <translation type="vanished">Экспорт завершён</translation>
+    </message>
+</context>
+<context>
     <name>AllowedDnsUiController</name>
     <message>
-        <location filename="../ui/controllers/allowedDnsUiController.cpp" line="33"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/allowedDnsUiController.cpp" line="33"/>
         <source>The address does not look like a valid IP address</source>
-        <translation>Адрес не похож на корректный IP-адрес</translation>
+        <translation type="unfinished">Адрес не похож на корректный IP-адрес</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/allowedDnsUiController.cpp" line="38"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/allowedDnsUiController.cpp" line="38"/>
         <source>New DNS server added: %1</source>
-        <translation>Добавлен новый DNS сервер: %1</translation>
+        <translation type="unfinished">Добавлен новый DNS сервер: %1</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/allowedDnsUiController.cpp" line="40"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/allowedDnsUiController.cpp" line="40"/>
         <source>DNS server already exists: %1</source>
-        <translation>DNS сервер уже существует: %1</translation>
+        <translation type="unfinished">DNS сервер уже существует: %1</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/allowedDnsUiController.cpp" line="49"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/allowedDnsUiController.cpp" line="49"/>
         <source>DNS server removed: %1</source>
-        <translation>DNS сервер удален: %1</translation>
+        <translation type="unfinished">DNS сервер удален: %1</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/allowedDnsUiController.cpp" line="56"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/allowedDnsUiController.cpp" line="56"/>
         <source>Can&apos;t open file: %1</source>
-        <translation>Невозможно открыть файл: %1</translation>
+        <translation type="unfinished">Невозможно открыть файл: %1</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/allowedDnsUiController.cpp" line="62"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/allowedDnsUiController.cpp" line="62"/>
         <source>Failed to parse JSON data from file: %1</source>
-        <translation>Не удалось разобрать JSON-данные из файла: %1</translation>
+        <translation type="unfinished">Не удалось разобрать JSON-данные из файла: %1</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/allowedDnsUiController.cpp" line="67"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/allowedDnsUiController.cpp" line="67"/>
         <source>The JSON data is not an array in file: %1</source>
-        <translation>JSON-данные не являются массивом в файле: %1</translation>
+        <translation type="unfinished">JSON-данные не являются массивом в файле: %1</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/allowedDnsUiController.cpp" line="86"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/allowedDnsUiController.cpp" line="86"/>
         <source>Import completed</source>
         <translation>Импорт завершен</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/allowedDnsUiController.cpp" line="107"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/allowedDnsUiController.cpp" line="107"/>
         <source>Export completed</source>
         <translation>Экспорт завершен</translation>
     </message>
@@ -52,178 +91,613 @@
 <context>
     <name>ApiAccountInfoModel</name>
     <message>
-        <location filename="../ui/models/api/apiAccountInfoModel.cpp" line="33"/>
-        <location filename="../ui/models/api/apiAccountInfoModel.cpp" line="38"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/models/api/apiAccountInfoModel.cpp" line="33"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/models/api/apiAccountInfoModel.cpp" line="38"/>
         <source>Active</source>
         <translation>Активна</translation>
     </message>
     <message>
-        <location filename="../ui/models/api/apiAccountInfoModel.cpp" line="37"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/models/api/apiAccountInfoModel.cpp" line="37"/>
         <source>Inactive</source>
         <translation>Не активна</translation>
     </message>
     <message>
-        <location filename="../ui/models/api/apiAccountInfoModel.cpp" line="51"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/models/api/apiAccountInfoModel.cpp" line="51"/>
         <source>%1 out of %2</source>
         <translation>%1 из %2</translation>
     </message>
 </context>
 <context>
+    <name>ApiConfigsController</name>
+    <message>
+        <source>%1 installed successfully.</source>
+        <translation type="vanished">%1 успешно установлен.</translation>
+    </message>
+    <message>
+        <source>Subscription restored successfully.</source>
+        <translation type="vanished">Подписка успешно восстановлена.</translation>
+    </message>
+    <message>
+        <source>%1/mo</source>
+        <comment>IAP: price per month in plan subtitle</comment>
+        <translation type="vanished">%1/мес</translation>
+    </message>
+    <message>
+        <source>from %1 per month</source>
+        <comment>IAP: card footer minimum monthly price from StoreKit</comment>
+        <translation type="vanished">от %1 в месяц</translation>
+    </message>
+    <message>
+        <source>This subscription has already been added</source>
+        <translation type="vanished">Эта подписка уже добавлена</translation>
+    </message>
+    <message>
+        <source>%1 has been added to the app</source>
+        <translation type="vanished">%1 добавлено в приложение</translation>
+    </message>
+    <message>
+        <source>This email address has already been used to activate a trial. If you like the service, you can upgrade to Premium</source>
+        <translation type="vanished">Этот адрес электронной почты уже использовался для активации пробного периода. Если вам понравился сервис, вы можете оформить подписку Premium</translation>
+    </message>
+    <message>
+        <source>API config reloaded</source>
+        <translation type="vanished">Конфигурация API перезагружена</translation>
+    </message>
+    <message>
+        <source>Successfully changed the country of connection to %1</source>
+        <translation type="vanished">Страна подключения изменена на %1</translation>
+    </message>
+</context>
+<context>
+    <name>ApiPremV1MigrationDrawer</name>
+    <message>
+        <source>Switch to the new Amnezia Premium subscription</source>
+        <translation type="vanished">Перейдите на новый тип подписки Amnezia Premium</translation>
+    </message>
+    <message>
+        <source>We&apos;ll preserve all remaining days of your current subscription and give you an extra month as a thank you. </source>
+        <translation type="vanished">Мы сохраним все оставшиеся дни текущей подписки и подарим дополнительный месяц в благодарность за переход. </translation>
+    </message>
+    <message>
+        <source>This new subscription type will be actively developed with more locations and features added regularly. Currently available:</source>
+        <translation type="vanished">Именно новый тип подписки будет активно развиваться и пополняться новыми локациями и функциями. Уже доступны:</translation>
+    </message>
+    <message>
+        <source>&lt;li&gt;20 locations (with more coming soon)&lt;/li&gt;</source>
+        <translation type="vanished">&lt;li&gt;20 локаций (их число будет расти)&lt;/li&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;li&gt;Easier switching between countries in the app&lt;/li&gt;</source>
+        <translation type="vanished">&lt;li&gt;Удобное переключение между странами в приложении&lt;/li&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;li&gt;Personal dashboard to manage your subscription&lt;/li&gt;</source>
+        <translation type="vanished">&lt;li&gt;Личный кабинет для управления подпиской&lt;/li&gt;</translation>
+    </message>
+    <message>
+        <source>Old keys will be deactivated after switching.</source>
+        <translation type="vanished">После перехода старые ключи перестанут работать.</translation>
+    </message>
+    <message>
+        <source>Email</source>
+        <translation type="vanished">Email</translation>
+    </message>
+    <message>
+        <source>mail@example.com</source>
+        <translation type="vanished">mail@example.com</translation>
+    </message>
+    <message>
+        <source>No old format subscriptions for a given email</source>
+        <translation type="vanished">Для указанного адреса электронной почты нет подписок старого типа</translation>
+    </message>
+    <message>
+        <source>Enter the email you used for your current subscription</source>
+        <translation type="vanished">Укажите адрес почты, который использовали при заказе текущей подписки</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="vanished">Продолжить</translation>
+    </message>
+    <message>
+        <source>Remind me later</source>
+        <translation type="vanished">Напомнить позже</translation>
+    </message>
+    <message>
+        <source>Don&apos;t remind me again</source>
+        <translation type="vanished">Больше не напоминать</translation>
+    </message>
+    <message>
+        <source>No more reminders? You can always switch to the new format in the server settings</source>
+        <translation type="vanished">Отключить напоминания? Вы всегда сможете перейти на новый тип подписки в настройках сервера</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="vanished">Отменить</translation>
+    </message>
+</context>
+<context>
+    <name>ApiPremV1SubListDrawer</name>
+    <message>
+        <source>Choose Subscription</source>
+        <translation type="vanished">Выбрать подписку</translation>
+    </message>
+    <message>
+        <source>Order ID: </source>
+        <translation type="vanished">ID заказа: </translation>
+    </message>
+    <message>
+        <source>Purchase Date: </source>
+        <translation type="vanished">Дата покупки: </translation>
+    </message>
+</context>
+<context>
     <name>ApiServicesModel</name>
     <message>
-        <location filename="../ui/models/api/apiServicesModel.cpp" line="77"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/models/api/apiServicesModel.cpp" line="77"/>
         <source>&lt;p&gt;&lt;a style=&quot;color: #EB5757;&quot;&gt;Not available in your region. If you have VPN enabled, disable it, return to the previous screen, and try again.&lt;/a&gt;</source>
         <translation>&lt;p&gt;&lt;a style=&quot;color: #EB5757;&quot;&gt;Недоступно в вашем регионе. Если у вас включен VPN, отключите его, вернитесь на предыдущий экран и попробуйте снова.&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <source>%1 MBit/s</source>
+        <translation type="vanished">%1 Мбит/с</translation>
+    </message>
+    <message>
+        <source>%1 days</source>
+        <translation type="vanished">%1 дней</translation>
+    </message>
+    <message>
+        <source>Free</source>
+        <translation type="vanished">Бесплатно</translation>
+    </message>
+    <message>
+        <source>%1 $</source>
+        <translation type="vanished">%1 $</translation>
+    </message>
+    <message>
+        <source>%1 $/month</source>
+        <translation type="vanished">%1 $/месяц</translation>
+    </message>
+</context>
+<context>
+    <name>AppSplitTunnelingController</name>
+    <message>
+        <source>Application added: %1</source>
+        <translation type="vanished">Приложение добавлено: %1</translation>
+    </message>
+    <message>
+        <source>The application has already been added</source>
+        <translation type="vanished">Приложение уже было добавлено</translation>
+    </message>
+    <message>
+        <source>The selected applications have been added</source>
+        <translation type="vanished">Выбранные приложения добавлены</translation>
+    </message>
+    <message>
+        <source>Application removed: %1</source>
+        <translation type="vanished">Приложение удалено: %1</translation>
     </message>
 </context>
 <context>
     <name>AppSplitTunnelingUiController</name>
     <message>
-        <location filename="../ui/controllers/appSplitTunnelingUiController.cpp" line="28"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/appSplitTunnelingUiController.cpp" line="28"/>
         <source>Application added: %1</source>
-        <translation>Приложение добавлено: %1</translation>
+        <translation type="unfinished">Приложение добавлено: %1</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/appSplitTunnelingUiController.cpp" line="30"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/appSplitTunnelingUiController.cpp" line="30"/>
         <source>The application has already been added</source>
-        <translation>Приложение уже было добавлено</translation>
+        <translation type="unfinished">Приложение уже было добавлено</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/appSplitTunnelingUiController.cpp" line="40"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/appSplitTunnelingUiController.cpp" line="40"/>
         <source>The selected applications have been added</source>
         <translation>Выбранные приложения уже были добавлены</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/appSplitTunnelingUiController.cpp" line="50"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/appSplitTunnelingUiController.cpp" line="50"/>
         <source>Application removed: %1</source>
-        <translation>Приложение удалено: %1</translation>
+        <translation type="unfinished">Приложение удалено: %1</translation>
+    </message>
+</context>
+<context>
+    <name>CaptchaDialogType</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Controls2/CaptchaDialogType.qml" line="18"/>
+        <source>Enter the digits from the image to continue</source>
+        <translation>Введите цифры с картинки, чтобы продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Controls2/CaptchaDialogType.qml" line="228"/>
+        <source>Digits from the image</source>
+        <translation>Цифры с картинки</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Controls2/CaptchaDialogType.qml" line="231"/>
+        <source>_ _ _ _ _ _</source>
+        <translation>_ _ _ _ _ _</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Controls2/CaptchaDialogType.qml" line="254"/>
+        <source>Continue</source>
+        <translation type="unfinished">Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Controls2/CaptchaDialogType.qml" line="271"/>
+        <source>Close</source>
+        <translation type="unfinished">Закрыть</translation>
+    </message>
+</context>
+<context>
+    <name>ChangelogDrawer</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Components/ChangelogDrawer.qml" line="70"/>
+        <source>Update</source>
+        <translation>Обновить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Components/ChangelogDrawer.qml" line="96"/>
+        <source>Skip</source>
+        <translation>Пропустить</translation>
+    </message>
+</context>
+<context>
+    <name>ConnectButton</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Components/ConnectButton.qml" line="54"/>
+        <source>Unable to disconnect during configuration preparation</source>
+        <translation>Невозможно отключиться во время подготовки конфигурации</translation>
+    </message>
+</context>
+<context>
+    <name>ConnectionController</name>
+    <message>
+        <source>Connecting...</source>
+        <translation type="vanished">Подключение...</translation>
+    </message>
+    <message>
+        <source>Connected</source>
+        <translation type="vanished">Подключено</translation>
+    </message>
+    <message>
+        <source>Preparing...</source>
+        <translation type="vanished">Подготовка...</translation>
+    </message>
+    <message>
+        <source>Settings updated successfully, reconnnection...</source>
+        <translation type="vanished">Настройки успешно обновлены, переподключение...</translation>
+    </message>
+    <message>
+        <source>Settings updated successfully</source>
+        <translation type="vanished">Настройки успешно обновлены</translation>
+    </message>
+    <message>
+        <source>Reconnecting...</source>
+        <translation type="vanished">Переподключение...</translation>
+    </message>
+    <message>
+        <source>Connect</source>
+        <translation type="vanished">Подключиться</translation>
+    </message>
+    <message>
+        <source>Disconnecting...</source>
+        <translation type="vanished">Отключение...</translation>
+    </message>
+</context>
+<context>
+    <name>ConnectionTypeSelectionDrawer</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Components/ConnectionTypeSelectionDrawer.qml" line="36"/>
+        <source>Add new connection</source>
+        <translation>Добавить новое соединение</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Components/ConnectionTypeSelectionDrawer.qml" line="44"/>
+        <source>Configure your server</source>
+        <translation>Настроить свой сервер</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Components/ConnectionTypeSelectionDrawer.qml" line="59"/>
+        <source>Open config file, key or QR code</source>
+        <translation>Открыть файл конфигурации, ключ или QR-код</translation>
     </message>
 </context>
 <context>
     <name>ConnectionUiController</name>
     <message>
-        <location filename="../ui/controllers/connectionUiController.cpp" line="59"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/connectionUiController.cpp" line="59"/>
         <source>Connecting...</source>
-        <translation>Подключение...</translation>
+        <translation type="unfinished">Подключение...</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/connectionUiController.cpp" line="66"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/connectionUiController.cpp" line="66"/>
         <source>Connected</source>
-        <translation>Подключено</translation>
+        <translation type="unfinished">Подключено</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/connectionUiController.cpp" line="75"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/connectionUiController.cpp" line="75"/>
         <source>Reconnecting...</source>
-        <translation>Переподключение...</translation>
+        <translation type="unfinished">Переподключение...</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/connectionUiController.cpp" line="80"/>
-        <location filename="../ui/controllers/connectionUiController.cpp" line="95"/>
-        <location filename="../ui/controllers/connectionUiController.cpp" line="101"/>
-        <location filename="../ui/controllers/connectionUiController.h" line="65"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/connectionUiController.cpp" line="80"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/connectionUiController.cpp" line="95"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/connectionUiController.cpp" line="101"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/connectionUiController.h" line="65"/>
         <source>Connect</source>
-        <translation>Подключиться</translation>
+        <translation type="unfinished">Подключиться</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/connectionUiController.cpp" line="85"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/connectionUiController.cpp" line="85"/>
         <source>Disconnecting...</source>
-        <translation>Отключение...</translation>
+        <translation type="unfinished">Отключение...</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/connectionUiController.cpp" line="90"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/connectionUiController.cpp" line="90"/>
         <source>Preparing...</source>
-        <translation>Подготовка...</translation>
+        <translation type="unfinished">Подготовка...</translation>
+    </message>
+</context>
+<context>
+    <name>ContextMenuType</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Controls2/ContextMenuType.qml" line="55"/>
+        <source>C&amp;ut</source>
+        <translation>Вырезать</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Controls2/ContextMenuType.qml" line="60"/>
+        <source>&amp;Copy</source>
+        <translation>Копировать</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Controls2/ContextMenuType.qml" line="65"/>
+        <source>&amp;Paste</source>
+        <translation>Вставить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Controls2/ContextMenuType.qml" line="72"/>
+        <source>&amp;SelectAll</source>
+        <translation>Выбрать всё</translation>
+    </message>
+</context>
+<context>
+    <name>HomeContainersListView</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Components/HomeContainersListView.qml" line="55"/>
+        <source>Unable change protocol while there is an active connection</source>
+        <translation>Невозможно изменить протокол во время активного соединения</translation>
+    </message>
+</context>
+<context>
+    <name>HomeSplitTunnelingDrawer</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Components/HomeSplitTunnelingDrawer.qml" line="34"/>
+        <source>Split tunneling</source>
+        <translation>Раздельное VPN-туннелирование</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Components/HomeSplitTunnelingDrawer.qml" line="35"/>
+        <source>Allows you to connect to some sites or applications through a VPN connection and bypass others</source>
+        <translation>Позволяет подключаться к одним сайтам или приложениям через VPN-соединение, а к другим — в обход него</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Components/HomeSplitTunnelingDrawer.qml" line="45"/>
+        <source>Split tunneling on the server</source>
+        <translation>Раздельное туннелирование на сервере</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Components/HomeSplitTunnelingDrawer.qml" line="46"/>
+        <source>Enabled 
+Can&apos;t be disabled for current server</source>
+        <translation>Включено
+Невозможно отключить для текущего сервера
+		</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Components/HomeSplitTunnelingDrawer.qml" line="64"/>
+        <source>Site-based split tunneling</source>
+        <translation>Раздельное туннелирование сайтов</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Components/HomeSplitTunnelingDrawer.qml" line="65"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Components/HomeSplitTunnelingDrawer.qml" line="84"/>
+        <source>Enabled</source>
+        <translation>Включено</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Components/HomeSplitTunnelingDrawer.qml" line="65"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Components/HomeSplitTunnelingDrawer.qml" line="84"/>
+        <source>Disabled</source>
+        <translation>Отключено</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Components/HomeSplitTunnelingDrawer.qml" line="83"/>
+        <source>App-based split tunneling</source>
+        <translation>Раздельное туннелирование приложений</translation>
+    </message>
+</context>
+<context>
+    <name>ImportController</name>
+    <message>
+        <source>Scanned %1 of %2.</source>
+        <translation type="vanished">Отсканировано %1 из %2.</translation>
+    </message>
+    <message>
+        <source>This configuration contains an OpenVPN setup. OpenVPN configurations can include malicious scripts, so only add it if you fully trust the provider of this config. </source>
+        <translation type="vanished">Эта конфигурация содержит настройки OpenVPN. Конфигурации OpenVPN могут содержать вредоносные скрипты, поэтому добавляйте их только в том случае, если полностью доверяете источнику этого файла. </translation>
+    </message>
+    <message>
+        <source>&lt;br&gt;In the imported configuration, potentially dangerous lines were found:</source>
+        <translation type="vanished">&lt;br&gt;В импортированной конфигурации обнаружены потенциально опасные строки:</translation>
     </message>
 </context>
 <context>
     <name>ImportUiController</name>
     <message>
-        <location filename="../ui/controllers/importUiController.cpp" line="185"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/importUiController.cpp" line="185"/>
         <source>Scanned %1 of %2.</source>
-        <translation>Отсканировано %1 из %2.</translation>
+        <translation type="unfinished">Отсканировано %1 из %2.</translation>
+    </message>
+</context>
+<context>
+    <name>InstallController</name>
+    <message>
+        <source>%1 installed successfully. </source>
+        <translation type="vanished">%1 успешно установлен. </translation>
+    </message>
+    <message>
+        <source>%1 is already installed on the server. </source>
+        <translation type="vanished">%1 уже установлен на сервер. </translation>
+    </message>
+    <message>
+        <source>
+Added containers that were already installed on the server</source>
+        <translation type="vanished">
+Добавлены сервисы и протоколы, которые были ранее установлены на сервер</translation>
+    </message>
+    <message>
+        <source>
+Already installed containers were found on the server. All installed containers have been added to the application</source>
+        <translation type="vanished">
+На сервере обнаружены установленные протоколы и сервисы. Все они были добавлены в приложение</translation>
+    </message>
+    <message>
+        <source>Settings updated successfully</source>
+        <translation type="vanished">Настройки успешно обновлены</translation>
+    </message>
+    <message>
+        <source>Server &apos;%1&apos; was rebooted</source>
+        <translation type="vanished">Сервер &apos;%1&apos; был перезагружен</translation>
+    </message>
+    <message>
+        <source>Server &apos;%1&apos; was removed</source>
+        <translation type="vanished">Сервер &apos;%1&apos; был удален</translation>
+    </message>
+    <message>
+        <source>All containers from server &apos;%1&apos; have been removed</source>
+        <translation type="vanished">Все протоколы и сервисы были удалены с сервера &apos;%1&apos;</translation>
+    </message>
+    <message>
+        <source>%1 has been removed from the server &apos;%2&apos;</source>
+        <translation type="vanished">%1 был удален с сервера &apos;%2&apos;</translation>
+    </message>
+    <message>
+        <source>Api config removed</source>
+        <translation type="vanished">Конфигурация API удалена</translation>
+    </message>
+    <message>
+        <source>%1 cached profile cleared</source>
+        <translation type="vanished">%1 закэшированный профиль очищен</translation>
+    </message>
+    <message>
+        <source>Please login as the user</source>
+        <translation type="vanished">Пожалуйста, войдите в систему от имени пользователя</translation>
+    </message>
+    <message>
+        <source>Server added successfully</source>
+        <translation type="vanished">Сервер успешно добавлен</translation>
     </message>
 </context>
 <context>
     <name>InstallUiController</name>
     <message>
-        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="125"/>
-        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="167"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/selfhosted/installUiController.cpp" line="125"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/selfhosted/installUiController.cpp" line="167"/>
         <source>%1 installed successfully. </source>
-        <translation>%1 успешно установлен. </translation>
+        <translation type="unfinished">%1 успешно установлен. </translation>
     </message>
     <message>
-        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="127"/>
-        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="169"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/selfhosted/installUiController.cpp" line="127"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/selfhosted/installUiController.cpp" line="169"/>
         <source>%1 is already installed on the server. </source>
-        <translation>%1 уже установлен на сервер. </translation>
+        <translation type="unfinished">%1 уже установлен на сервер. </translation>
     </message>
     <message>
-        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="131"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/selfhosted/installUiController.cpp" line="131"/>
         <source>
 Added containers that were already installed on the server</source>
-        <translation>
+        <translation type="unfinished">
 Добавлены сервисы и протоколы, которые были ранее установлены на сервер</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="173"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/selfhosted/installUiController.cpp" line="173"/>
         <source>
 Already installed containers were found on the server. All installed containers have been added to the application</source>
-        <translation>
+        <translation type="unfinished">
 На сервере обнаружены установленные протоколы и сервисы. Все они были добавлены в приложение</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="288"/>
-        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="327"/>
-        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="351"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/selfhosted/installUiController.cpp" line="288"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/selfhosted/installUiController.cpp" line="327"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/selfhosted/installUiController.cpp" line="351"/>
         <source>Settings updated successfully</source>
-        <translation>Настройки успешно обновлены</translation>
+        <translation type="unfinished">Настройки успешно обновлены</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="471"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/selfhosted/installUiController.cpp" line="471"/>
         <source>Server &apos;%1&apos; was rebooted</source>
-        <translation>Сервер &apos;%1&apos; был перезагружен</translation>
+        <translation type="unfinished">Сервер &apos;%1&apos; был перезагружен</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="485"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/selfhosted/installUiController.cpp" line="485"/>
         <source>Server &apos;%1&apos; was removed</source>
-        <translation>Сервер &apos;%1&apos; был удален</translation>
+        <translation type="unfinished">Сервер &apos;%1&apos; был удален</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="494"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/selfhosted/installUiController.cpp" line="494"/>
         <source>All containers from server &apos;%1&apos; have been removed</source>
-        <translation>Все протоколы и сервисы были удалены с сервера &apos;%1&apos;</translation>
+        <translation type="unfinished">Все протоколы и сервисы были удалены с сервера &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="520"/>
-        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="538"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/selfhosted/installUiController.cpp" line="520"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/selfhosted/installUiController.cpp" line="538"/>
         <source>%1 has been removed from the server &apos;%2&apos;</source>
-        <translation>%1 был удален с сервера &apos;%2&apos;</translation>
+        <translation type="unfinished">%1 был удален с сервера &apos;%2&apos;</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="553"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/selfhosted/installUiController.cpp" line="553"/>
         <source>%1 cached profile cleared</source>
-        <translation>%1 закэшированный профиль очищен</translation>
+        <translation type="unfinished">%1 закэшированный профиль очищен</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="607"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/selfhosted/installUiController.cpp" line="607"/>
         <source>Please login as the user</source>
-        <translation>Пожалуйста, войдите в систему от имени пользователя</translation>
+        <translation type="unfinished">Пожалуйста, войдите в систему от имени пользователя</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="631"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/selfhosted/installUiController.cpp" line="631"/>
         <source>Server added successfully</source>
-        <translation>Сервер успешно добавлен</translation>
+        <translation type="unfinished">Сервер успешно добавлен</translation>
+    </message>
+</context>
+<context>
+    <name>InstalledAppsDrawer</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Components/InstalledAppsDrawer.qml" line="57"/>
+        <source>Choose application</source>
+        <translation>Выберите приложение</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Components/InstalledAppsDrawer.qml" line="124"/>
+        <source>application name</source>
+        <translation>название приложения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Components/InstalledAppsDrawer.qml" line="137"/>
+        <source>Add selected</source>
+        <translation>Добавить выбранные</translation>
     </message>
 </context>
 <context>
     <name>IpSplitTunnelingController</name>
     <message>
-        <location filename="../core/controllers/ipSplitTunnelingController.cpp" line="198"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/controllers/ipSplitTunnelingController.cpp" line="219"/>
         <source>Failed to parse JSON data: %1</source>
         <translation>Не удалось разобрать данные в формате JSON: %1</translation>
     </message>
     <message>
-        <location filename="../core/controllers/ipSplitTunnelingController.cpp" line="203"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/controllers/ipSplitTunnelingController.cpp" line="224"/>
         <source>The JSON data is not an array</source>
         <translation>Данные в формате JSON не являются массивом</translation>
     </message>
@@ -231,93 +705,1776 @@ Already installed containers were found on the server. All installed containers 
 <context>
     <name>IpSplitTunnelingUiController</name>
     <message>
-        <location filename="../ui/controllers/ipSplitTunnelingUiController.cpp" line="22"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/ipSplitTunnelingUiController.cpp" line="22"/>
         <source>New site added: %1</source>
-        <translation>Добавлен новый сайт: %1</translation>
+        <translation type="unfinished">Добавлен новый сайт: %1</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/ipSplitTunnelingUiController.cpp" line="31"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/ipSplitTunnelingUiController.cpp" line="31"/>
         <source>Site removed: %1</source>
-        <translation>Сайт удален: %1</translation>
+        <translation type="unfinished">Сайт удален: %1</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/ipSplitTunnelingUiController.cpp" line="38"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/ipSplitTunnelingUiController.cpp" line="38"/>
         <source>Site list cleared!</source>
-        <translation>Список сайтов очищен!</translation>
+        <translation type="unfinished">Список сайтов очищен!</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/ipSplitTunnelingUiController.cpp" line="45"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/ipSplitTunnelingUiController.cpp" line="45"/>
         <source>Can&apos;t open file: %1</source>
-        <translation>Невозможно открыть файл: %1</translation>
+        <translation type="unfinished">Невозможно открыть файл: %1</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/ipSplitTunnelingUiController.cpp" line="51"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/ipSplitTunnelingUiController.cpp" line="51"/>
         <source>Import completed</source>
         <translation>Импорт завершен</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/ipSplitTunnelingUiController.cpp" line="64"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/ipSplitTunnelingUiController.cpp" line="64"/>
         <source>Export completed</source>
         <translation>Экспорт завершен</translation>
     </message>
 </context>
 <context>
+    <name>KeyChainClass</name>
+    <message>
+        <source>Read key failed: %1</source>
+        <translation type="vanished">Не удалось считать ключ: %1</translation>
+    </message>
+    <message>
+        <source>Write key failed: %1</source>
+        <translation type="vanished">Не удалось записать ключ: %1</translation>
+    </message>
+    <message>
+        <source>Delete key failed: %1</source>
+        <translation type="vanished">Не удалось удалить ключ: %1</translation>
+    </message>
+</context>
+<context>
     <name>MarketplaceUpdateController</name>
     <message>
-        <location filename="../ui/controllers/marketplaceUpdateController.cpp" line="153"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/marketplaceUpdateController.cpp" line="153"/>
         <source>Update available</source>
         <translation>Доступно обновление</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/marketplaceUpdateController.cpp" line="154"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/marketplaceUpdateController.cpp" line="154"/>
         <source>A new version of AmneziaVPN is available.</source>
         <translation>Доступна новая версия AmneziaVPN</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/marketplaceUpdateController.cpp" line="155"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/marketplaceUpdateController.cpp" line="155"/>
         <source>Update</source>
         <translation>Обновить</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/marketplaceUpdateController.cpp" line="156"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/marketplaceUpdateController.cpp" line="156"/>
         <source>Skip</source>
         <translation>Пропустить</translation>
     </message>
 </context>
 <context>
+    <name>MinMaxRowType</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Controls2/MinMaxRowType.qml" line="78"/>
+        <source>Min</source>
+        <translation>Мин</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Controls2/MinMaxRowType.qml" line="113"/>
+        <source>Max</source>
+        <translation>Макс</translation>
+    </message>
+</context>
+<context>
     <name>NotificationHandler</name>
     <message>
-        <location filename="../ui/utils/notificationHandler.cpp" line="57"/>
-        <location filename="../ui/utils/notificationHandler.cpp" line="64"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/utils/notificationHandler.cpp" line="57"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/utils/notificationHandler.cpp" line="64"/>
         <source>AmneziaVPN</source>
         <translation>AmneziaVPN</translation>
     </message>
     <message>
-        <location filename="../ui/utils/notificationHandler.cpp" line="58"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/utils/notificationHandler.cpp" line="58"/>
         <source>VPN Connected</source>
         <translation>VPN подключен</translation>
     </message>
     <message>
-        <location filename="../ui/utils/notificationHandler.cpp" line="65"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/utils/notificationHandler.cpp" line="65"/>
         <source>VPN Disconnected</source>
         <translation>VPN выключен</translation>
     </message>
     <message>
-        <location filename="../ui/utils/notificationHandler.cpp" line="88"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/utils/notificationHandler.cpp" line="88"/>
         <source>AmneziaVPN notification</source>
         <translation>Уведомление AmneziaVPN</translation>
     </message>
     <message>
-        <location filename="../ui/utils/notificationHandler.cpp" line="89"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/utils/notificationHandler.cpp" line="89"/>
         <source>Unsecured network detected: </source>
         <translation>Обнаружена незащищенная сеть: </translation>
     </message>
 </context>
 <context>
+    <name>OtpCodeDrawer</name>
+    <message>
+        <source>OTP code was sent to your email</source>
+        <translation type="vanished">Одноразовый код был отправлен на ваш email</translation>
+    </message>
+    <message>
+        <source>OTP Code</source>
+        <translation type="vanished">Одноразовый код</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="vanished">Продолжить</translation>
+    </message>
+</context>
+<context>
+    <name>PageDeinstalling</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageDeinstalling.qml" line="52"/>
+        <source>Removing services from %1</source>
+        <translation>Удаление сервисов c %1</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageDeinstalling.qml" line="81"/>
+        <source>Usually it takes no more than 5 minutes</source>
+        <translation>Обычно это занимает не более 5 минут</translation>
+    </message>
+</context>
+<context>
+    <name>PageDevMenu</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageDevMenu.qml" line="60"/>
+        <source>Gateway endpoint</source>
+        <translation>Gateway endpoint</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageDevMenu.qml" line="77"/>
+        <source>Save</source>
+        <translation type="unfinished">Сохранить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageDevMenu.qml" line="85"/>
+        <source>Settings saved</source>
+        <translation type="unfinished">Настройки сохранены</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageDevMenu.qml" line="99"/>
+        <source>Dev gateway environment</source>
+        <translation>Dev gateway environment</translation>
+    </message>
+</context>
+<context>
+    <name>PageHome</name>
+    <message>
+        <source>You&apos;ve successfully switched to the new Amnezia Premium subscription!</source>
+        <translation type="vanished">Вы успешно перешли на новый тип подписки Amnezia Premium!</translation>
+    </message>
+    <message>
+        <source>Old keys will no longer work. Please use your new subscription key to connect. 
+Thank you for staying with us!</source>
+        <translation type="vanished">Старые ключи перестанут работать. Пожалуйста, используйте новый ключ для подключения.
+Спасибо, что остаетесь с нами!</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="vanished">Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/_tvharness/PageHome.qml" line="12"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageHome.qml" line="157"/>
+        <source>Logging enabled</source>
+        <translation>Логирование включено</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageHome.qml" line="185"/>
+        <source>Dev gateway enabled</source>
+        <translation>Dev gateway enabled</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageHome.qml" line="462"/>
+        <source>AmneziaWG 2.0 is outdated and no longer supported. Continued use requires a fresh installation of the AmneziaWG 3.0 container.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageHome.qml" line="508"/>
+        <source>Unable change protocol while trying to make an active connection</source>
+        <translation>Невозможно сменить протокол при активном подключении</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageHome.qml" line="512"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageHome.qml" line="722"/>
+        <source>Cannot change protocol during active connection</source>
+        <translation type="unfinished">Невозможно изменить протокол во время активного соединения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/_tvharness/PageHome.qml" line="13"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageHome.qml" line="227"/>
+        <source>Split tunneling enabled</source>
+        <translation>Раздельное туннелирование включено</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/_tvharness/PageHome.qml" line="14"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageHome.qml" line="227"/>
+        <source>Split tunneling disabled</source>
+        <translation>Раздельное туннелирование выключено</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/_tvharness/PageHome.qml" line="15"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageHome.qml" line="554"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageHome.qml" line="672"/>
+        <source>VPN protocol</source>
+        <translation>VPN-протокол</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageHome.qml" line="607"/>
+        <source>Servers</source>
+        <translation>Серверы</translation>
+    </message>
+</context>
+<context>
+    <name>PageProtocolAwgClientSettings</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/_tvharness/PageProtocolAwgClientSettings.qml" line="12"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="56"/>
+        <source>AmneziaWG settings</source>
+        <translation>Настройки AmneziaWG</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="80"/>
+        <source>MTU</source>
+        <translation>MTU</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="132"/>
+        <source>I1 - First special junk packet</source>
+        <translation>I1 - First special junk packet</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="142"/>
+        <source>I2 - Second special junk packet</source>
+        <translation>I2 - Second special junk packet</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="152"/>
+        <source>I3 - Third special junk packet</source>
+        <translation>I3 - Third special junk packet</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="162"/>
+        <source>I4 - Fourth special junk packet</source>
+        <translation>I4 - Fourth special junk packet</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="172"/>
+        <source>I5 - Fifth special junk packet</source>
+        <translation>I5 - Fifth special junk packet</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="189"/>
+        <source>HeaderProtectionKey</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="199"/>
+        <source>ContentPaddingAddition - Content padding addition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="211"/>
+        <source>RekeyAfterTime - Rekey after time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="223"/>
+        <source>RekeyTimeout - Rekey timeout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="235"/>
+        <source>RejectAfterTime - Reject after time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="247"/>
+        <source>KeepaliveTimeout - Keepalive timeout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="259"/>
+        <source>MaxHandshakeAttempts - Max handshake attempts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/_tvharness/PageProtocolAwgClientSettings.qml" line="13"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="273"/>
+        <source>Server settings</source>
+        <translation>Настройки сервера</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/_tvharness/PageProtocolAwgClientSettings.qml" line="14"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="281"/>
+        <source>Port</source>
+        <translation>Порт</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/_tvharness/PageProtocolAwgClientSettings.qml" line="15"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="376"/>
+        <source>Save</source>
+        <translation>Сохранить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="385"/>
+        <source>Save settings?</source>
+        <translation>Сохранить настройки?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="386"/>
+        <source>Only the settings for this device will be changed</source>
+        <translation>Будут изменены настройки только для этого устройства</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="387"/>
+        <source>Continue</source>
+        <translation>Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="388"/>
+        <source>Cancel</source>
+        <translation>Отменить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="392"/>
+        <source>Unable change settings while there is an active connection</source>
+        <translation>Невозможно изменить настройки во время активного соединения</translation>
+    </message>
+</context>
+<context>
+    <name>PageProtocolAwgSettings</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/_tvharness/PageProtocolAwgSettings.qml" line="12"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="68"/>
+        <source>AmneziaWG settings</source>
+        <translation>Настройки AmneziaWG</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/_tvharness/PageProtocolAwgSettings.qml" line="13"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="108"/>
+        <source>Port</source>
+        <translation>Порт</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="253"/>
+        <source>I1 - Special junk 1</source>
+        <translation>I1 - Special junk 1</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="263"/>
+        <source>I2 - Special junk 2</source>
+        <translation>I2 - Special junk 2</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="273"/>
+        <source>I3 - Special junk 3</source>
+        <translation>I3 - Special junk 3</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="283"/>
+        <source>I4 - Special junk 4</source>
+        <translation>I4 - Special junk 4</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="293"/>
+        <source>I5 - Special junk 5</source>
+        <translation>I5 - Special junk 5</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="310"/>
+        <source>HeaderProtectionKey</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="326"/>
+        <source>ContentPaddingAddition - Content padding addition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="339"/>
+        <source>RekeyAfterTime - Rekey after time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="352"/>
+        <source>RekeyTimeout - Rekey timeout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="365"/>
+        <source>RejectAfterTime - Reject after time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="378"/>
+        <source>KeepaliveTimeout - Keepalive timeout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="391"/>
+        <source>MaxHandshakeAttempts - Max handshake attempts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="450"/>
+        <source>The value of the field S1 + message initiation size (148) must not equal S2 + message response size (92) + S3 + cookie reply size (64) + S4 + transport packet size (32)</source>
+        <translation>Значение поля S1 + размер инициализации сообщения (148) не должно равняться S2 + размер ответа сообщения (92) + S3 + размер ответа cookie (64) + S4 + размер транспортного пакета (32)</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="456"/>
+        <source>All users with whom you shared a connection with will no longer be able to connect to it.</source>
+        <translation>Все пользователи, с которыми вы поделились конфигурацией вашего VPN, больше не смогут к нему подключаться.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/_tvharness/PageProtocolAwgSettings.qml" line="14"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="427"/>
+        <source>Save</source>
+        <translation>Сохранить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/_tvharness/PageProtocolAwgSettings.qml" line="15"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="81"/>
+        <source>VPN address subnet</source>
+        <translation>Подсеть VPN-адресов</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="131"/>
+        <source>Jc - Junk packet count</source>
+        <translation>Jc - Junk packet count</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="141"/>
+        <source>Jmin - Junk packet minimum size</source>
+        <translation>Jmin - Junk packet minimum size</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="151"/>
+        <source>Jmax - Junk packet maximum size</source>
+        <translation>Jmax - Junk packet maximum size</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="161"/>
+        <source>S1 - Init packet junk size</source>
+        <translation>S1 - Init packet junk size</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="171"/>
+        <source>S2 - Response packet junk size</source>
+        <translation>S2 - Response packet junk size</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="183"/>
+        <source>S3 - Cookie reply packet junk size</source>
+        <translation>S3 - Cookie reply packet junk size</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="195"/>
+        <source>S4 - Transport packet junk size</source>
+        <translation>S4 - Transport packet junk size</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="207"/>
+        <source>H1 - Init packet magic header</source>
+        <translation>H1 - Init packet magic header</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="219"/>
+        <source>H2 - Response packet magic header</source>
+        <translation>H2 - Response packet magic header</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="243"/>
+        <source>H4 - Transport packet magic header</source>
+        <translation>H4 - Transport packet magic header</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="231"/>
+        <source>H3 - Underload packet magic header</source>
+        <translation>H3 - Underload packet magic header</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="442"/>
+        <source>The values of the H1-H4 fields must be unique</source>
+        <translation>Значения в полях H1-H4 должны быть уникальными</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="455"/>
+        <source>Save settings?</source>
+        <translation>Сохранить настройки?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="457"/>
+        <source>Continue</source>
+        <translation>Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="458"/>
+        <source>Cancel</source>
+        <translation>Отменить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolAwgSettings.qml" line="462"/>
+        <source>Unable change settings while there is an active connection</source>
+        <translation>Невозможно изменить настройки во время активного соединения</translation>
+    </message>
+</context>
+<context>
+    <name>PageProtocolCloakSettings</name>
+    <message>
+        <source>Cloak settings</source>
+        <translation type="vanished">Настройки Cloak</translation>
+    </message>
+    <message>
+        <source>Disguised as traffic from</source>
+        <translation type="vanished">Замаскировать трафик под</translation>
+    </message>
+    <message>
+        <source>Port</source>
+        <translation type="vanished">Порт</translation>
+    </message>
+    <message>
+        <source>Cipher</source>
+        <translation type="vanished">Шифрование</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="vanished">Сохранить</translation>
+    </message>
+    <message>
+        <source>Save settings?</source>
+        <translation type="vanished">Сохранить настройки?</translation>
+    </message>
+    <message>
+        <source>All users with whom you shared a connection with will no longer be able to connect to it.</source>
+        <translation type="vanished">Все пользователи, с которыми вы поделились конфигурацией вашего VPN, больше не смогут к нему подключаться.</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="vanished">Продолжить</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="vanished">Отменить</translation>
+    </message>
+    <message>
+        <source>Unable change settings while there is an active connection</source>
+        <translation type="vanished">Невозможно изменить настройки во время активного соединения</translation>
+    </message>
+</context>
+<context>
+    <name>PageProtocolOpenVpnSettings</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/_tvharness/PageProtocolOpenVpnSettings.qml" line="12"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="55"/>
+        <source>OpenVPN Settings</source>
+        <translation>Настройки OpenVPN</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/_tvharness/PageProtocolOpenVpnSettings.qml" line="13"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="76"/>
+        <source>VPN address subnet</source>
+        <translation>Подсеть VPN-адресов</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/_tvharness/PageProtocolOpenVpnSettings.qml" line="14"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="94"/>
+        <source>Network protocol</source>
+        <translation>Сетевой протокол</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/_tvharness/PageProtocolOpenVpnSettings.qml" line="15"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="131"/>
+        <source>Port</source>
+        <translation>Порт</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="153"/>
+        <source>Auto-negotiate encryption</source>
+        <translation>Шифрование с автоматическим согласованием</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="172"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="173"/>
+        <source>Hash</source>
+        <translation>Хэш</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="183"/>
+        <source>SHA512</source>
+        <translation>SHA512</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="184"/>
+        <source>SHA384</source>
+        <translation>SHA384</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="185"/>
+        <source>SHA256</source>
+        <translation>SHA256</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="186"/>
+        <source>SHA3-512</source>
+        <translation>SHA3-512</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="187"/>
+        <source>SHA3-384</source>
+        <translation>SHA3-384</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="188"/>
+        <source>SHA3-256</source>
+        <translation>SHA3-256</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="189"/>
+        <source>whirlpool</source>
+        <translation>whirlpool</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="190"/>
+        <source>BLAKE2b512</source>
+        <translation>BLAKE2b512</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="191"/>
+        <source>BLAKE2s256</source>
+        <translation>BLAKE2s256</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="192"/>
+        <source>SHA1</source>
+        <translation>SHA1</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="233"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="234"/>
+        <source>Cipher</source>
+        <translation>Шифрование</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="244"/>
+        <source>AES-256-GCM</source>
+        <translation>AES-256-GCM</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="245"/>
+        <source>AES-192-GCM</source>
+        <translation>AES-192-GCM</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="246"/>
+        <source>AES-128-GCM</source>
+        <translation>AES-128-GCM</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="247"/>
+        <source>AES-256-CBC</source>
+        <translation>AES-256-CBC</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="248"/>
+        <source>AES-192-CBC</source>
+        <translation>AES-192-CBC</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="249"/>
+        <source>AES-128-CBC</source>
+        <translation>AES-128-CBC</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="250"/>
+        <source>ChaCha20-Poly1305</source>
+        <translation>ChaCha20-Poly1305</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="251"/>
+        <source>ARIA-256-CBC</source>
+        <translation>ARIA-256-CBC</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="252"/>
+        <source>CAMELLIA-256-CBC</source>
+        <translation>CAMELLIA-256-CBC</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="253"/>
+        <source>none</source>
+        <translation>none</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="305"/>
+        <source>TLS auth</source>
+        <translation>TLS авторизация</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="322"/>
+        <source>Block DNS requests outside of VPN</source>
+        <translation>Блокировать DNS-запросы за пределами VPN</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="343"/>
+        <source>Additional client configuration commands</source>
+        <translation>Дополнительные команды конфигурации клиента</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="362"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="399"/>
+        <source>Commands:</source>
+        <translation>Команды:</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="380"/>
+        <source>Additional server configuration commands</source>
+        <translation>Дополнительные команды конфигурации сервера</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="425"/>
+        <source>Save settings?</source>
+        <translation>Сохранить настройки?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="426"/>
+        <source>All users with whom you shared a connection with will no longer be able to connect to it.</source>
+        <translation>Все пользователи, с которыми вы поделились конфигурацией вашего VPN, больше не смогут к нему подключаться.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="427"/>
+        <source>Continue</source>
+        <translation>Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="428"/>
+        <source>Cancel</source>
+        <translation>Отменить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="432"/>
+        <source>Unable change settings while there is an active connection</source>
+        <translation>Невозможно изменить настройки во время активного соединения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="420"/>
+        <source>Save</source>
+        <translation>Сохранить</translation>
+    </message>
+</context>
+<context>
     <name>PageProtocolRaw</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolRaw.qml" line="52"/>
+        <source> settings</source>
+        <translation> настройки</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolRaw.qml" line="68"/>
+        <source>Show connection options</source>
+        <translation>Показать параметры подключения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolRaw.qml" line="124"/>
+        <source>Connection options %1</source>
+        <translation>Параметры подключения %1</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolRaw.qml" line="176"/>
+        <source>Remove </source>
+        <translation>Удалить </translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolRaw.qml" line="180"/>
+        <source>Remove %1 from server?</source>
+        <translation>Удалить %1 с сервера?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolRaw.qml" line="181"/>
+        <source>All users with whom you shared a connection with will no longer be able to connect to it.</source>
+        <translation>Все пользователи, с которыми вы поделились конфигурацией вашего VPN, больше не смогут к нему подключаться.</translation>
+    </message>
     <message>
         <source>All users who you shared a connection with will no longer be able to connect to it.</source>
         <translation type="obsolete">Все пользователи, с которыми вы поделились этим VPN-протоколом, больше не смогут к нему подключаться.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolRaw.qml" line="182"/>
+        <source>Continue</source>
+        <translation>Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolRaw.qml" line="183"/>
+        <source>Cancel</source>
+        <translation>Отменить</translation>
+    </message>
+</context>
+<context>
+    <name>PageProtocolShadowSocksSettings</name>
+    <message>
+        <source>Shadowsocks settings</source>
+        <translation type="vanished">Настройки Shadowsocks</translation>
+    </message>
+    <message>
+        <source>Port</source>
+        <translation type="vanished">Порт</translation>
+    </message>
+    <message>
+        <source>Cipher</source>
+        <translation type="vanished">Шифрование</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="vanished">Сохранить</translation>
+    </message>
+    <message>
+        <source>Save settings?</source>
+        <translation type="vanished">Сохранить настройки?</translation>
+    </message>
+    <message>
+        <source>All users with whom you shared a connection with will no longer be able to connect to it.</source>
+        <translation type="vanished">Все пользователи, с которыми вы поделились конфигурацией вашего VPN, больше не смогут к нему подключаться.</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="vanished">Продолжить</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="vanished">Отменить</translation>
+    </message>
+    <message>
+        <source>Unable change settings while there is an active connection</source>
+        <translation type="vanished">Невозможно изменить настройки во время активного соединения</translation>
+    </message>
+</context>
+<context>
+    <name>PageProtocolWireGuardClientSettings</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolWireGuardClientSettings.qml" line="58"/>
+        <source>WG settings</source>
+        <translation>Настройки WG</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolWireGuardClientSettings.qml" line="68"/>
+        <source>MTU</source>
+        <translation>MTU</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolWireGuardClientSettings.qml" line="86"/>
+        <source>Server settings</source>
+        <translation>Настройки сервера</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolWireGuardClientSettings.qml" line="98"/>
+        <source>Port</source>
+        <translation>Порт</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolWireGuardClientSettings.qml" line="117"/>
+        <source>Save</source>
+        <translation>Сохранить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolWireGuardClientSettings.qml" line="120"/>
+        <source>Save settings?</source>
+        <translation>Сохранить настройки?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolWireGuardClientSettings.qml" line="121"/>
+        <source>Only the settings for this device will be changed</source>
+        <translation>Будут изменены настройки только для этого устройства</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolWireGuardClientSettings.qml" line="122"/>
+        <source>Continue</source>
+        <translation>Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolWireGuardClientSettings.qml" line="123"/>
+        <source>Cancel</source>
+        <translation>Отменить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolWireGuardClientSettings.qml" line="127"/>
+        <source>Unable change settings while there is an active connection</source>
+        <translation>Невозможно изменить настройки во время активного соединения</translation>
+    </message>
+</context>
+<context>
+    <name>PageProtocolWireGuardSettings</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolWireGuardSettings.qml" line="59"/>
+        <source>WG settings</source>
+        <translation>Настройки WG</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolWireGuardSettings.qml" line="70"/>
+        <source>VPN address subnet</source>
+        <translation>Подсеть VPN-адресов</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolWireGuardSettings.qml" line="89"/>
+        <source>Port</source>
+        <translation>Порт</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolWireGuardSettings.qml" line="120"/>
+        <source>Save settings?</source>
+        <translation>Сохранить настройки?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolWireGuardSettings.qml" line="121"/>
+        <source>All users with whom you shared a connection with will no longer be able to connect to it.</source>
+        <translation>Все пользователи, с которыми вы поделились конфигурацией вашего VPN, больше не смогут к нему подключаться.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolWireGuardSettings.qml" line="127"/>
+        <source>Unable change settings while there is an active connection</source>
+        <translation>Невозможно изменить настройки во время активного соединения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolWireGuardSettings.qml" line="122"/>
+        <source>Continue</source>
+        <translation>Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolWireGuardSettings.qml" line="123"/>
+        <source>Cancel</source>
+        <translation>Отменить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolWireGuardSettings.qml" line="115"/>
+        <source>Save</source>
+        <translation>Сохранить</translation>
+    </message>
+</context>
+<context>
+    <name>PageProtocolXrayFlowSettings</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayFlowSettings.qml" line="49"/>
+        <source>Flow</source>
+        <translation>Flow</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayFlowSettings.qml" line="56"/>
+        <source>Empty</source>
+        <translation>Пусто</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayFlowSettings.qml" line="97"/>
+        <source>xtls-rprx-vision is available only with the RAW (TCP) transport.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayFlowSettings.qml" line="118"/>
+        <source>Save</source>
+        <translation type="unfinished">Сохранить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayFlowSettings.qml" line="120"/>
+        <source>Save settings?</source>
+        <translation type="unfinished">Сохранить настройки?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayFlowSettings.qml" line="121"/>
+        <source>All users with whom you shared a connection with will no longer be able to connect to it.</source>
+        <translation type="unfinished">Все пользователи, с которыми вы поделились конфигурацией вашего VPN, больше не смогут к нему подключаться.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayFlowSettings.qml" line="122"/>
+        <source>Continue</source>
+        <translation type="unfinished">Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayFlowSettings.qml" line="123"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Отменить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayFlowSettings.qml" line="126"/>
+        <source>Unable change settings while there is an active connection</source>
+        <translation type="unfinished">Невозможно изменить настройки во время активного соединения</translation>
+    </message>
+</context>
+<context>
+    <name>PageProtocolXraySecuritySettings</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="51"/>
+        <source>Security</source>
+        <translation>Безопасность</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="58"/>
+        <source>None</source>
+        <translation>Нет</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="70"/>
+        <source>TLS</source>
+        <translation>TLS</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="82"/>
+        <source>Reality</source>
+        <translation>Reality</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="95"/>
+        <source>REALITY is not supported with the mKCP transport. Use None or TLS.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="115"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="116"/>
+        <source>ALPN</source>
+        <translation>ALPN</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="160"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="161"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="232"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="233"/>
+        <source>Fingerprint</source>
+        <translation>Fingerprint</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="203"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="275"/>
+        <source>Server Name (SNI)</source>
+        <translation>Имя сервера (SNI)</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="212"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="284"/>
+        <source>Enter a valid IP address or domain name</source>
+        <translation>Введите корректный IP-адрес или доменное имя</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="308"/>
+        <source>Save</source>
+        <translation type="unfinished">Сохранить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="315"/>
+        <source>Save settings?</source>
+        <translation type="unfinished">Сохранить настройки?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="316"/>
+        <source>All users with whom you shared a connection with will no longer be able to connect to it.</source>
+        <translation type="unfinished">Все пользователи, с которыми вы поделились конфигурацией вашего VPN, больше не смогут к нему подключаться.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="317"/>
+        <source>Continue</source>
+        <translation type="unfinished">Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="318"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Отменить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="321"/>
+        <source>Unable change settings while there is an active connection</source>
+        <translation type="unfinished">Невозможно изменить настройки во время активного соединения</translation>
+    </message>
+</context>
+<context>
+    <name>PageProtocolXraySettings</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySettings.qml" line="93"/>
+        <source>XRay VLESS settings</source>
+        <translation>Настройки XRay VLESS</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySettings.qml" line="94"/>
+        <source>More about settings</source>
+        <translation>Подробнее о настройках</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySettings.qml" line="250"/>
+        <source>Reset settings</source>
+        <translation>Сбросить настройки</translation>
+    </message>
+    <message>
+        <source>XRay settings</source>
+        <translation type="vanished">Настройки XRay</translation>
+    </message>
+    <message>
+        <source>Disguised as traffic from</source>
+        <translation type="vanished">Замаскировать трафик под</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySettings.qml" line="39"/>
+        <source>Empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySettings.qml" line="82"/>
+        <source>You have read-only access to this server. XRay settings cannot be edited.</source>
+        <translation>У вас доступ к этому серверу только для чтения. Настройки XRay изменить нельзя.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySettings.qml" line="115"/>
+        <source>Port</source>
+        <translation>Порт</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySettings.qml" line="116"/>
+        <source>Valid range: 1–65535.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySettings.qml" line="161"/>
+        <source>Transport</source>
+        <translation>Транспорт</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySettings.qml" line="175"/>
+        <source>Security</source>
+        <translation>Безопасность</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySettings.qml" line="189"/>
+        <source>Flow</source>
+        <translation>Flow</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySettings.qml" line="214"/>
+        <source>Save</source>
+        <translation>Сохранить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySettings.qml" line="222"/>
+        <source>Save settings?</source>
+        <translation>Сохранить настройки?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySettings.qml" line="223"/>
+        <source>All users with whom you shared a connection with will no longer be able to connect to it.</source>
+        <translation>Все пользователи, с которыми вы поделились конфигурацией вашего VPN, больше не смогут к нему подключаться.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySettings.qml" line="224"/>
+        <source>Continue</source>
+        <translation>Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySettings.qml" line="225"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySettings.qml" line="260"/>
+        <source>Cancel</source>
+        <translation>Отменить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySettings.qml" line="228"/>
+        <source>Unable change settings while there is an active connection</source>
+        <translation>Невозможно изменить настройки во время активного соединения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySettings.qml" line="256"/>
+        <source>Settings were reset to defaults. Tap Save to apply them on the server.</source>
+        <translation>Настройки сброшены к значениям по умолчанию. Нажмите «Сохранить», чтобы применить их на сервере.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySettings.qml" line="259"/>
+        <source>Reset settings?</source>
+        <translation>Сбросить настройки?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySettings.qml" line="259"/>
+        <source>All XRay settings will be restored to defaults.</source>
+        <translation>Все настройки XRay будут восстановлены к значениям по умолчанию.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySettings.qml" line="260"/>
+        <source>Reset</source>
+        <translation>Сбросить</translation>
+    </message>
+</context>
+<context>
+    <name>PageProtocolXraySnapshots</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="31"/>
+        <source>Save XRay configuration</source>
+        <translation>Сохранить конфигурацию XRay</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="32"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="116"/>
+        <source>JSON files (*.json)</source>
+        <translation>Файлы JSON (*.json)</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="41"/>
+        <source>Configuration saved</source>
+        <translation>Конфигурация сохранена</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="73"/>
+        <source>XRay Configurations</source>
+        <translation>Конфигурации XRay</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="79"/>
+        <source>Create configuration based on current settings</source>
+        <translation>Создать конфигурацию на основе текущих настроек</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="93"/>
+        <source>Export settings</source>
+        <translation>Экспорт настроек</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="110"/>
+        <source>Import settings</source>
+        <translation>Импорт настроек</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="111"/>
+        <source>In JSON format</source>
+        <translation>В формате JSON</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="115"/>
+        <source>Open XRay configuration</source>
+        <translation>Открыть конфигурацию XRay</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="121"/>
+        <source>Failed to import configuration</source>
+        <translation>Не удалось импортировать конфигурацию</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="123"/>
+        <source>Configuration imported successfully</source>
+        <translation>Конфигурация успешно импортирована</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="140"/>
+        <source>Configurations</source>
+        <translation>Конфигурации</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="160"/>
+        <source>No saved configurations yet.
+Create one from the current settings.</source>
+        <translation>Сохранённых конфигураций пока нет.
+Создайте конфигурацию из текущих настроек.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="236"/>
+        <source>Apply configuration</source>
+        <translation>Применить конфигурацию</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="251"/>
+        <source>Export configuration</source>
+        <translation>Экспортировать конфигурацию</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="266"/>
+        <source>Delete configuration</source>
+        <translation>Удалить конфигурацию</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="276"/>
+        <source>Delete configuration?</source>
+        <translation>Удалить конфигурацию?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="277"/>
+        <source>This action cannot be undone.</source>
+        <translation>Это действие нельзя отменить.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="278"/>
+        <source>Delete</source>
+        <translation>Удалить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="278"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Отменить</translation>
+    </message>
+</context>
+<context>
+    <name>PageProtocolXrayTransportSettings</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="61"/>
+        <source>Transport</source>
+        <translation>Транспорт</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="69"/>
+        <source>RAW (TCP)</source>
+        <translation>RAW (TCP)</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="81"/>
+        <source>XHTTP</source>
+        <translation>XHTTP</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="82"/>
+        <source>Advanced users</source>
+        <translation>Для продвинутых пользователей</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="94"/>
+        <source>mKCP</source>
+        <translation>mKCP</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="116"/>
+        <source>mKCP Settings</source>
+        <translation>Настройки mKCP</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="125"/>
+        <source>TTI</source>
+        <translation>TTI</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="126"/>
+        <source>Transmission time interval (ms). Valid range: 10–100.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="145"/>
+        <source>uplinkCapacity</source>
+        <translation>uplinkCapacity</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="146"/>
+        <source>Uplink capacity (MB/s). Maximum: 2147483647.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="165"/>
+        <source>downlinkCapacity</source>
+        <translation>downlinkCapacity</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="166"/>
+        <source>Downlink capacity (MB/s). Maximum: 2147483647.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="185"/>
+        <source>readBufferSize</source>
+        <translation>readBufferSize</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="186"/>
+        <source>Read buffer size (MB). Range: 1–2147483647.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="205"/>
+        <source>writeBufferSize</source>
+        <translation>writeBufferSize</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="206"/>
+        <source>Write buffer size (MB). Range: 1–2147483647.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="224"/>
+        <source>Congestion</source>
+        <translation>Congestion</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="246"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="247"/>
+        <source>Mode</source>
+        <translation type="unfinished">Режим</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="289"/>
+        <source>HTTP Profile</source>
+        <translation>Профиль HTTP</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="299"/>
+        <source>Host</source>
+        <translation type="unfinished">Хост</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="308"/>
+        <source>Enter a valid IP address or domain name</source>
+        <translation>Введите корректный IP-адрес или доменное имя</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="319"/>
+        <source>Path</source>
+        <translation>Путь</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="327"/>
+        <source>Path must start with &quot;/&quot;</source>
+        <translation>Путь должен начинаться с «/»</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="340"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="341"/>
+        <source>UplinkHTTPMethod</source>
+        <translation>UplinkHTTPMethod</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="381"/>
+        <source>Disable gRPC Header</source>
+        <translation>Отключить заголовок gRPC</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="382"/>
+        <source>noGRPCHeader</source>
+        <translation>noGRPCHeader</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="393"/>
+        <source>Disable SSE Header</source>
+        <translation>Отключить заголовок SSE</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="394"/>
+        <source>noSSEHeader</source>
+        <translation>noSSEHeader</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="409"/>
+        <source>Session &amp; Sequence</source>
+        <translation>Сессия и последовательность</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="421"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="422"/>
+        <source>SessionPlacement</source>
+        <translation>SessionPlacement</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="463"/>
+        <source>SessionKey</source>
+        <translation>SessionKey</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="483"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="484"/>
+        <source>SeqPlacement</source>
+        <translation>SeqPlacement</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="525"/>
+        <source>SeqKey</source>
+        <translation>SeqKey</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="545"/>
+        <source>Header/Cookie apply only in Packet-up mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="546"/>
+        <source>UplinkDataPlacement</source>
+        <translation>UplinkDataPlacement</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="587"/>
+        <source>UplinkDataKey</source>
+        <translation>UplinkDataKey</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="606"/>
+        <source>Traffic Shaping</source>
+        <translation>Формирование трафика</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="615"/>
+        <source>UplinkChunkSize</source>
+        <translation>UplinkChunkSize</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="616"/>
+        <source>Uplink chunk size in bytes. Maximum: 2147483647. 0 = off.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="635"/>
+        <source>scMaxBufferedPosts</source>
+        <translation>scMaxBufferedPosts</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="636"/>
+        <source>Max buffered POSTs. Range: 0–2147483647.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="655"/>
+        <source>scMaxEachPostBytes</source>
+        <translation>scMaxEachPostBytes</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="677"/>
+        <source>scStreamUpServerSecs</source>
+        <translation>scStreamUpServerSecs</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="699"/>
+        <source>scMinPostsIntervalMs</source>
+        <translation>scMinPostsIntervalMs</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="722"/>
+        <source>Padding and multiplexing</source>
+        <translation>Заполнение и мультиплексирование</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="728"/>
+        <source>xPadding</source>
+        <translation>xPadding</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="740"/>
+        <source>XMux</source>
+        <translation>XMux</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="741"/>
+        <source>On</source>
+        <translation>Вкл.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="741"/>
+        <source>Off</source>
+        <translation>Выкл.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="770"/>
+        <source>Save</source>
+        <translation type="unfinished">Сохранить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="777"/>
+        <source>Save settings?</source>
+        <translation type="unfinished">Сохранить настройки?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="778"/>
+        <source>All users with whom you shared a connection with will no longer be able to connect to it.</source>
+        <translation type="unfinished">Все пользователи, с которыми вы поделились конфигурацией вашего VPN, больше не смогут к нему подключаться.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="779"/>
+        <source>Continue</source>
+        <translation type="unfinished">Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="780"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Отменить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="783"/>
+        <source>Unable change settings while there is an active connection</source>
+        <translation type="unfinished">Невозможно изменить настройки во время активного соединения</translation>
+    </message>
+</context>
+<context>
+    <name>PageProtocolXrayXPaddingBytesSettings</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXPaddingBytesSettings.qml" line="48"/>
+        <source>xPaddingBytes</source>
+        <translation>xPaddingBytes</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXPaddingBytesSettings.qml" line="56"/>
+        <source>Range</source>
+        <translation>Диапазон</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXPaddingBytesSettings.qml" line="91"/>
+        <source>Save</source>
+        <translation type="unfinished">Сохранить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXPaddingBytesSettings.qml" line="93"/>
+        <source>Save settings?</source>
+        <translation type="unfinished">Сохранить настройки?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXPaddingBytesSettings.qml" line="94"/>
+        <source>All users with whom you shared a connection with will no longer be able to connect to it.</source>
+        <translation type="unfinished">Все пользователи, с которыми вы поделились конфигурацией вашего VPN, больше не смогут к нему подключаться.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXPaddingBytesSettings.qml" line="95"/>
+        <source>Continue</source>
+        <translation type="unfinished">Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXPaddingBytesSettings.qml" line="96"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Отменить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXPaddingBytesSettings.qml" line="99"/>
+        <source>Unable change settings while there is an active connection</source>
+        <translation type="unfinished">Невозможно изменить настройки во время активного соединения</translation>
+    </message>
+</context>
+<context>
+    <name>PageProtocolXrayXPaddingSettings</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXPaddingSettings.qml" line="48"/>
+        <source>xPadding</source>
+        <translation>xPadding</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXPaddingSettings.qml" line="54"/>
+        <source>xPaddingBytes</source>
+        <translation>xPaddingBytes</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXPaddingSettings.qml" line="68"/>
+        <source>xPaddingObfsMode</source>
+        <translation>xPaddingObfsMode</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXPaddingSettings.qml" line="81"/>
+        <source>xPaddingKey</source>
+        <translation>xPaddingKey</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXPaddingSettings.qml" line="99"/>
+        <source>xPaddingHeader</source>
+        <translation>xPaddingHeader</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXPaddingSettings.qml" line="120"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXPaddingSettings.qml" line="121"/>
+        <source>xPaddingPlacement</source>
+        <translation>xPaddingPlacement</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXPaddingSettings.qml" line="165"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXPaddingSettings.qml" line="166"/>
+        <source>xPaddingMethod</source>
+        <translation>xPaddingMethod</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXPaddingSettings.qml" line="220"/>
+        <source>Save</source>
+        <translation type="unfinished">Сохранить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXPaddingSettings.qml" line="222"/>
+        <source>Save settings?</source>
+        <translation type="unfinished">Сохранить настройки?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXPaddingSettings.qml" line="223"/>
+        <source>All users with whom you shared a connection with will no longer be able to connect to it.</source>
+        <translation type="unfinished">Все пользователи, с которыми вы поделились конфигурацией вашего VPN, больше не смогут к нему подключаться.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXPaddingSettings.qml" line="224"/>
+        <source>Continue</source>
+        <translation type="unfinished">Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXPaddingSettings.qml" line="225"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Отменить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXPaddingSettings.qml" line="228"/>
+        <source>Unable change settings while there is an active connection</source>
+        <translation type="unfinished">Невозможно изменить настройки во время активного соединения</translation>
+    </message>
+</context>
+<context>
+    <name>PageProtocolXrayXmuxSettings</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXmuxSettings.qml" line="61"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXmuxSettings.qml" line="67"/>
+        <source>xmux</source>
+        <translation>xmux</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXmuxSettings.qml" line="87"/>
+        <source>maxConcurrency</source>
+        <translation>maxConcurrency</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXmuxSettings.qml" line="110"/>
+        <source>maxConnections</source>
+        <translation>maxConnections</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXmuxSettings.qml" line="133"/>
+        <source>cMaxReuseTimes</source>
+        <translation>cMaxReuseTimes</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXmuxSettings.qml" line="156"/>
+        <source>hMaxRequestTimes</source>
+        <translation>hMaxRequestTimes</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXmuxSettings.qml" line="179"/>
+        <source>hMaxReusableSecs</source>
+        <translation>hMaxReusableSecs</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXmuxSettings.qml" line="200"/>
+        <source>hKeepAlivePeriod</source>
+        <translation>hKeepAlivePeriod</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXmuxSettings.qml" line="201"/>
+        <source>HTTP keep-alive period. Integer, may be negative.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXmuxSettings.qml" line="233"/>
+        <source>Save</source>
+        <translation type="unfinished">Сохранить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXmuxSettings.qml" line="235"/>
+        <source>Save settings?</source>
+        <translation type="unfinished">Сохранить настройки?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXmuxSettings.qml" line="236"/>
+        <source>All users with whom you shared a connection with will no longer be able to connect to it.</source>
+        <translation type="unfinished">Все пользователи, с которыми вы поделились конфигурацией вашего VPN, больше не смогут к нему подключаться.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXmuxSettings.qml" line="237"/>
+        <source>Continue</source>
+        <translation type="unfinished">Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXmuxSettings.qml" line="238"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Отменить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageProtocolXrayXmuxSettings.qml" line="241"/>
+        <source>Unable change settings while there is an active connection</source>
+        <translation type="unfinished">Невозможно изменить настройки во время активного соединения</translation>
     </message>
 </context>
 <context>
@@ -328,271 +2485,4040 @@ Already installed containers were found on the server. All installed containers 
     </message>
 </context>
 <context>
-    <name>QKeychain::DeletePasswordJobPrivate</name>
+    <name>PageServiceDnsSettings</name>
     <message>
-        <location filename="../3rd/qtkeychain/qtkeychain/keychain_win.cpp" line="104"/>
-        <source>Password entry not found</source>
-        <translation>Пароль не найден</translation>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceDnsSettings.qml" line="52"/>
+        <source>A DNS service is installed on your server, and it is only accessible via VPN.
+</source>
+        <translation>На вашем сервере установлен DNS-сервис, доступ к нему возможен только через VPN.
+</translation>
     </message>
     <message>
-        <location filename="../3rd/qtkeychain/qtkeychain/keychain_win.cpp" line="108"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceDnsSettings.qml" line="53"/>
+        <source>The DNS address is the same as the address of your server. You can configure DNS in the settings, under the connections tab.</source>
+        <translation>Адрес DNS совпадает с адресом вашего сервера. Настроить DNS можно во вкладке &quot;Соединение&quot; настроек приложения.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceDnsSettings.qml" line="68"/>
+        <source>Remove </source>
+        <translation>Удалить </translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceDnsSettings.qml" line="72"/>
+        <source>Remove %1 from server?</source>
+        <translation>Удалить %1 с сервера?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceDnsSettings.qml" line="73"/>
+        <source>Continue</source>
+        <translation>Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceDnsSettings.qml" line="74"/>
+        <source>Cancel</source>
+        <translation>Отменить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceDnsSettings.qml" line="79"/>
+        <source>Cannot remove AmneziaDNS from running server</source>
+        <translation>Невозможно удалить AmneziaDNS с работающего сервера</translation>
+    </message>
+</context>
+<context>
+    <name>PageServiceMtProxySettings</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="215"/>
+        <source>Checking...</source>
+        <translation>Проверка...</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="218"/>
+        <source>Updating</source>
+        <translation>Обновление</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="222"/>
+        <source>Not deployed</source>
+        <translation>Не установлен</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="225"/>
+        <source>Running</source>
+        <translation>Запущен</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="228"/>
+        <source>Stopped</source>
+        <translation>Остановлен</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="231"/>
+        <source>Error</source>
+        <translation type="unfinished">Ошибка</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="234"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Неизвестный</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="349"/>
+        <source>MTProxy started</source>
+        <translation>MTProxy запущен</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="349"/>
+        <source>MTProxy stopped</source>
+        <translation>MTProxy остановлен</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="362"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="910"/>
+        <source>Settings locked: connection timed out (error code %1). Re-open the page to retry.</source>
+        <translation>Настройки заблокированы: истекло время ожидания подключения (код ошибки %1). Откройте страницу заново, чтобы повторить попытку.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="442"/>
+        <source>MTProxy settings</source>
+        <translation>Настройки MTProxy</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="443"/>
+        <source>Read more about this settings</source>
+        <translation>Подробнее об этих настройках</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="453"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1884"/>
+        <source>No internet connection. Connect to the internet to change MTProxy settings.</source>
+        <translation>Нет подключения к интернету. Подключитесь к интернету, чтобы изменить настройки MTProxy.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="478"/>
+        <source>Connection</source>
+        <translation type="unfinished">Соединение</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="482"/>
+        <source>Settings</source>
+        <translation type="unfinished">Настройки</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="532"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1419"/>
+        <source>Use Telegram connection link</source>
+        <translation>Использовать ссылку для подключения Telegram</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="558"/>
+        <source>Deploy MTProxy first</source>
+        <translation>Сначала установите MTProxy</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="574"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="633"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="713"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="748"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="789"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="860"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1849"/>
+        <source>Copied</source>
+        <translation type="unfinished">Скопировано</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="619"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="865"/>
+        <source>Telegram connection link</source>
+        <translation>Ссылка для подключения Telegram</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="620"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="866"/>
+        <source>MTProxy connection link</source>
+        <translation>Ссылка для подключения MTProxy</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="647"/>
+        <source>Or enter the proxy details manually.</source>
+        <translation>Или введите параметры прокси вручную.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="653"/>
+        <source>How to do it</source>
+        <translation>Как это сделать</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="695"/>
+        <source>Host</source>
+        <translation type="unfinished">Хост</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="731"/>
+        <source>Port</source>
+        <translation type="unfinished">Порт</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="770"/>
+        <source>Secret</source>
+        <translation>Секрет</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="802"/>
+        <source>Delete MTProxy</source>
+        <translation>Удалить MTProxy</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="805"/>
+        <source>Remove %1 from server?</source>
+        <translation type="unfinished">Удалить %1 с сервера?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="806"/>
+        <source>The proxy will be stopped and all users will lose access.</source>
+        <translation>Прокси будет остановлен, и все пользователи потеряют доступ.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="807"/>
+        <source>Continue</source>
+        <translation type="unfinished">Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="808"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="957"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Отменить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="880"/>
+        <source>Enable MTProxy</source>
+        <translation>Включить MTProxy</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="908"/>
+        <source>Enable MTProxy to edit settings</source>
+        <translation>Включите MTProxy, чтобы изменить настройки</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="911"/>
+        <source>Cannot reach the server — settings are unavailable</source>
+        <translation>Сервер недоступен — настройки нельзя изменить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="925"/>
+        <source>Base secret</source>
+        <translation>Основной секрет</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="936"/>
+        <source>Not generated</source>
+        <translation>Не сгенерирован</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="954"/>
+        <source>Generate new secret?</source>
+        <translation>Сгенерировать новый секрет?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="955"/>
+        <source>All existing connection links will stop working. Users will need new links.</source>
+        <translation>Все существующие ссылки для подключения перестанут работать. Пользователям понадобятся новые ссылки.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="956"/>
+        <source>Generate</source>
+        <translation>Сгенерировать</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="966"/>
+        <source>New secret saved. It will be applied when MTProxy is started.</source>
+        <translation>Новый секрет сохранён. Он будет применён при запуске MTProxy.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="984"/>
+        <source>Public host / IP</source>
+        <translation>Публичный хост / IP</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="995"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1003"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1906"/>
+        <source>Enter a valid IP address or domain name</source>
+        <translation>Введите корректный IP-адрес или доменное имя</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1020"/>
+        <source>Leave empty to use server IP automatically</source>
+        <translation>Оставьте пустым, чтобы автоматически использовать IP сервера</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1033"/>
+        <source>⚠ This overrides the server IP in connection links. Make sure this host/domain points to your server.</source>
+        <translation>⚠ Это значение заменяет IP сервера в ссылках для подключения. Убедитесь, что этот хост или домен указывает на ваш сервер.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1046"/>
+        <source>Server port</source>
+        <translation>Порт сервера</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1077"/>
+        <source>FakeTLS may not work on ports other than 443</source>
+        <translation>FakeTLS может не работать на портах, отличных от 443</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1088"/>
+        <source>The promoted channel is set in @MTProxyBot. Paste the proxy tag here: exactly 32 hexadecimal characters (0-9, A-F), as in the bot message — or leave empty.</source>
+        <translation>Рекламируемый канал задаётся в @MTProxyBot. Вставьте сюда тег прокси: ровно 32 шестнадцатеричных символа (0-9, A-F), как в сообщении бота — или оставьте поле пустым.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1101"/>
+        <source>Promoted channel tag (optional)</source>
+        <translation>Тег рекламируемого канала (необязательно)</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1102"/>
+        <source>32 hex chars from @MTProxyBot (e.g. 3b7b2fa9…)</source>
+        <translation>32 шестнадцатеричных символа от @MTProxyBot (например, 3b7b2fa9…)</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1123"/>
+        <source>Proxy tag must be exactly 32 hexadecimal characters (0-9, A-F).</source>
+        <translation>Тег прокси должен состоять ровно из 32 шестнадцатеричных символов (0-9, A-F).</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1133"/>
+        <source>Proxy tag must be exactly 32 hexadecimal characters (0-9, A-F). Leave empty if unused.</source>
+        <translation>Тег прокси должен состоять ровно из 32 шестнадцатеричных символов (0-9, A-F). Оставьте поле пустым, если он не используется.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1152"/>
+        <source>Get a tag from</source>
+        <translation>Получить тег у</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1173"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1188"/>
+        <source>Transport mode</source>
+        <translation>Режим транспорта</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1189"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1193"/>
+        <source>FakeTLS</source>
+        <translation>FakeTLS</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1189"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1193"/>
+        <source>Standard MTProto</source>
+        <translation>Стандартный MTProto</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1222"/>
+        <source>FakeTLS domain</source>
+        <translation>Домен FakeTLS</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1237"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1244"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1921"/>
+        <source>Enter a valid domain name</source>
+        <translation>Введите корректное доменное имя</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1265"/>
+        <source>The domain is encoded into the FakeTLS client secret (ee + base_secret + hex(domain)). It must support HTTPS / TLS 1.3.</source>
+        <translation>Домен кодируется в клиентский секрет FakeTLS (ee + base_secret + hex(domain)). Он должен поддерживать HTTPS / TLS 1.3.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1272"/>
+        <source>⚠ Changing the domain will invalidate all previously issued FakeTLS connection links.</source>
+        <translation>⚠ Смена домена сделает недействительными все ранее выданные ссылки для подключения FakeTLS.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1285"/>
+        <source>Advanced</source>
+        <translation>Дополнительно</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1307"/>
+        <source>Additional secrets</source>
+        <translation>Дополнительные секреты</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1315"/>
+        <source>Add extra secrets to allow gradual migration without disconnecting existing users.</source>
+        <translation>Добавьте дополнительные секреты, чтобы переводить пользователей постепенно, не отключая существующих.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1516"/>
+        <source>Add additional secret</source>
+        <translation>Добавить дополнительный секрет</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1531"/>
+        <source>Worker mode</source>
+        <translation>Режим воркеров</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1548"/>
+        <source>Auto</source>
+        <translation>Авто</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1555"/>
+        <source>Manual</source>
+        <translation type="unfinished">Ручная</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1568"/>
+        <source>Workers are set to 0 automatically for FakeTLS mode.</source>
+        <translation>Для режима FakeTLS количество воркеров автоматически устанавливается в 0.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1581"/>
+        <source>Workers count</source>
+        <translation>Количество воркеров</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1640"/>
+        <source>Server is behind NAT / Docker bridge</source>
+        <translation>Сервер за NAT / Docker bridge</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1641"/>
+        <source>Enable if your server is not directly accessible from the internet, e.g. Docker or private network</source>
+        <translation>Включите, если ваш сервер недоступен из интернета напрямую, например Docker или частная сеть</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1658"/>
+        <source>Internal IP</source>
+        <translation>Внутренний IP</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1667"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1675"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1702"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1710"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1925"/>
+        <source>Enter a valid IPv4 address</source>
+        <translation>Введите корректный адрес IPv4</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1693"/>
+        <source>External IP</source>
+        <translation>Внешний IP</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1741"/>
+        <source>Diagnostics</source>
+        <translation>Диагностика</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1769"/>
+        <source>Public port reachable</source>
+        <translation>Публичный порт доступен</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1773"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1793"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1813"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1833"/>
+        <source>—</source>
+        <translation>—</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1773"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1793"/>
+        <source>Yes</source>
+        <translation>Да</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1773"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1793"/>
+        <source>No</source>
+        <translation>Нет</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1789"/>
+        <source>Telegram upstream reachable</source>
+        <translation>Серверы Telegram доступны</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1809"/>
+        <source>Clients connected</source>
+        <translation>Подключено клиентов</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1829"/>
+        <source>Last config refresh</source>
+        <translation>Последнее обновление конфигурации</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1842"/>
+        <source>Stats endpoint</source>
+        <translation>Адрес статистики</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1855"/>
+        <source>Refreshing…</source>
+        <translation>Обновление…</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1855"/>
+        <source>Tap ↻ to refresh diagnostics</source>
+        <translation>Нажмите ↻, чтобы обновить диагностику</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1867"/>
+        <source>If you change the settings, the proxy connection link will change. The old link will stop working.</source>
+        <translation>Если изменить настройки, ссылка для подключения к прокси изменится. Старая ссылка перестанет работать.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1881"/>
+        <source>Save</source>
+        <translation type="unfinished">Сохранить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1901"/>
+        <source>The port must be in the range of 1 to 65535</source>
+        <translation type="unfinished">Порт должен быть в диапазоне от 1 до 65535</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1913"/>
+        <source>Proxy tag must be exactly 32 hexadecimal characters (0-9, A-F), or leave empty.</source>
+        <translation>Тег прокси должен состоять ровно из 32 шестнадцатеричных символов (0-9, A-F) или быть пустым.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1928"/>
+        <source>NAT internal IP: enter a valid IPv4 address</source>
+        <translation>Внутренний IP для NAT: введите корректный адрес IPv4</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1932"/>
+        <source>NAT external IP: enter a valid IPv4 address</source>
+        <translation>Внешний IP для NAT: введите корректный адрес IPv4</translation>
+    </message>
+</context>
+<context>
+    <name>PageServiceSftpSettings</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSftpSettings.qml" line="23"/>
+        <source>Settings updated successfully</source>
+        <translation>Настройки успешно обновлены</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSftpSettings.qml" line="64"/>
+        <source>SFTP settings</source>
+        <translation>Настройки SFTP</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSftpSettings.qml" line="75"/>
+        <source>Host</source>
+        <translation>Хост</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSftpSettings.qml" line="85"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSftpSettings.qml" line="106"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSftpSettings.qml" line="127"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSftpSettings.qml" line="150"/>
+        <source>Copied</source>
+        <translation>Скопировано</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSftpSettings.qml" line="96"/>
+        <source>Port</source>
+        <translation>Порт</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSftpSettings.qml" line="117"/>
+        <source>User name</source>
+        <translation>Имя пользователя</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSftpSettings.qml" line="138"/>
+        <source>Password</source>
+        <translation>Пароль</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSftpSettings.qml" line="172"/>
+        <source>Mount folder on device</source>
+        <translation>Смонтировать папку на устройстве</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSftpSettings.qml" line="197"/>
+        <source>In order to mount remote SFTP folder as local drive, perform following steps: &lt;br&gt;</source>
+        <translation>Чтобы смонтировать SFTP-папку как локальный диск, выполните следующие действия: &lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSftpSettings.qml" line="199"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSftpSettings.qml" line="202"/>
+        <source>&lt;br&gt;1. Install the latest version of </source>
+        <translation>&lt;br&gt;1. Установите последнюю версию </translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSftpSettings.qml" line="200"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSftpSettings.qml" line="203"/>
+        <source>&lt;br&gt;2. Install the latest version of </source>
+        <translation>&lt;br&gt;2. Установите последнюю версию </translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSftpSettings.qml" line="232"/>
+        <source>Detailed instructions</source>
+        <translation>Подробные инструкции</translation>
+    </message>
+</context>
+<context>
+    <name>PageServiceSocksProxySettings</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="25"/>
+        <source>Settings updated successfully</source>
+        <translation>Настройки успешно обновлены</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="64"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="188"/>
+        <source>SOCKS5 settings</source>
+        <translation>Настройки SOCKS5</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="73"/>
+        <source>Host</source>
+        <translation>Хост</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="83"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="102"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="121"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="142"/>
+        <source>Copied</source>
+        <translation>Скопировано</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="92"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="199"/>
+        <source>Port</source>
+        <translation>Порт</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="111"/>
+        <source>User name</source>
+        <translation>Имя пользователя</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="130"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="243"/>
+        <source>Password</source>
+        <translation>Пароль</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="220"/>
+        <source>Username</source>
+        <translation>Имя пользователя</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="272"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="307"/>
+        <source>Change connection settings</source>
+        <translation>Изменить настройки соединения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="276"/>
+        <source>The port must be in the range of 1 to 65535</source>
+        <translation>Порт должен быть в диапазоне от 1 до 65535</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="280"/>
+        <source>Password cannot be empty</source>
+        <translation>Пароль не может быть пустым</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="283"/>
+        <source>Username cannot be empty</source>
+        <translation>Имя пользователя не может быть пустым</translation>
+    </message>
+</context>
+<context>
+    <name>PageServiceTelemtSettings</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="215"/>
+        <source>Checking...</source>
+        <translation>Проверка...</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="218"/>
+        <source>Updating</source>
+        <translation>Обновление</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="222"/>
+        <source>Not deployed</source>
+        <translation>Не установлен</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="225"/>
+        <source>Running</source>
+        <translation>Запущен</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="228"/>
+        <source>Stopped</source>
+        <translation>Остановлен</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="231"/>
+        <source>Error</source>
+        <translation type="unfinished">Ошибка</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="234"/>
+        <source>Unknown</source>
+        <translation type="unfinished">Неизвестный</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="349"/>
+        <source>Telemt started</source>
+        <translation>Telemt запущен</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="349"/>
+        <source>Telemt stopped</source>
+        <translation>Telemt остановлен</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="362"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="910"/>
+        <source>Settings locked: connection timed out (error code %1). Re-open the page to retry.</source>
+        <translation>Настройки заблокированы: истекло время ожидания подключения (код ошибки %1). Откройте страницу заново, чтобы повторить попытку.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="442"/>
+        <source>Telemt settings</source>
+        <translation>Настройки Telemt</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="443"/>
+        <source>Read more about this settings</source>
+        <translation>Подробнее об этих настройках</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="453"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1741"/>
+        <source>No internet connection. Connect to the internet to change Telemt settings.</source>
+        <translation>Нет подключения к интернету. Подключитесь к интернету, чтобы изменить настройки Telemt.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="478"/>
+        <source>Connection</source>
+        <translation type="unfinished">Соединение</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="482"/>
+        <source>Settings</source>
+        <translation type="unfinished">Настройки</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="532"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1419"/>
+        <source>Use Telegram connection link</source>
+        <translation>Использовать ссылку для подключения Telegram</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="558"/>
+        <source>Deploy Telemt first</source>
+        <translation>Сначала установите Telemt</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="574"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="633"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="713"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="748"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="789"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="860"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1706"/>
+        <source>Copied</source>
+        <translation type="unfinished">Скопировано</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="619"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="865"/>
+        <source>Telegram connection link</source>
+        <translation>Ссылка для подключения Telegram</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="620"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="866"/>
+        <source>Telemt connection link</source>
+        <translation>Ссылка для подключения Telemt</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="647"/>
+        <source>Or enter the proxy details manually.</source>
+        <translation>Или введите параметры прокси вручную.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="653"/>
+        <source>How to do it</source>
+        <translation>Как это сделать</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="695"/>
+        <source>Host</source>
+        <translation type="unfinished">Хост</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="731"/>
+        <source>Port</source>
+        <translation type="unfinished">Порт</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="770"/>
+        <source>Secret</source>
+        <translation>Секрет</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="802"/>
+        <source>Delete Telemt</source>
+        <translation>Удалить Telemt</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="805"/>
+        <source>Remove %1 from server?</source>
+        <translation type="unfinished">Удалить %1 с сервера?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="806"/>
+        <source>The proxy will be stopped and all users will lose access.</source>
+        <translation>Прокси будет остановлен, и все пользователи потеряют доступ.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="807"/>
+        <source>Continue</source>
+        <translation type="unfinished">Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="808"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="957"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Отменить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="880"/>
+        <source>Enable Telemt</source>
+        <translation>Включить Telemt</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="908"/>
+        <source>Enable Telemt to edit settings</source>
+        <translation>Включите Telemt, чтобы изменить настройки</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="911"/>
+        <source>Cannot reach the server — settings are unavailable</source>
+        <translation>Сервер недоступен — настройки нельзя изменить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="925"/>
+        <source>Base secret</source>
+        <translation>Основной секрет</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="936"/>
+        <source>Not generated</source>
+        <translation>Не сгенерирован</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="954"/>
+        <source>Generate new secret?</source>
+        <translation>Сгенерировать новый секрет?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="955"/>
+        <source>All existing connection links will stop working. Users will need new links.</source>
+        <translation>Все существующие ссылки для подключения перестанут работать. Пользователям понадобятся новые ссылки.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="956"/>
+        <source>Generate</source>
+        <translation>Сгенерировать</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="966"/>
+        <source>New secret saved. It will be applied when Telemt is started.</source>
+        <translation>Новый секрет сохранён. Он будет применён при запуске Telemt.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="984"/>
+        <source>Public host / IP</source>
+        <translation>Публичный хост / IP</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="995"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1003"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1762"/>
+        <source>Enter a valid IP address or domain name</source>
+        <translation>Введите корректный IP-адрес или доменное имя</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1020"/>
+        <source>Leave empty to use server IP automatically</source>
+        <translation>Оставьте пустым, чтобы автоматически использовать IP сервера</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1033"/>
+        <source>⚠ This overrides the server IP in connection links. Make sure this host/domain points to your server.</source>
+        <translation>⚠ Это значение заменяет IP сервера в ссылках для подключения. Убедитесь, что этот хост или домен указывает на ваш сервер.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1046"/>
+        <source>Server port</source>
+        <translation>Порт сервера</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1077"/>
+        <source>FakeTLS may not work on ports other than 443</source>
+        <translation>FakeTLS может не работать на портах, отличных от 443</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1088"/>
+        <source>The promoted channel is set in @MTProxyBot. Paste the proxy tag here: exactly 32 hexadecimal characters (0-9, A-F), as in the bot message — or leave empty.</source>
+        <translation>Рекламируемый канал задаётся в @MTProxyBot. Вставьте сюда тег прокси: ровно 32 шестнадцатеричных символа (0-9, A-F), как в сообщении бота — или оставьте поле пустым.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1101"/>
+        <source>Promoted channel tag (optional)</source>
+        <translation>Тег рекламируемого канала (необязательно)</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1102"/>
+        <source>32 hex chars from @MTProxyBot (e.g. 3b7b2fa9…)</source>
+        <translation>32 шестнадцатеричных символа от @MTProxyBot (например, 3b7b2fa9…)</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1123"/>
+        <source>Proxy tag must be exactly 32 hexadecimal characters (0-9, A-F).</source>
+        <translation>Тег прокси должен состоять ровно из 32 шестнадцатеричных символов (0-9, A-F).</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1133"/>
+        <source>Proxy tag must be exactly 32 hexadecimal characters (0-9, A-F). Leave empty if unused.</source>
+        <translation>Тег прокси должен состоять ровно из 32 шестнадцатеричных символов (0-9, A-F). Оставьте поле пустым, если он не используется.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1152"/>
+        <source>Get a tag from</source>
+        <translation>Получить тег у</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1173"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1188"/>
+        <source>Transport mode</source>
+        <translation>Режим транспорта</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1189"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1193"/>
+        <source>FakeTLS</source>
+        <translation>FakeTLS</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1189"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1193"/>
+        <source>Standard MTProto</source>
+        <translation>Стандартный MTProto</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1222"/>
+        <source>FakeTLS domain</source>
+        <translation>Домен FakeTLS</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1237"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1244"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1777"/>
+        <source>Enter a valid domain name</source>
+        <translation>Введите корректное доменное имя</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1265"/>
+        <source>The domain is encoded into the FakeTLS client secret (ee + base_secret + hex(domain)). It must support HTTPS / TLS 1.3.</source>
+        <translation>Домен кодируется в клиентский секрет FakeTLS (ee + base_secret + hex(domain)). Он должен поддерживать HTTPS / TLS 1.3.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1272"/>
+        <source>⚠ Changing the domain will invalidate all previously issued FakeTLS connection links.</source>
+        <translation>⚠ Смена домена сделает недействительными все ранее выданные ссылки для подключения FakeTLS.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1285"/>
+        <source>Advanced</source>
+        <translation>Дополнительно</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1307"/>
+        <source>Additional secrets</source>
+        <translation>Дополнительные секреты</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1315"/>
+        <source>Add extra secrets to allow gradual migration without disconnecting existing users.</source>
+        <translation>Добавьте дополнительные секреты, чтобы переводить пользователей постепенно, не отключая существующих.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1516"/>
+        <source>Add additional secret</source>
+        <translation>Добавить дополнительный секрет</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1532"/>
+        <source>Set public IP manually</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1533"/>
+        <source>By default the proxy auto-detects its public IP. Enable to override it manually, e.g. when the server is behind NAT / Docker bridge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1550"/>
+        <source>Public IP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1559"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1567"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1781"/>
+        <source>Enter a valid IPv4 address</source>
+        <translation>Введите корректный адрес IPv4</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1598"/>
+        <source>Diagnostics</source>
+        <translation>Диагностика</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1626"/>
+        <source>Public port reachable</source>
+        <translation>Публичный порт доступен</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1630"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1650"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1670"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1690"/>
+        <source>—</source>
+        <translation>—</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1630"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1650"/>
+        <source>Yes</source>
+        <translation>Да</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1630"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1650"/>
+        <source>No</source>
+        <translation>Нет</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1646"/>
+        <source>Telegram upstream reachable</source>
+        <translation>Серверы Telegram доступны</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1666"/>
+        <source>Clients connected</source>
+        <translation>Подключено клиентов</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1686"/>
+        <source>Last config refresh</source>
+        <translation>Последнее обновление конфигурации</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1699"/>
+        <source>Stats endpoint</source>
+        <translation>Адрес статистики</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1712"/>
+        <source>Refreshing…</source>
+        <translation>Обновление…</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1712"/>
+        <source>Tap ↻ to refresh diagnostics</source>
+        <translation>Нажмите ↻, чтобы обновить диагностику</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1724"/>
+        <source>If you change the settings, the proxy connection link will change. The old link will stop working.</source>
+        <translation>Если изменить настройки, ссылка для подключения к прокси изменится. Старая ссылка перестанет работать.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1738"/>
+        <source>Save</source>
+        <translation type="unfinished">Сохранить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1757"/>
+        <source>The port must be in the range of 1 to 65535</source>
+        <translation type="unfinished">Порт должен быть в диапазоне от 1 до 65535</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1769"/>
+        <source>Proxy tag must be exactly 32 hexadecimal characters (0-9, A-F), or leave empty.</source>
+        <translation>Тег прокси должен состоять ровно из 32 шестнадцатеричных символов (0-9, A-F) или быть пустым.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1784"/>
+        <source>Public IP: enter a valid IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageServiceTorWebsiteSettings</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTorWebsiteSettings.qml" line="24"/>
+        <source>Settings updated successfully</source>
+        <translation>Настройки успешно обновлены</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTorWebsiteSettings.qml" line="59"/>
+        <source>Tor website settings</source>
+        <translation>Настройки сайта в сети Тоr</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTorWebsiteSettings.qml" line="75"/>
+        <source>Website address</source>
+        <translation>Адрес сайта</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTorWebsiteSettings.qml" line="86"/>
+        <source>Copied</source>
+        <translation>Скопировано</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTorWebsiteSettings.qml" line="102"/>
+        <source>Use &lt;a href=&quot;https://www.torproject.org/download/&quot; style=&quot;color: #FBB26A;&quot;&gt;Tor Browser&lt;/a&gt; to open this URL.</source>
+        <translation>Используйте &lt;a href=&quot;https://www.torproject.org/download/&quot; style=&quot;color: #FBB26A;&quot;&gt;Tor Browser&lt;/a&gt; для открытия этой ссылки.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTorWebsiteSettings.qml" line="117"/>
+        <source>After creating your onion site, it takes a few minutes for the Tor network to make it available for use.</source>
+        <translation>Через несколько минут после установки ваш onion-сайт станет доступен в сети Tor.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageServiceTorWebsiteSettings.qml" line="126"/>
+        <source>When configuring WordPress set the this onion address as domain.</source>
+        <translation>При настройке WordPress укажите этот onion-адрес в качестве домена.</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettings</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettings.qml" line="48"/>
+        <source>Settings</source>
+        <translation>Настройки</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettings.qml" line="117"/>
+        <source>Servers</source>
+        <translation>Серверы</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettings.qml" line="128"/>
+        <source>Connection</source>
+        <translation>Соединение</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettings.qml" line="139"/>
+        <source>Application</source>
+        <translation>Приложение</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettings.qml" line="150"/>
+        <source>News &amp; Notifications</source>
+        <translation>Новости и Уведомления</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettings.qml" line="166"/>
+        <source>Backup</source>
+        <translation>Резервное копирование</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettings.qml" line="177"/>
+        <source>About AmneziaVPN</source>
+        <translation>Об AmneziaVPN</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettings.qml" line="188"/>
+        <source>Dev console</source>
+        <translation>Dev console</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettings.qml" line="85"/>
+        <source>Close application</source>
+        <translation>Закрыть приложение</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsAbout</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsAbout.qml" line="61"/>
+        <source>Support Amnezia</source>
+        <translation>Поддержите Amnezia</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsAbout.qml" line="76"/>
+        <source>Amnezia is a free and open-source application. You can support the developers if you like it.</source>
+        <translation>Amnezia — это бесплатное приложение с открытым исходным кодом. Поддержите разработчиков, если оно вам нравится.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsAbout.qml" line="86"/>
+        <source>Contacts</source>
+        <translation>Контакты</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsAbout.qml" line="189"/>
+        <source>Telegram group</source>
+        <translation>Группа в Telegram</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsAbout.qml" line="190"/>
+        <source>To discuss features</source>
+        <translation>Для обсуждения возможностей</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsAbout.qml" line="193"/>
+        <source>https://t.me/amnezia_vpn_en</source>
+        <translation>https://t.me/amnezia_vpn</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsAbout.qml" line="200"/>
+        <source>support@amnezia.org</source>
+        <translation>support@amnezia.org</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsAbout.qml" line="201"/>
+        <source>For reviews and bug reports</source>
+        <translation>Для отзывов и сообщений об ошибках</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsAbout.qml" line="204"/>
+        <source>mailto:support@amnezia.org</source>
+        <translation>mailto:support@amnezia.org</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsAbout.qml" line="211"/>
+        <source>GitHub</source>
+        <translation>GitHub</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsAbout.qml" line="212"/>
+        <source>Discover the source code</source>
+        <translation>Посмотреть исходный код</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsAbout.qml" line="215"/>
+        <source>https://github.com/amnezia-vpn/amnezia-client</source>
+        <translation>https://github.com/amnezia-vpn/amnezia-client</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsAbout.qml" line="222"/>
+        <source>Website</source>
+        <translation>Веб-сайт</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsAbout.qml" line="223"/>
+        <source>Visit official website</source>
+        <translation>Посетить официальный сайт</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsAbout.qml" line="119"/>
+        <source>Software version: %1</source>
+        <translation>Версия ПО: %1</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsAbout.qml" line="149"/>
+        <source>Check for updates</source>
+        <translation>Проверить обновления</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsAbout.qml" line="170"/>
+        <source>Privacy Policy</source>
+        <translation>Политика конфиденциальности</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsApiAvailableCountries</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiAvailableCountries.qml" line="147"/>
+        <source>Subscription expired</source>
+        <translation>Подписка закончилась</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiAvailableCountries.qml" line="147"/>
+        <source>Subscription expiring soon</source>
+        <translation>Подписка скоро закончится</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiAvailableCountries.qml" line="166"/>
+        <source>Renew subscription</source>
+        <translation>Продлить подписку</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiAvailableCountries.qml" line="180"/>
+        <source>Location for connection</source>
+        <translation>Страны для подключения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiAvailableCountries.qml" line="209"/>
+        <source>Unable change server location while trying to make an active connection</source>
+        <translation>Невозможно изменить локацию во время попытки соединения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiAvailableCountries.qml" line="213"/>
+        <source>Unable change server location while there is an active connection</source>
+        <translation>Невозможно изменить локацию во время активного соединения</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsApiDevices</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiDevices.qml" line="45"/>
+        <source>Active Devices</source>
+        <translation>Активные устройства</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiDevices.qml" line="46"/>
+        <source>Manage currently connected devices</source>
+        <translation>Управление подключенными устройствами</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiDevices.qml" line="55"/>
+        <source>You can find the identifier on the Support tab or, for older versions of the app, by tapping &apos;+&apos; and then the three dots at the top of the page.</source>
+        <translation>Вы можете найти support tag во вкладке «Поддержка» или, в более ранних версиях приложения, нажав «+» на нижней панели, а затем три точки вверху страницы.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiDevices.qml" line="69"/>
+        <source> (current device)</source>
+        <translation> (текущее устройство)</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiDevices.qml" line="70"/>
+        <source>Support tag: </source>
+        <translation>Support tag: </translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiDevices.qml" line="70"/>
+        <source>Last updated: </source>
+        <translation>Последнее обновление: </translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiDevices.qml" line="75"/>
+        <source>Cannot unlink device during active connection</source>
+        <translation>Невозможно отвязать устройство во время активного соединения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiDevices.qml" line="79"/>
+        <source>Are you sure you want to unlink this device?</source>
+        <translation>Вы уверены, что хотите отвязать это устройство?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiDevices.qml" line="80"/>
+        <source>This will unlink the device from your subscription. You can reconnect it anytime by pressing&#xa0;&quot;Reload API config&quot; in subscription settings on device.</source>
+        <translation>Это отключит устройство от вашей подписки. Вы можете повторно подключить его в любое время, нажав &quot;Перезагрузить конфигурацию API&quot; в настройках подписки на устройстве.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiDevices.qml" line="81"/>
+        <source>Continue</source>
+        <translation>Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiDevices.qml" line="82"/>
+        <source>Cancel</source>
+        <translation>Отменить</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsApiInstructions</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiInstructions.qml" line="22"/>
+        <source>Windows</source>
+        <translation>Windows</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiInstructions.qml" line="29"/>
+        <source>macOS</source>
+        <translation>macOS</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiInstructions.qml" line="36"/>
+        <source>Android</source>
+        <translation>Android</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiInstructions.qml" line="43"/>
+        <source>AndroidTV</source>
+        <translation>Android TV</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiInstructions.qml" line="50"/>
+        <source>iOS</source>
+        <translation>iOS</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiInstructions.qml" line="57"/>
+        <source>Linux</source>
+        <translation>Linux</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiInstructions.qml" line="64"/>
+        <source>Routers</source>
+        <translation>Маршрутизаторы</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiInstructions.qml" line="23"/>
+        <source>documentation/instructions/connect-amnezia-premium#windows</source>
+        <translation>documentation/instructions/connect-amnezia-premium#windows</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiInstructions.qml" line="30"/>
+        <source>documentation/instructions/connect-amnezia-premium#macos</source>
+        <translation>documentation/instructions/connect-amnezia-premium#macos</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiInstructions.qml" line="37"/>
+        <source>documentation/instructions/connect-amnezia-premium#android</source>
+        <translation>documentation/instructions/connect-amnezia-premium#android</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiInstructions.qml" line="44"/>
+        <source>documentation/instructions/android_tv_connect/</source>
+        <translation>documentation/instructions/android_tv_connect/</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiInstructions.qml" line="51"/>
+        <source>documentation/instructions/connect-amnezia-premium#ios</source>
+        <translation>documentation/instructions/connect-amnezia-premium#ios</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiInstructions.qml" line="58"/>
+        <source>documentation/instructions/connect-amnezia-premium#linux</source>
+        <translation>documentation/instructions/connect-amnezia-premium#linux</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiInstructions.qml" line="65"/>
+        <source>documentation/instructions/connect-amnezia-premium#routers</source>
+        <translation>documentation/instructions/connect-amnezia-premium#routers</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiInstructions.qml" line="101"/>
+        <source>How to connect on another device</source>
+        <translation>Как подключить другие устройства</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiInstructions.qml" line="102"/>
+        <source>Setup guides on the Amnezia website</source>
+        <translation>Инструкции по настройке</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsApiNativeConfigs</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiNativeConfigs.qml" line="23"/>
+        <source>Save AmneziaVPN config</source>
+        <translation>Сохранить конфигурацию AmneziaVPN</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiNativeConfigs.qml" line="60"/>
+        <source>Configuration Files</source>
+        <translation>Файлы конфигурации</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiNativeConfigs.qml" line="61"/>
+        <source>For router setup or the AmneziaWG app</source>
+        <translation>Для настройки роутера или приложения AmneziaWG</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiNativeConfigs.qml" line="73"/>
+        <source>The configuration needs to be reissued</source>
+        <translation>Необходимо заново скачать конфигурацию и добавить ее в приложение</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiNativeConfigs.qml" line="135"/>
+        <source> configuration file</source>
+        <translation> файл конфигурации</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiNativeConfigs.qml" line="149"/>
+        <source>Generate a new configuration file</source>
+        <translation>Создать новый файл конфигурации</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiNativeConfigs.qml" line="150"/>
+        <source>The previously created one will stop working</source>
+        <translation>Ранее созданный файл перестанет работать</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiNativeConfigs.qml" line="168"/>
+        <source>Revoke the current configuration file</source>
+        <translation>Отозвать текущий  файл конфигурации</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiNativeConfigs.qml" line="198"/>
+        <source>Config file saved</source>
+        <translation>Файл конфигурации сохранен</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiNativeConfigs.qml" line="212"/>
+        <source>The config has been revoked</source>
+        <translation>Конфигурация была отозвана</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiNativeConfigs.qml" line="219"/>
+        <source>Generate a new %1 configuration file?</source>
+        <translation>Создать новый %1 файл конфигурации?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiNativeConfigs.qml" line="221"/>
+        <source>Revoke the current %1 configuration file?</source>
+        <translation>Отозвать текущий %1 файл конфигурации?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiNativeConfigs.qml" line="224"/>
+        <source>Your previous configuration file will no longer work, and it will not be possible to connect using it</source>
+        <translation>Ваш предыдущий файл конфигурации не будет работать, и вы больше не сможете использовать его для подключения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiNativeConfigs.qml" line="225"/>
+        <source>Download</source>
+        <translation>Скачать</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiNativeConfigs.qml" line="225"/>
+        <source>Continue</source>
+        <translation>Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiNativeConfigs.qml" line="226"/>
+        <source>Cancel</source>
+        <translation>Отменить</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsApiServerInfo</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="277"/>
+        <source>Configurations have been updated for some countries. Download and install the updated configuration files</source>
+        <translation>Сетевые адреса одного или нескольких серверов были обновлены. Пожалуйста, удалите старые конфигурацию и загрузите новые файлы</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="322"/>
+        <source>Manage configuration files</source>
+        <translation>Управление файлами конфигурации</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="29"/>
+        <source>Subscription Status</source>
+        <translation>Статус подписки</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="38"/>
+        <source>Valid Until</source>
+        <translation>Действительна до</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="47"/>
+        <source>Active Connections</source>
+        <translation>Активные соединения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="158"/>
+        <source>Subscription expired</source>
+        <translation>Подписка закончилась</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="159"/>
+        <source>Subscription expiring soon</source>
+        <translation>Подписка скоро закончится</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="189"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="254"/>
+        <source>Renew subscription</source>
+        <translation>Продлить подписку</translation>
+    </message>
+    <message>
+        <source>Use VLESS protocol</source>
+        <translation type="vanished">Использовать протокол VLESS</translation>
+    </message>
+    <message>
+        <source>Cannot change protocol during active connection</source>
+        <translation type="vanished">Невозможно изменить протокол во время активного соединения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="298"/>
+        <source>Subscription Key</source>
+        <translation>Ключ для подключения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="320"/>
+        <source>Configuration Files</source>
+        <translation>Файлы конфигурации</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="340"/>
+        <source>Active Devices</source>
+        <translation>Активные устройства</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="342"/>
+        <source>Manage currently connected devices</source>
+        <translation>Управление подключенными устройствами</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="359"/>
+        <source>Support</source>
+        <translation>Поддержка</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="374"/>
+        <source>How to connect on another device</source>
+        <translation>Как подключить другие устройства</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="399"/>
+        <source>Reload API config</source>
+        <translation>Перезагрузить конфигурацию API</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="402"/>
+        <source>Reload API config?</source>
+        <translation>Перезагрузить конфигурацию API?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="403"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="441"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="478"/>
+        <source>Continue</source>
+        <translation>Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="404"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="442"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="479"/>
+        <source>Cancel</source>
+        <translation>Отменить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="408"/>
+        <source>Cannot reload API config during active connection</source>
+        <translation>Невозможно перзагрузить API конфигурацию при активном соединении</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="436"/>
+        <source>Unlink this device</source>
+        <translation>Отвязать это устройство</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="439"/>
+        <source>Are you sure you want to unlink this device?</source>
+        <translation>Вы уверены, что хотите отвязать это устройство?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="440"/>
+        <source>This will unlink the device from your subscription. You can reconnect it anytime by pressing&#xa0;&quot;Reload API config&quot; in subscription settings on device.</source>
+        <translation>Это отключит устройство от вашей подписки. Вы можете повторно подключить его в любое время, нажав &quot;Перезагрузить конфигурацию API&quot; в настройках подписки на устройстве.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="446"/>
+        <source>Cannot unlink device during active connection</source>
+        <translation>Невозможно отвязать устройство во время активного соединения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="474"/>
+        <source>Remove from application</source>
+        <translation>Удалить из приложения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="477"/>
+        <source>Remove from application?</source>
+        <translation>Удалить из приложения?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="483"/>
+        <source>Cannot remove server during active connection</source>
+        <translation>Невозможно удалить сервер во время активного соединения</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsApiSubscriptionKey</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiSubscriptionKey.qml" line="93"/>
+        <source>Copy key</source>
+        <translation>Скопировать ключ</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiSubscriptionKey.qml" line="98"/>
+        <source>Copied</source>
+        <translation>Скопировано</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiSubscriptionKey.qml" line="114"/>
+        <source>Save key as a file</source>
+        <translation>Сохранить ключ как файл</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiSubscriptionKey.qml" line="121"/>
+        <source>Save AmneziaVPN config</source>
+        <translation>Сохранить конфигурацию AmneziaVPN</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiSubscriptionKey.qml" line="122"/>
+        <source>Config files (*.vpn)</source>
+        <translation>Файлы конфигов (*.vpn)</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiSubscriptionKey.qml" line="133"/>
+        <source>Config file saved</source>
+        <translation type="unfinished">Файл конфигурации сохранен</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiSubscriptionKey.qml" line="150"/>
+        <source>Show key text</source>
+        <translation>Показать ключ</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiSubscriptionKey.qml" line="191"/>
+        <source>To read the QR code in the Amnezia app, tap + in the main menu → &apos;QR code&apos;</source>
+        <translation>Для считывания QR-кода в приложении Amnezia выберите + в главном меню → &apos;QR-код&apos;</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsApiSupport</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiSupport.qml" line="22"/>
+        <source>Telegram</source>
+        <translation>Telegram</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiSupport.qml" line="30"/>
+        <source>Email</source>
+        <translation>Email</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiSupport.qml" line="38"/>
+        <source>Email Billing &amp; Orders</source>
+        <translation>По вопросам оплаты</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiSupport.qml" line="46"/>
+        <source>Website</source>
+        <translation>Сайт</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiSupport.qml" line="81"/>
+        <source>Support</source>
+        <translation>Поддержка</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiSupport.qml" line="82"/>
+        <source>Our technical support specialists are available to assist you at any time</source>
+        <translation>Наши специалисты технической поддержки всегда готовы помочь вам.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiSupport.qml" line="110"/>
+        <source>Support tag</source>
+        <translation>Идентификатор поддержки</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApiSupport.qml" line="120"/>
+        <source>Copied</source>
+        <translation>Скопировано</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsAppSplitTunneling</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsAppSplitTunneling.qml" line="27"/>
+        <source>Cannot change split tunneling settings during active connection</source>
+        <translation>Невозможно изменить настройки раздельного туннелирования во время активного соединения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsAppSplitTunneling.qml" line="49"/>
+        <source>Only the apps from the list should have access via VPN</source>
+        <translation>Только приложения из списка должны работать через VPN</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsAppSplitTunneling.qml" line="56"/>
+        <source>Apps from the list should not have access via VPN</source>
+        <translation>Приложения из списка не должны работать через VPN</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsAppSplitTunneling.qml" line="87"/>
+        <source>App split tunneling</source>
+        <translation>Раздельное туннелирование приложений</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsAppSplitTunneling.qml" line="112"/>
+        <source>Mode</source>
+        <translation>Режим</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsAppSplitTunneling.qml" line="154"/>
+        <source>Only &quot;Apps from the list should not have access via VPN&quot; mode is available on Windows</source>
+        <translation>На Windows доступен только режим &quot;Приложения из списка не должны работать через VPN&quot;</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsAppSplitTunneling.qml" line="200"/>
+        <source>Remove </source>
+        <translation>Удалить </translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsAppSplitTunneling.qml" line="201"/>
+        <source>Continue</source>
+        <translation>Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsAppSplitTunneling.qml" line="202"/>
+        <source>Cancel</source>
+        <translation>Отменить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsAppSplitTunneling.qml" line="245"/>
+        <source>application name</source>
+        <translation>название приложения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsAppSplitTunneling.qml" line="255"/>
+        <source>Open executable file</source>
+        <translation>Открыть исполняемый файл</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsAppSplitTunneling.qml" line="256"/>
+        <source>Executable files (*.*)</source>
+        <translation>Исполняемые файлы (*.*)</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsApplication</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApplication.qml" line="48"/>
+        <source>Application</source>
+        <translation>Приложение</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApplication.qml" line="66"/>
+        <source>Allow application screenshots</source>
+        <translation>Разрешить скриншоты приложения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApplication.qml" line="108"/>
+        <source>Auto start</source>
+        <translation>Автозапуск</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApplication.qml" line="109"/>
+        <source>Launch the application every time the device is starts</source>
+        <translation>Запускать приложение при загрузке устройства</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApplication.qml" line="131"/>
+        <source>Auto connect</source>
+        <translation>Автоподключение</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApplication.qml" line="132"/>
+        <source>Connect to VPN on app start</source>
+        <translation>Подключаться к VPN при запуске приложения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApplication.qml" line="154"/>
+        <source>Start minimized</source>
+        <translation>Запускать в свернутом виде</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApplication.qml" line="205"/>
+        <source>Language</source>
+        <translation>Язык</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApplication.qml" line="87"/>
+        <source>Enable notifications</source>
+        <translation>Включить уведомления</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApplication.qml" line="88"/>
+        <source>Enable notifications to show the VPN state in the status bar</source>
+        <translation>Включить уведомления для отображения статуса VPN в строке состояния</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApplication.qml" line="155"/>
+        <source>Launch application minimized (works with autostart option turned on)</source>
+        <translation>Запускает приложение свёрнутым (работает с включенной функцией автозапуска)</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApplication.qml" line="180"/>
+        <source>News Notification</source>
+        <translation>Уведомления о новостях</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApplication.qml" line="181"/>
+        <source>Show a notification icon for unread news</source>
+        <translation>Показывать значок уведомления, если есть непрочитанные новости</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApplication.qml" line="221"/>
+        <source>Logging</source>
+        <translation>Логирование</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApplication.qml" line="222"/>
+        <source>Enabled</source>
+        <translation>Включено</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApplication.qml" line="222"/>
+        <source>Disabled</source>
+        <translation>Отключено</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApplication.qml" line="237"/>
+        <source>Reset settings and remove all data from the application</source>
+        <translation>Сбросить настройки и удалить все данные из приложения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApplication.qml" line="242"/>
+        <source>Reset settings and remove all data from the application?</source>
+        <translation>Сбросить настройки и удалить все данные из приложения?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApplication.qml" line="243"/>
+        <source>All settings will be reset to default. All installed AmneziaVPN services will still remain on the server.</source>
+        <translation>Все настройки будут сброшены до значений по умолчанию. Все установленные сервисы AmneziaVPN останутся на сервере.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApplication.qml" line="244"/>
+        <source>Continue</source>
+        <translation>Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApplication.qml" line="245"/>
+        <source>Cancel</source>
+        <translation>Отменить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsApplication.qml" line="249"/>
+        <source>Cannot reset settings during active connection</source>
+        <translation>Невозможно сбросить настройки во время активного соединения</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsBackup</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsBackup.qml" line="26"/>
+        <source>Settings restored from backup file</source>
+        <translation>Настройки восстановлены из файла резервной копии</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsBackup.qml" line="69"/>
+        <source>Back up your configuration</source>
+        <translation>Создать резервную копию конфигурации</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsBackup.qml" line="70"/>
+        <source>You can save your settings to a backup file to restore them the next time you install the application.</source>
+        <translation>Вы можете сохранить настройки в файл резервной копии, чтобы восстановить их при следующей установке приложения.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsBackup.qml" line="88"/>
+        <source>The backup will contain your passwords and private keys for all servers added to AmneziaVPN. Keep this information in a secure place.</source>
+        <translation>Резервная копия будет содержать ваши пароли и закрытые ключи для всех серверов, добавленных в AmneziaVPN. Храните эту информацию в надежном месте.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsBackup.qml" line="102"/>
+        <source>Make a backup</source>
+        <translation>Создать резервную копию</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsBackup.qml" line="109"/>
+        <source>Save backup file</source>
+        <translation>Сохранить резервную копию</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsBackup.qml" line="110"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsBackup.qml" line="148"/>
+        <source>Backup files (*.backup)</source>
+        <translation>Файлы резервных копий (*.backup)</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsBackup.qml" line="119"/>
+        <source>Backup file saved</source>
+        <translation>Резервная копия сохранена</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsBackup.qml" line="141"/>
+        <source>Restore from backup</source>
+        <translation>Восстановить из резервной копии</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsBackup.qml" line="147"/>
+        <source>Open backup file</source>
+        <translation>Открыть резервную копию</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsBackup.qml" line="162"/>
+        <source>Import settings from a backup file?</source>
+        <translation>Импортировать настройки из резервной копии?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsBackup.qml" line="163"/>
+        <source>All current settings will be reset</source>
+        <translation>Все текущие настройки будут сброшены</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsBackup.qml" line="164"/>
+        <source>Continue</source>
+        <translation>Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsBackup.qml" line="165"/>
+        <source>Cancel</source>
+        <translation>Отменить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsBackup.qml" line="169"/>
+        <source>Cannot restore backup settings during active connection</source>
+        <translation>Невозможно восстановить настройки из резервной копии во время активного соединения</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsConnection</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsConnection.qml" line="49"/>
+        <source>Connection</source>
+        <translation>Соединение</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsConnection.qml" line="65"/>
+        <source>Use AmneziaDNS</source>
+        <translation>Использовать AmneziaDNS</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsConnection.qml" line="66"/>
+        <source>If AmneziaDNS is installed on the server</source>
+        <translation>Если AmneziaDNS установлен на сервере</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsConnection.qml" line="83"/>
+        <source>DNS servers</source>
+        <translation>DNS-серверы</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsConnection.qml" line="84"/>
+        <source>When AmneziaDNS is not used or installed</source>
+        <translation>Когда AmneziaDNS не используется или не установлен</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsConnection.qml" line="124"/>
+        <source>Allows you to use the VPN only for certain Apps</source>
+        <translation>Позволяет использовать VPN только для определенных приложений</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsConnection.qml" line="142"/>
+        <source>KillSwitch</source>
+        <translation>KillSwitch</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsConnection.qml" line="143"/>
+        <source>Blocks network connections without VPN</source>
+        <translation>Блокирует интернет-соединение без VPN</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsConnection.qml" line="99"/>
+        <source>Site-based split tunneling</source>
+        <translation>Раздельное туннелирование сайтов</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsConnection.qml" line="100"/>
+        <source>Allows you to select which sites you want to access through the VPN</source>
+        <translation>Позволяет выбирать, к каким сайтам подключаться через VPN</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsConnection.qml" line="123"/>
+        <source>App-based split tunneling</source>
+        <translation>Раздельное туннелирование приложений</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsDns</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsDns.qml" line="46"/>
+        <source>Default server does not support custom DNS</source>
+        <translation>Сервер по умолчанию не поддерживает пользовательские DNS</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsDns.qml" line="59"/>
+        <source>DNS servers</source>
+        <translation>DNS-серверы</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsDns.qml" line="67"/>
+        <source>If AmneziaDNS is not used or installed</source>
+        <translation>Если AmneziaDNS не используется или не установлен</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsDns.qml" line="84"/>
+        <source>Primary DNS</source>
+        <translation>Первичный DNS</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsDns.qml" line="99"/>
+        <source>Secondary DNS</source>
+        <translation>Вторичный DNS</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsDns.qml" line="122"/>
+        <source>Restore default</source>
+        <translation>Восстановить по умолчанию</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsDns.qml" line="125"/>
+        <source>Restore default DNS settings?</source>
+        <translation>Восстановить настройки DNS по умолчанию?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsDns.qml" line="126"/>
+        <source>Continue</source>
+        <translation>Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsDns.qml" line="127"/>
+        <source>Cancel</source>
+        <translation>Отменить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsDns.qml" line="134"/>
+        <source>Settings have been reset</source>
+        <translation>Настройки были сброшены</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsDns.qml" line="149"/>
+        <source>Save</source>
+        <translation>Сохранить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsDns.qml" line="153"/>
+        <source>Primary DNS cannot be empty</source>
+        <translation>Основной DNS не может быть пустым</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsDns.qml" line="165"/>
+        <source>Settings saved</source>
+        <translation>Настройки сохранены</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsKillSwitch</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsKillSwitch.qml" line="40"/>
+        <source>KillSwitch</source>
+        <translation>KillSwitch</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsKillSwitch.qml" line="41"/>
+        <source>Enable to ensure network traffic goes through a secure VPN tunnel, preventing accidental exposure of your IP and DNS queries if the connection drops</source>
+        <translation>Включите, чтобы весь сетевой трафик проходил только через безопасный VPN-туннель. Это предотвратит случайное раскрытие вашего IP-адреса и DNS-запросов при разрыве соединения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsKillSwitch.qml" line="52"/>
+        <source>KillSwitch settings cannot be changed during an active connection</source>
+        <translation>Настройки KillSwitch нельзя изменить во время активного подключения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsKillSwitch.qml" line="68"/>
+        <source>Soft KillSwitch</source>
+        <translation>Soft KillSwitch</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsKillSwitch.qml" line="69"/>
+        <source>Internet access is blocked if the VPN disconnects unexpectedly</source>
+        <translation>Доступ в интернет блокируется при разрыве VPN-соединения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsKillSwitch.qml" line="92"/>
+        <source>Strict KillSwitch</source>
+        <translation>Strict KillSwitch</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsKillSwitch.qml" line="93"/>
+        <source>Internet connection is blocked even when VPN is turned off manually or hasn&apos;t started</source>
+        <translation>Доступ в интернет блокируется, даже если VPN отключен вручную или не был запущен</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsKillSwitch.qml" line="96"/>
+        <source>Just a little heads-up</source>
+        <translation>Небольшое предупреждение</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsKillSwitch.qml" line="97"/>
+        <source>If the VPN disconnects or drops while Strict KillSwitch is enabled, internet access will be blocked. To restore access, reconnect VPN or disable/change the KillSwitch.</source>
+        <translation>Если VPN отключится или соединение прервётся при включённом Strict KillSwitch, доступ в интернет будет заблокирован. Чтобы восстановить доступ, снова подключитесь к VPN или отключите (измените) режим KillSwitch.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsKillSwitch.qml" line="98"/>
+        <source>Continue</source>
+        <translation>Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsKillSwitch.qml" line="99"/>
+        <source>Cancel</source>
+        <translation>Отменить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsKillSwitch.qml" line="123"/>
+        <source>DNS Exceptions</source>
+        <translation>Исключения для DNS</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsKillSwitch.qml" line="124"/>
+        <source>DNS servers listed here will remain accessible when KillSwitch is active.</source>
+        <translation>DNS-серверы из этого списка останутся доступными при активном KillSwitch.</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsKillSwitchExceptions</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="44"/>
+        <source>DNS Exceptions</source>
+        <translation>Исключения для DNS</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="45"/>
+        <source>DNS servers listed here will remain accessible when KillSwitch is active</source>
+        <translation>DNS-серверы из этого списка останутся доступными при активном KillSwitch</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="105"/>
+        <source>Delete </source>
+        <translation>Удалить </translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="106"/>
+        <source>Continue</source>
+        <translation>Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="107"/>
+        <source>Cancel</source>
+        <translation>Отменить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="137"/>
+        <source>IPv4 address</source>
+        <translation>IPv4 адрес</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="167"/>
+        <source>Import / Export addresses</source>
+        <translation>Импорт / Экспорт адресов</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="174"/>
+        <source>Import</source>
+        <translation>Импорт</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="187"/>
+        <source>Save address list</source>
+        <translation>Сохранить список адресов</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="194"/>
+        <source>Save addresses</source>
+        <translation>Сохранить адреса</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="195"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="265"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="281"/>
+        <source>Address files (*.json)</source>
+        <translation>Файлы адресов (*.json)</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="254"/>
+        <source>Import address list</source>
+        <translation>Импорт списка адресов</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="261"/>
+        <source>Replace address list</source>
+        <translation>Заменить список адресов</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="264"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="280"/>
+        <source>Open address file</source>
+        <translation>Открыть файл адресов</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="277"/>
+        <source>Add imported addresses to existing ones</source>
+        <translation>Добавить импортированные адреса к существующим</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsLogging</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsLogging.qml" line="50"/>
+        <source>Logging</source>
+        <translation>Логирование</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsLogging.qml" line="51"/>
+        <source>Enabling this function will save application&apos;s logs automatically. By default, logging functionality is disabled. Enable log saving in case of application malfunction.</source>
+        <translation>Включение этой функции позволяет сохранять логи на вашем устройстве. По умолчанию она отключена. Включите сохранение логов в случае сбоев в работе приложения.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsLogging.qml" line="192"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsLogging.qml" line="218"/>
+        <source>Save</source>
+        <translation>Сохранить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsLogging.qml" line="193"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsLogging.qml" line="219"/>
+        <source>Logs files (*.log)</source>
+        <translation>Файлы логов (*.log)</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsLogging.qml" line="202"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsLogging.qml" line="227"/>
+        <source>Logs file saved</source>
+        <translation>Файл с логами сохранен</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsLogging.qml" line="63"/>
+        <source>Enable logs</source>
+        <translation>Включить запись логов</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsLogging.qml" line="85"/>
+        <source>Clear logs?</source>
+        <translation>Очистить логи?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsLogging.qml" line="86"/>
+        <source>Continue</source>
+        <translation>Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsLogging.qml" line="87"/>
+        <source>Cancel</source>
+        <translation>Отменить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsLogging.qml" line="93"/>
+        <source>Logs have been cleaned up</source>
+        <translation>Логи очищены</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsLogging.qml" line="181"/>
+        <source>Client logs</source>
+        <translation>Логи приложения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsLogging.qml" line="182"/>
+        <source>AmneziaVPN logs</source>
+        <translation>AmneziaVPN logs</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsLogging.qml" line="143"/>
+        <source>Open logs folder</source>
+        <translation>Открыть папку с логами</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsLogging.qml" line="157"/>
+        <source>Export logs</source>
+        <translation>Сохранить логи</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsLogging.qml" line="210"/>
+        <source>Service logs</source>
+        <translation>Логи службы</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsLogging.qml" line="211"/>
+        <source>AmneziaVPN-service logs</source>
+        <translation>AmneziaVPN-service logs</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsLogging.qml" line="80"/>
+        <source>Clear logs</source>
+        <translation>Очистить логи</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsNewsDetail</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsNewsDetail.qml" line="87"/>
+        <source>Update</source>
+        <translation>Обновить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsNewsDetail.qml" line="112"/>
+        <source>Skip</source>
+        <translation>Пропустить</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsNewsNotifications</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsNewsNotifications.qml" line="33"/>
+        <source>News &amp; Notifications</source>
+        <translation>Новости и Уведомления</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsServerData</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerData.qml" line="28"/>
+        <source>All installed containers have been added to the application</source>
+        <translation>Все установленные протоколы и сервисы были добавлены в приложение</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerData.qml" line="30"/>
+        <source>No new installed containers found</source>
+        <translation>Новые установленные протоколы и сервисы не обнаружены</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerData.qml" line="118"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerData.qml" line="148"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerData.qml" line="178"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerData.qml" line="207"/>
+        <source>Continue</source>
+        <translation>Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerData.qml" line="119"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerData.qml" line="149"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerData.qml" line="179"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerData.qml" line="208"/>
+        <source>Cancel</source>
+        <translation>Отменить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerData.qml" line="98"/>
+        <source>Check the server for previously installed Amnezia services</source>
+        <translation>Проверить сервер на наличие ранее установленных сервисов Amnezia</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerData.qml" line="99"/>
+        <source>Add them to the application if they were not displayed</source>
+        <translation>Добавить их в приложение, если они не отображаются</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerData.qml" line="112"/>
+        <source>Reboot server</source>
+        <translation>Перезагрузить сервер</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerData.qml" line="116"/>
+        <source>Do you want to reboot the server?</source>
+        <translation>Вы уверены, что хотите перезагрузить сервер?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerData.qml" line="117"/>
+        <source>The reboot process may take approximately 30 seconds. Are you sure you wish to proceed?</source>
+        <translation>Процесс перезагрузки может занять около 30 секунд. Вы уверены, что хотите продолжить?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerData.qml" line="123"/>
+        <source>Cannot reboot server during active connection</source>
+        <translation>Невозможно перезагрузить сервер во время активного соединения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerData.qml" line="146"/>
+        <source>Do you want to remove the server from application?</source>
+        <translation>Вы уверены, что хотите удалить сервер из приложения?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerData.qml" line="153"/>
+        <source>Cannot remove server during active connection</source>
+        <translation>Невозможно удалить сервер во время активного соединения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerData.qml" line="176"/>
+        <source>Do you want to clear server from Amnezia software?</source>
+        <translation>Вы хотите очистить сервер от всех сервисов Amnezia?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerData.qml" line="177"/>
+        <source>All users whom you shared a connection with will no longer be able to connect to it.</source>
+        <translation>Все пользователи, с которыми вы поделились конфигурацией вашего VPN, больше не смогут к нему подключаться.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerData.qml" line="183"/>
+        <source>Cannot clear server from Amnezia software during active connection</source>
+        <translation>Невозможно очистить сервер от сервисов Amnezia во время активного соединения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerData.qml" line="201"/>
+        <source>Reset API config</source>
+        <translation>Сбросить конфигурацию API</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerData.qml" line="205"/>
+        <source>Do you want to reset API config?</source>
+        <translation>Вы хотите сбросить конфигурацию API?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerData.qml" line="212"/>
+        <source>Cannot reset API config during active connection</source>
+        <translation>Невозможно сбросить конфигурацию API во время активного соединения</translation>
+    </message>
+    <message>
+        <source>Switch to the new Amnezia Premium subscription</source>
+        <translation type="vanished">Перейти на новый тип подписки Amnezia Premium</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerData.qml" line="142"/>
+        <source>Remove server from application</source>
+        <translation>Удалить сервер из приложения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerData.qml" line="147"/>
+        <source>All installed AmneziaVPN services will still remain on the server.</source>
+        <translation>Все установленные сервисы и протоколы Amnezia останутся на сервере.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerData.qml" line="172"/>
+        <source>Clear server from Amnezia software</source>
+        <translation>Очистить сервер от протоколов и сервисов Amnezia</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsServerInfo</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerInfo.qml" line="140"/>
+        <source>Protocols</source>
+        <translation>Протоколы</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerInfo.qml" line="151"/>
+        <source>Services</source>
+        <translation>Сервисы</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerInfo.qml" line="160"/>
+        <source>Management</source>
+        <translation>Управление</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsServerProtocol</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerProtocol.qml" line="56"/>
+        <source> settings</source>
+        <translation> настройки</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerProtocol.qml" line="154"/>
+        <source>Clear %1 profile?</source>
+        <translation>Очистить профиль %1?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerProtocol.qml" line="90"/>
+        <source> connection settings</source>
+        <translation> настройки подключения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerProtocol.qml" line="57"/>
+        <source>This protocol is no longer supported.</source>
+        <translation>Этот протокол больше не поддерживается.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerProtocol.qml" line="71"/>
+        <source>AmneziaWG 2.0 is outdated and does not include the latest security improvements, but it will continue to work. Moving to AmneziaWG 3.0 by deploying a new container on the server is recommended for stronger protocol security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerProtocol.qml" line="99"/>
+        <source>Click the &quot;connect&quot; button to create a connection configuration</source>
+        <translation>Нажмите кнопку «Подключиться», чтобы создать конфигурацию</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerProtocol.qml" line="119"/>
+        <source> server settings</source>
+        <translation> настройки сервера</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerProtocol.qml" line="151"/>
+        <source>Clear profile</source>
+        <translation>Очистить профиль</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerProtocol.qml" line="155"/>
+        <source>The connection configuration will be deleted for this device only</source>
+        <translation>Конфигурация подключения будет удалена только на этом устройстве</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerProtocol.qml" line="161"/>
+        <source>Unable to clear %1 profile while there is an active connection</source>
+        <translation>Невозможно очистить профиль %1 во время активного соединения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerProtocol.qml" line="195"/>
+        <source>Remove </source>
+        <translation>Удалить </translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerProtocol.qml" line="199"/>
+        <source>Remove %1 from server?</source>
+        <translation>Удалить %1 с сервера?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerProtocol.qml" line="200"/>
+        <source>All users with whom you shared a connection will no longer be able to connect to it.</source>
+        <translation>Все пользователи, с которыми вы поделились конфигурацией вашего VPN, больше не смогут к нему подключаться.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerProtocol.qml" line="207"/>
+        <source>Cannot remove active container</source>
+        <translation>Невозможно удалить активный контейнер</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerProtocol.qml" line="156"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerProtocol.qml" line="201"/>
+        <source>Continue</source>
+        <translation>Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerProtocol.qml" line="157"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServerProtocol.qml" line="202"/>
+        <source>Cancel</source>
+        <translation>Отменить</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsServersList</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsServersList.qml" line="38"/>
+        <source>Servers</source>
+        <translation>Серверы</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsSplitTunneling</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="32"/>
+        <source>Default server does not support split tunneling function</source>
+        <translation>Сервер по умолчанию не поддерживает раздельное туннелирование</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="70"/>
+        <source>Addresses from the list should not be accessed via VPN</source>
+        <translation>Адреса из списка не должны открываться через VPN</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="101"/>
+        <source>Split tunneling</source>
+        <translation>Раздельное туннелирование сайтов</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="128"/>
+        <source>Mode</source>
+        <translation>Режим</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="210"/>
+        <source>Remove </source>
+        <translation>Удалить </translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="211"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="361"/>
+        <source>Continue</source>
+        <translation>Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="212"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="362"/>
+        <source>Cancel</source>
+        <translation>Отменить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="65"/>
+        <source>Only the sites listed here will be accessed through the VPN</source>
+        <translation>Только адреса из списка должны открываться через VPN</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="29"/>
+        <source>Cannot change split tunneling settings during active connection</source>
+        <translation>Невозможно изменить настройки раздельного туннелирования во время активного соединения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="262"/>
+        <source>website or IP</source>
+        <translation>веб-сайт или IP</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="308"/>
+        <source>Additional options</source>
+        <translation>Дополнительные настройки</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="315"/>
+        <source>Import</source>
+        <translation>Импорт</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="328"/>
+        <source>Save site list</source>
+        <translation>Сохранить список сайтов</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="335"/>
+        <source>Save sites</source>
+        <translation>Сохранить сайты</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="336"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="462"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="475"/>
+        <source>Sites files (*.json)</source>
+        <translation>Файлы сайтов (*.json)</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="356"/>
+        <source>Clear site list</source>
+        <translation>Очистить список сайтов</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="359"/>
+        <source>Clear site list?</source>
+        <translation>Очистить список сайтов?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="360"/>
+        <source>All sites will be removed from list.</source>
+        <translation>Все сайты будут удалены из списка.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="424"/>
+        <source>Import a list of sites</source>
+        <translation>Импортировать список с сайтами</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="459"/>
+        <source>Replace site list</source>
+        <translation>Заменить список с сайтами</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="461"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="474"/>
+        <source>Open sites file</source>
+        <translation>Открыть список с сайтами</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="472"/>
+        <source>Add imported sites to existing ones</source>
+        <translation>Добавить импортированные сайты к существующим</translation>
+    </message>
+</context>
+<context>
+    <name>PageSetupWizardApiFreeInfo</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardApiFreeInfo.qml" line="74"/>
+        <source>Free features</source>
+        <translation>Возможности Free</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardApiFreeInfo.qml" line="125"/>
+        <source>Continue</source>
+        <translation>Продолжить</translation>
+    </message>
+</context>
+<context>
+    <name>PageSetupWizardApiPremiumInfo</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardApiPremiumInfo.qml" line="91"/>
+        <source>Recommended</source>
+        <translation>Рекомендуется</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardApiPremiumInfo.qml" line="103"/>
+        <source>Premium features</source>
+        <translation>Возможности Premium</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardApiPremiumInfo.qml" line="132"/>
+        <source>Charged to your Apple ID at confirmation. Renews automatically unless auto-renew is turned off at least 24 hours before period end. Manage in Apple ID settings.</source>
+        <translation>Списание с Apple ID при подтверждении. Продление автоматическое, если автопродление не отключено минимум за 24 часа до окончания периода. Управление в настройках Apple ID.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardApiPremiumInfo.qml" line="169"/>
+        <source>Continue</source>
+        <translation>Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardApiPremiumInfo.qml" line="171"/>
+        <source>Subscribe — %1 for %2</source>
+        <translation>Подписаться — %1 за %2</translation>
+    </message>
+</context>
+<context>
+    <name>PageSetupWizardApiServiceInfo</name>
+    <message>
+        <source>Charged to your Apple ID at confirmation. Renews automatically unless auto-renew is turned off at least 24 hours before period end. Manage in Apple ID settings.</source>
+        <translation type="vanished">Списание с Apple ID при подтверждении. Продление автоматическое, если автопродление не отключено минимум за 24 часа до окончания периода. Управление в настройках Apple ID.</translation>
+    </message>
+    <message>
+        <source>Subscribe Now</source>
+        <translation type="vanished">Подписаться сейчас</translation>
+    </message>
+    <message>
+        <source>By continuing, you agree to the &lt;a href=&quot;%1&quot; style=&quot;color: #FBB26A;&quot;&gt;Terms of Use&lt;/a&gt; and &lt;a href=&quot;%2&quot; style=&quot;color: #FBB26A;&quot;&gt;Privacy Policy&lt;/a&gt;</source>
+        <translation type="vanished">Продолжая, вы соглашаетесь с &lt;a href=&quot;%1&quot; style=&quot;color: #FBB26A;&quot;&gt;Условиями использования&lt;/a&gt; и &lt;a href=&quot;%2&quot; style=&quot;color: #FBB26A;&quot;&gt;Политикой конфиденциальности&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <source>For the region</source>
+        <translation type="vanished">Для региона</translation>
+    </message>
+    <message>
+        <source>Price</source>
+        <translation type="vanished">Цена</translation>
+    </message>
+    <message>
+        <source>Work period</source>
+        <translation type="vanished">Период работы</translation>
+    </message>
+    <message>
+        <source>Speed</source>
+        <translation type="vanished">Скорость</translation>
+    </message>
+    <message>
+        <source>Features</source>
+        <translation type="vanished">Особенности</translation>
+    </message>
+    <message>
+        <source>Connect</source>
+        <translation type="vanished">Подключиться</translation>
+    </message>
+</context>
+<context>
+    <name>PageSetupWizardApiServicesList</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardApiServicesList.qml" line="52"/>
+        <source>VPN by Amnezia</source>
+        <translation>VPN от Amnezia</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardApiServicesList.qml" line="53"/>
+        <source>Choose a VPN service that suits your needs.</source>
+        <translation>Выберите VPN-сервис, который подходит именно вам.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardApiServicesList.qml" line="91"/>
+        <source>Recommended</source>
+        <translation>Рекомендуется</translation>
+    </message>
+</context>
+<context>
+    <name>PageSetupWizardApiTrialEmail</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardApiTrialEmail.qml" line="65"/>
+        <source>Create an account</source>
+        <translation>Создайте учётную запись</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardApiTrialEmail.qml" line="66"/>
+        <source>To manage your subscription</source>
+        <translation>Для управления подпиской</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardApiTrialEmail.qml" line="77"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardApiTrialEmail.qml" line="78"/>
+        <source>Email</source>
+        <translation>Электронная почта</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardApiTrialEmail.qml" line="102"/>
+        <source>We will create an account for your trial subscription and send important subscription updates to this email address</source>
+        <translation>Мы создадим учётную запись для вашей пробной подписки и будем отправлять на этот адрес электронной почты важные уведомления о подписке</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardApiTrialEmail.qml" line="118"/>
+        <source>Continue</source>
+        <translation>Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardApiTrialEmail.qml" line="126"/>
+        <source>Enter a valid email address</source>
+        <translation>Введите корректный адрес электронной почты</translation>
+    </message>
+</context>
+<context>
+    <name>PageSetupWizardConfigSource</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="342"/>
+        <source>File with connection settings</source>
+        <translation>Файл с настройками подключения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="50"/>
+        <source>Connection</source>
+        <translation>Соединение</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="77"/>
+        <source>Settings</source>
+        <translation>Настройки</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="87"/>
+        <source>Enable logs</source>
+        <translation>Включить запись логов</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="101"/>
+        <source>Export client logs</source>
+        <translation>Экспорт логов клиента</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="111"/>
+        <source>Save</source>
+        <translation>Сохранить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="112"/>
+        <source>Logs files (*.log)</source>
+        <translation>Файлы логов (*.log)</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="121"/>
+        <source>Logs file saved</source>
+        <translation>Файл с логами сохранен</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="131"/>
+        <source>Support tag</source>
+        <translation>Support tag</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="142"/>
+        <source>Copied</source>
+        <translation>Скопировано</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="161"/>
+        <source>Insert the key, add a configuration file or scan the QR-code</source>
+        <translation>Вставьте ключ, добавьте файл конфигурации или отсканируйте QR-код</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="171"/>
+        <source>Insert key</source>
+        <translation>Вставьте ключ</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="172"/>
+        <source>Insert</source>
+        <translation>Вставить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="190"/>
+        <source>Continue</source>
+        <translation>Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="207"/>
+        <source>Other connection options</source>
+        <translation>Другие варианты подключения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="228"/>
+        <source>Recommended</source>
+        <translation>Рекомендуется</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="260"/>
+        <source>Site Amnezia</source>
+        <translation>Сайт Amnezia</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="285"/>
+        <source>The easiest way to connect to the VPN</source>
+        <translation>Самый простой способ подключиться к VPN</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="377"/>
+        <source>Restore purchases</source>
+        <translation>Восстановить покупки</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="284"/>
+        <source>VPN by Amnezia</source>
+        <translation>VPN от Amnezia</translation>
+    </message>
+    <message>
+        <source>Connect to classic paid and free VPN services from Amnezia</source>
+        <translation type="vanished">Подключайтесь к классическим платным и бесплатным VPN-сервисам от Amnezia</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="303"/>
+        <source>Self-hosted VPN</source>
+        <translation>Self-hosted VPN</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="304"/>
+        <source>Configure Amnezia VPN on your own server</source>
+        <translation>Настроить VPN на собственном сервере</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="316"/>
+        <source>Restore from backup</source>
+        <translation>Восстановить из резервной копии</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="317"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="343"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="362"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="378"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="393"/>
+        <source></source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="324"/>
+        <source>Open backup file</source>
+        <translation>Открыть резервную копию</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="325"/>
+        <source>Backup files (*.backup)</source>
+        <translation>Файлы резервных копий (*.backup)</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="348"/>
+        <source>Open config file</source>
+        <translation>Открыть файл с конфигурацией</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="361"/>
+        <source>QR code</source>
+        <translation>QR-код</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="392"/>
+        <source>I have nothing</source>
+        <translation>У меня ничего нет</translation>
+    </message>
+</context>
+<context>
+    <name>PageSetupWizardCredentials</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardCredentials.qml" line="206"/>
+        <source>Server IP address [:port]</source>
+        <translation>IP-адрес[:порт] сервера</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardCredentials.qml" line="112"/>
+        <source>Continue</source>
+        <translation>Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardCredentials.qml" line="179"/>
+        <source>Enter the address in the format 255.255.255.255:88</source>
+        <translation>Введите адрес в формате 255.255.255.255:88</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardCredentials.qml" line="48"/>
+        <source>Configure your server</source>
+        <translation>Настроить ваш сервер</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardCredentials.qml" line="207"/>
+        <source>255.255.255.255:22</source>
+        <translation>255.255.255.255:22</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardCredentials.qml" line="215"/>
+        <source>SSH Username</source>
+        <translation>Имя пользователя SSH</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardCredentials.qml" line="82"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardCredentials.qml" line="94"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardCredentials.qml" line="224"/>
+        <source>Password or SSH private key</source>
+        <translation>Пароль или закрытый ключ SSH</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardCredentials.qml" line="97"/>
+        <source>SSH key requirements: supported key types are ED25519 and RSA in PEM format. Paste the private key, including the BEGIN/END lines. If your key doesn’t work, generate a compatible one</source>
+        <translation>Требования к SSH-ключу: поддерживаются ключи ED25519 и RSA в формате PEM. Вставьте закрытый ключ целиком, включая строки BEGIN/END. Если ваш ключ не подходит, создайте совместимый ключ</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardCredentials.qml" line="144"/>
+        <source>All data you enter will remain strictly confidential and will not be shared or disclosed to the Amnezia or any third parties</source>
+        <translation>Все данные, которые вы вводите, останутся строго конфиденциальными и не будут переданы или раскрыты Amnezia или каким-либо третьим лицам</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardCredentials.qml" line="155"/>
+        <source>How to run your VPN server</source>
+        <translation>Как создать VPN на собственном сервере</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardCredentials.qml" line="156"/>
+        <source>Where to get connection data, step-by-step instructions for buying a VPS</source>
+        <translation>Где взять данные для подключения, пошаговые инструкции по покупке VPS</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardCredentials.qml" line="176"/>
+        <source>Ip address cannot be empty</source>
+        <translation>Поле с IP-адресом не может быть пустым</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardCredentials.qml" line="184"/>
+        <source>Login cannot be empty</source>
+        <translation>Поле с логином не может быть пустым</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardCredentials.qml" line="190"/>
+        <source>Password/private key cannot be empty</source>
+        <translation>Поле с паролем/закрытым ключом не может быть пустым</translation>
+    </message>
+</context>
+<context>
+    <name>PageSetupWizardEasy</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardEasy.qml" line="85"/>
+        <source>Choose Installation Type</source>
+        <translation>Выберите тип установки</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardEasy.qml" line="138"/>
+        <source>Manual</source>
+        <translation>Ручная</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardEasy.qml" line="139"/>
+        <source>Choose a VPN protocol</source>
+        <translation>Выбрать VPN-протокол</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardEasy.qml" line="200"/>
+        <source>Skip setup</source>
+        <translation>Пропустить настройку</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardEasy.qml" line="159"/>
+        <source>Continue</source>
+        <translation>Продолжить</translation>
+    </message>
+</context>
+<context>
+    <name>PageSetupWizardInstalling</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardInstalling.qml" line="57"/>
+        <source>The server has already been added to the application</source>
+        <translation>Сервер уже был добавлен в приложение</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardInstalling.qml" line="63"/>
+        <source>Amnezia has detected that your server is currently </source>
+        <translation>Amnezia обнаружила, что ваш сервер в настоящее время </translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardInstalling.qml" line="64"/>
+        <source>busy installing other software. Amnezia installation </source>
+        <translation>занят установкой других протоколов или сервисов. Установка Amnezia </translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardInstalling.qml" line="65"/>
+        <source>will pause until the server finishes installing other software</source>
+        <translation>будет приостановлена до тех пор, пока сервер не завершит установку другого ПО</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardInstalling.qml" line="104"/>
+        <source>Installing</source>
+        <translation>Установка</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardInstalling.qml" line="150"/>
+        <source>Cancel installation</source>
+        <translation>Отменить установку</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardInstalling.qml" line="25"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardInstalling.qml" line="69"/>
+        <source>Usually it takes no more than 5 minutes</source>
+        <translation>Обычно это занимает не более 5 минут</translation>
+    </message>
+</context>
+<context>
+    <name>PageSetupWizardProtocolSettings</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardProtocolSettings.qml" line="69"/>
+        <source>Installing %1</source>
+        <translation>Устанавливается %1</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardProtocolSettings.qml" line="88"/>
+        <source>More detailed</source>
+        <translation>Подробнее</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardProtocolSettings.qml" line="175"/>
+        <source>Close</source>
+        <translation>Закрыть</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardProtocolSettings.qml" line="193"/>
+        <source>Network protocol</source>
+        <translation>Сетевой протокол</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardProtocolSettings.qml" line="214"/>
+        <source>Port</source>
+        <translation>Порт</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardProtocolSettings.qml" line="235"/>
+        <source>Install</source>
+        <translation>Установить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardProtocolSettings.qml" line="241"/>
+        <source>The port must be in the range of 1 to 65535</source>
+        <translation>Порт должен быть в диапазоне от 1 до 65535</translation>
+    </message>
+</context>
+<context>
+    <name>PageSetupWizardProtocols</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardProtocols.qml" line="78"/>
+        <source>VPN protocol</source>
+        <translation>VPN-протокол</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardProtocols.qml" line="79"/>
+        <source>Choose the one with the highest priority for you. Later, you can install other protocols and additional services, such as DNS proxy and SFTP.</source>
+        <translation>Выберите протокол, который вам больше подходит. В дальнейшем можно установить другие протоколы и дополнительные сервисы, такие как DNS-прокси и SFTP.</translation>
+    </message>
+</context>
+<context>
+    <name>PageSetupWizardQrReader</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardQrReader.qml" line="38"/>
+        <source>Point the camera at the QR code and hold for a couple of seconds. </source>
+        <translation>Наведите камеру на QR-код и удерживайте ее в течение нескольких секунд. </translation>
+    </message>
+</context>
+<context>
+    <name>PageSetupWizardStart</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardStart.qml" line="42"/>
+        <source>Let&apos;s get started</source>
+        <translation>Приступим</translation>
+    </message>
+</context>
+<context>
+    <name>PageSetupWizardTextKey</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardTextKey.qml" line="47"/>
+        <source>Connection key</source>
+        <translation>Ключ для подключения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardTextKey.qml" line="48"/>
+        <source>A line that starts with vpn://...</source>
+        <translation>Строка, которая начинается с vpn://...</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardTextKey.qml" line="66"/>
+        <source>Key</source>
+        <translation>Ключ</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardTextKey.qml" line="68"/>
+        <source>Insert</source>
+        <translation>Вставить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardTextKey.qml" line="89"/>
+        <source>Continue</source>
+        <translation>Продолжить</translation>
+    </message>
+</context>
+<context>
+    <name>PageSetupWizardViewConfig</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardViewConfig.qml" line="75"/>
+        <source>New connection</source>
+        <translation>Новое соединение</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardViewConfig.qml" line="115"/>
+        <source>Collapse content</source>
+        <translation>Свернуть</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardViewConfig.qml" line="115"/>
+        <source>Show content</source>
+        <translation>Показать</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardViewConfig.qml" line="132"/>
+        <source>Enable WireGuard obfuscation. It may be useful if WireGuard is blocked on your provider.</source>
+        <translation>Включить обфускацию WireGuard. Это может быть полезно, если WireGuard блокируется вашим провайдером.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardViewConfig.qml" line="163"/>
+        <source>Use connection codes only from sources you trust. Codes from public sources may have been created to intercept your data.</source>
+        <translation>Используйте файлы конфигурации только из тех источников, которым вы доверяете. Файлы из общедоступных источников могли быть созданы с целью перехвата ваших личных данных.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageSetupWizardViewConfig.qml" line="207"/>
+        <source>Connect</source>
+        <translation>Подключиться</translation>
+    </message>
+</context>
+<context>
+    <name>PageShare</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="113"/>
+        <source>OpenVPN native format</source>
+        <translation>Оригинальный формат OpenVPN</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="118"/>
+        <source>WireGuard native format</source>
+        <translation>Оригинальный формат WireGuard</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="233"/>
+        <source>Connection</source>
+        <translation>Соединение</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="301"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="302"/>
+        <source>Server</source>
+        <translation>Сервер</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="35"/>
+        <source>Config revoked</source>
+        <translation>Конфигурация отозвана</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="51"/>
+        <source>Save AmneziaVPN config</source>
+        <translation>Сохранить конфигурацию AmneziaVPN</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="58"/>
+        <source>Save OpenVPN config</source>
+        <translation>Сохранить конфигурацию OpenVPN</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="65"/>
+        <source>Save WireGuard config</source>
+        <translation>Сохранить конфигурацию WireGuard</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="72"/>
+        <source>Save AmneziaWG config</source>
+        <translation>Сохранить конфигурацию AmneziaWG</translation>
+    </message>
+    <message>
+        <source>Save Shadowsocks config</source>
+        <translation type="vanished">Сохранить конфигурацию Shadowsocks</translation>
+    </message>
+    <message>
+        <source>Save Cloak config</source>
+        <translation type="vanished">Сохранить конфигурацию  Cloak</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="79"/>
+        <source>Save XRay config</source>
+        <translation>Сохранить конфигурацию XRay</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="88"/>
+        <source>Connection to </source>
+        <translation>Подключение к </translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="89"/>
+        <source>File with connection settings to </source>
+        <translation>Файл с настройками подключения к </translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="108"/>
+        <source>For the AmneziaVPN app</source>
+        <translation>Для приложения AmneziaVPN</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="123"/>
+        <source>AmneziaWG native format</source>
+        <translation>Оригинальный формат AmneziaWG</translation>
+    </message>
+    <message>
+        <source>Shadowsocks native format</source>
+        <translation type="vanished">Оригинальный формат Shadowsocks</translation>
+    </message>
+    <message>
+        <source>Cloak native format</source>
+        <translation type="vanished">Оригинальный формат Cloak</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="128"/>
+        <source>XRay native format</source>
+        <translation>Оригинальный формат XRay</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="156"/>
+        <source>Share VPN Access</source>
+        <translation>Поделиться VPN</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="190"/>
+        <source>Share full access to the server and VPN</source>
+        <translation>Поделиться полным доступом к серверу и VPN</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="191"/>
+        <source>Use for your own devices, or share with those you trust to manage the server.</source>
+        <translation>Используйте для собственных устройств или передайте управление сервером тем, кому вы доверяете.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="248"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="559"/>
+        <source>Users</source>
+        <translation>Пользователи</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="282"/>
+        <source>User name</source>
+        <translation>Имя пользователя</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="575"/>
+        <source>Search</source>
+        <translation>Поиск</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="704"/>
+        <source>Creation date: %1</source>
+        <translation>Дата создания: %1</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="716"/>
+        <source>Latest handshake: %1</source>
+        <translation>Последнее рукопожатие: %1</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="728"/>
+        <source>Data received: %1</source>
+        <translation>Получено данных: %1</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="740"/>
+        <source>Data sent: %1</source>
+        <translation>Отправлено данных: %1</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="750"/>
+        <source>Allowed IPs: %1</source>
+        <translation>Разрешенные подсети: %1</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="765"/>
+        <source>Rename</source>
+        <translation>Переименовать</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="790"/>
+        <source>Client name</source>
+        <translation>Имя клиента</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="801"/>
+        <source>Save</source>
+        <translation>Сохранить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="837"/>
+        <source>Revoke</source>
+        <translation>Отозвать</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="840"/>
+        <source>Revoke the config for a user - %1?</source>
+        <translation>Отозвать конфигурацию для пользователя - %1?</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="841"/>
+        <source>The user will no longer be able to connect to your server.</source>
+        <translation>Пользователь больше не сможет подключаться к вашему серверу.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="842"/>
+        <source>Continue</source>
+        <translation>Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="843"/>
+        <source>Cancel</source>
+        <translation>Отменить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="271"/>
+        <source>Share VPN access without the ability to manage the server</source>
+        <translation>Поделиться доступом к VPN без возможности управления сервером</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="366"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="367"/>
+        <source>Protocol</source>
+        <translation>Протокол</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="479"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="480"/>
+        <source>Connection format</source>
+        <translation>Формат подключения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="198"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShare.qml" line="541"/>
+        <source>Share</source>
+        <translation>Поделиться</translation>
+    </message>
+</context>
+<context>
+    <name>PageShareConnection</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShareConnection.qml" line="25"/>
+        <source>Share</source>
+        <translation>Поделиться</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShareConnection.qml" line="26"/>
+        <source>Copy</source>
+        <translation>Скопировать</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShareConnection.qml" line="30"/>
+        <source>Save AmneziaVPN config</source>
+        <translation>Сохранить конфигурацию AmneziaVPN</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShareConnection.qml" line="150"/>
+        <source>Copy config string</source>
+        <translation>Скопировать строку конфигурации</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShareConnection.qml" line="168"/>
+        <source>Show connection settings</source>
+        <translation>Показать настройки подключения</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShareConnection.qml" line="189"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShareConnection.qml" line="199"/>
+        <source>Copied</source>
+        <translation>Скопировано</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShareConnection.qml" line="326"/>
+        <source>To read the QR code in the Amnezia app, tap + in the main menu → &apos;QR code&apos;</source>
+        <translation type="unfinished">Для считывания QR-кода в приложении Amnezia выберите + в главном меню → &apos;QR-код&apos;</translation>
+    </message>
+    <message>
+        <source>To read the QR code in the Amnezia app, select &quot;Add server&quot; → &quot;I have data to connect&quot; → &quot;QR code, key or settings file&quot;</source>
+        <translation type="vanished">Для считывания QR-кода в приложении Amnezia выберите &quot;Добавить сервер&quot; → &quot;У меня есть данные для подключения&quot; → &quot;Открыть файл конфигурации, ключ или QR-код&quot;</translation>
+    </message>
+</context>
+<context>
+    <name>PageShareFullAccess</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShareFullAccess.qml" line="57"/>
+        <source>Full access to the server and VPN</source>
+        <translation>Полный доступ к серверу и VPN</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShareFullAccess.qml" line="67"/>
+        <source>We recommend that you use full access to the server only for your own additional devices.
+</source>
+        <translation>Мы рекомендуем использовать полный доступ к серверу только для собственных устройств.
+</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShareFullAccess.qml" line="68"/>
+        <source>If you share full access with other people, they can remove and add protocols and services to the server, which will cause the VPN to work incorrectly for all users. </source>
+        <translation>Если вы поделитесь полным доступом с другими людьми, то они смогут удалять и добавлять протоколы и сервисы на сервер, что приведет к некорректной работе VPN для всех пользователей. </translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShareFullAccess.qml" line="87"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShareFullAccess.qml" line="88"/>
+        <source>Server</source>
+        <translation>Сервер</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShareFullAccess.qml" line="115"/>
+        <source>Accessing </source>
+        <translation>Доступ </translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShareFullAccess.qml" line="116"/>
+        <source>File with accessing settings to </source>
+        <translation>Файл с настройками доступа к </translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShareFullAccess.qml" line="147"/>
+        <source>Share</source>
+        <translation>Поделиться</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageShareFullAccess.qml" line="155"/>
+        <source>Access error!</source>
+        <translation>Ошибка доступа!</translation>
+    </message>
+</context>
+<context>
+    <name>PageStart</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageStart.qml" line="207"/>
+        <source>Logging was disabled after 14 days, log files were deleted</source>
+        <translation>Логирование было отключено по прошествии 14 дней, файлы логов были удалены.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageStart.qml" line="211"/>
+        <source>Settings restored from backup file</source>
+        <translation>Настройки восстановлены из бэкап файла</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Pages2/PageStart.qml" line="217"/>
+        <source>Logging is enabled. Note that logs will be automaticallydisabled after 14 days, and all log files will be deleted.</source>
+        <translation>Логирование включено. Обратите внимание, что через 14 дней оно будет автоматически отключено, а все файлы логов будут удалены.</translation>
+    </message>
+</context>
+<context>
+    <name>PopupType</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Controls2/PopupType.qml" line="101"/>
+        <source>Close</source>
+        <translation>Закрыть</translation>
+    </message>
+</context>
+<context>
+    <name>QKeychain::DeletePasswordJobPrivate</name>
+    <message>
+        <source>Password entry not found</source>
+        <translation type="vanished">Пароль не найден</translation>
+    </message>
+    <message>
         <source>Could not decrypt data</source>
-        <translation>Не удалось расшифровать данные</translation>
+        <translation type="vanished">Не удалось расшифровать данные</translation>
+    </message>
+    <message>
+        <source>Unknown error</source>
+        <translation type="vanished">Неизвестная ошибка</translation>
+    </message>
+    <message>
+        <source>Could not open wallet: %1; %2</source>
+        <translation type="vanished">Не удалось открыть бумажник: %1; %2</translation>
+    </message>
+    <message>
+        <source>Password not found</source>
+        <translation type="vanished">Пароль не найден</translation>
+    </message>
+    <message>
+        <source>Could not open keystore</source>
+        <translation type="vanished">Не удалось открыть хранилище ключей</translation>
+    </message>
+    <message>
+        <source>Could not remove private key from keystore</source>
+        <translation type="vanished">Не удалось удалить закрытый ключ из хранилища ключей</translation>
+    </message>
+</context>
+<context>
+    <name>QKeychain::JobPrivate</name>
+    <message>
+        <source>Unknown error</source>
+        <translation type="vanished">Неизвестная ошибка</translation>
+    </message>
+    <message>
+        <source>Access to keychain denied</source>
+        <translation type="vanished">Доступ к брелоку запрещен</translation>
+    </message>
+</context>
+<context>
+    <name>QKeychain::PlainTextStore</name>
+    <message>
+        <source>Could not store data in settings: access error</source>
+        <translation type="vanished">Не удалось сохранить данные в настройках: ошибка доступа</translation>
+    </message>
+    <message>
+        <source>Could not store data in settings: format error</source>
+        <translation type="vanished">Не удалось сохранить данные в настройках: ошибка формата</translation>
+    </message>
+    <message>
+        <source>Could not delete data from settings: access error</source>
+        <translation type="vanished">Не удалось удалить данные из настроек: ошибка доступа</translation>
+    </message>
+    <message>
+        <source>Could not delete data from settings: format error</source>
+        <translation type="vanished">Не удалось удалить данные из настроек: ошибка формата</translation>
+    </message>
+    <message>
+        <source>Entry not found</source>
+        <translation type="vanished">Запись не найдена</translation>
     </message>
 </context>
 <context>
     <name>QKeychain::ReadPasswordJobPrivate</name>
     <message>
-        <location filename="../3rd/qtkeychain/qtkeychain/keychain_win.cpp" line="32"/>
         <source>Password entry not found</source>
-        <translation>Пароль не найден</translation>
+        <translation type="vanished">Пароль не найден</translation>
     </message>
     <message>
-        <location filename="../3rd/qtkeychain/qtkeychain/keychain_win.cpp" line="36"/>
-        <location filename="../3rd/qtkeychain/qtkeychain/keychain_win.cpp" line="139"/>
         <source>Could not decrypt data</source>
-        <translation>Не удалось расшифровать данные</translation>
+        <translation type="vanished">Не удалось расшифровать данные</translation>
+    </message>
+    <message>
+        <source>D-Bus is not running</source>
+        <translation type="vanished">D-Bus не запущен</translation>
+    </message>
+    <message>
+        <source>Unknown error</source>
+        <translation type="vanished">Неизвестная ошибка</translation>
+    </message>
+    <message>
+        <source>No keychain service available</source>
+        <translation type="vanished">Сервис брелоков не доступен</translation>
+    </message>
+    <message>
+        <source>Could not open wallet: %1; %2</source>
+        <translation type="vanished">Не удалось открыть бумажник: %1; %2</translation>
+    </message>
+    <message>
+        <source>Access to keychain denied</source>
+        <translation type="vanished">Доступ к брелоку запрещен</translation>
+    </message>
+    <message>
+        <source>Could not determine data type: %1; %2</source>
+        <translation type="vanished">Не удалось определить тип данных: %1; %2</translation>
+    </message>
+    <message>
+        <source>Entry not found</source>
+        <translation type="vanished">Запись не найдена</translation>
+    </message>
+    <message>
+        <source>Unsupported entry type &apos;Map&apos;</source>
+        <translation type="vanished">Неподдерживаемый тип записи &apos;Map&apos;</translation>
+    </message>
+    <message>
+        <source>Unknown kwallet entry type &apos;%1&apos;</source>
+        <translation type="vanished">Неизвестный тип записи kwallet &apos;%1&apos;</translation>
+    </message>
+    <message>
+        <source>Password not found</source>
+        <translation type="vanished">Пароль не найден</translation>
+    </message>
+    <message>
+        <source>Could not open keystore</source>
+        <translation type="vanished">Не удалось открыть хранилище ключей</translation>
+    </message>
+    <message>
+        <source>Could not retrieve private key from keystore</source>
+        <translation type="vanished">Не удалось получить закрытый ключ из хранилища ключей</translation>
+    </message>
+    <message>
+        <source>Could not create decryption cipher</source>
+        <translation type="vanished">Не удалось создать шифр для расшифровки</translation>
     </message>
 </context>
 <context>
     <name>QKeychain::WritePasswordJobPrivate</name>
     <message>
-        <location filename="../3rd/qtkeychain/qtkeychain/keychain_win.cpp" line="78"/>
         <source>Credential size exceeds maximum size of %1</source>
-        <translation>Размер учетных данных превышает максимальный размер %1</translation>
+        <translation type="vanished">Размер учетных данных превышает максимальный размер %1</translation>
     </message>
     <message>
-        <location filename="../3rd/qtkeychain/qtkeychain/keychain_win.cpp" line="87"/>
         <source>Credential key exceeds maximum size of %1</source>
-        <translation>Ключ учетных данных превышает максимальный размер %1</translation>
+        <translation type="vanished">Ключ учетных данных превышает максимальный размер %1</translation>
     </message>
     <message>
-        <location filename="../3rd/qtkeychain/qtkeychain/keychain_win.cpp" line="92"/>
         <source>Writing credentials failed: Win32 error code %1</source>
-        <translation>Не удалось записать учетные данные: код ошибки Win32 %1</translation>
+        <translation type="vanished">Не удалось записать учетные данные: код ошибки Win32 %1</translation>
     </message>
     <message>
-        <location filename="../3rd/qtkeychain/qtkeychain/keychain_win.cpp" line="162"/>
         <source>Encryption failed</source>
-        <translation>Не удалось зашифровать</translation>
+        <translation type="vanished">Не удалось зашифровать</translation>
+    </message>
+    <message>
+        <source>D-Bus is not running</source>
+        <translation type="vanished">D-Bus не запущен</translation>
+    </message>
+    <message>
+        <source>Unknown error</source>
+        <translation type="vanished">Неизвестная ошибка</translation>
+    </message>
+    <message>
+        <source>Could not open wallet: %1; %2</source>
+        <translation type="vanished">Не удалось открыть бумажник: %1; %2</translation>
+    </message>
+    <message>
+        <source>Password not found</source>
+        <translation type="vanished">Пароль не найден</translation>
+    </message>
+    <message>
+        <source>Could not open keystore</source>
+        <translation type="vanished">Не удалось открыть хранилище ключей</translation>
+    </message>
+    <message>
+        <source>Could not create private key generator</source>
+        <translation type="vanished">Не удалось создать генератор закрытых ключей</translation>
+    </message>
+    <message>
+        <source>Could not generate new private key</source>
+        <translation type="vanished">Не удалось сгенерировать новый закрытый ключ</translation>
+    </message>
+    <message>
+        <source>Could not retrieve private key from keystore</source>
+        <translation type="vanished">Не удалось получить закрытый ключ из хранилища ключей</translation>
+    </message>
+    <message>
+        <source>Could not create encryption cipher</source>
+        <translation type="vanished">Не удалось создать шифр шифрования</translation>
+    </message>
+    <message>
+        <source>Could not encrypt data</source>
+        <translation type="vanished">Не удалось зашифровать данные</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="11"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="11"/>
         <source>No error</source>
         <translation>Нет ошибки</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="13"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="13"/>
         <source>Function not implemented</source>
         <translation>Функция не реализована</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="14"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="14"/>
         <source>Background service is not running</source>
         <translation>Фоновая служба не запущена</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="15"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="15"/>
         <source>The selected protocol is not supported on the current platform</source>
         <translation>Выбранный протокол не поддерживается на данном устройстве</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="18"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="18"/>
         <source>Server check failed</source>
         <translation>Проверка сервера завершилась неудачей</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="19"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="19"/>
         <source>Server port already used. Check for another software</source>
         <translation>Порт сервера уже используется. Проверьте наличие другого ПО</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="20"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="20"/>
         <source>Server error: Docker container missing</source>
         <translation>Ошибка сервера: отсутствует Docker-контейнер</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="21"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="21"/>
         <source>Server error: Docker failed</source>
         <translation>Ошибка сервера: сбой в работе Docker</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="22"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="22"/>
         <source>Installation canceled by user</source>
         <translation>Установка отменена пользователем</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="23"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="23"/>
         <source>The user is not a member of the sudo group</source>
         <translation>Пользователь не входит в группу sudo</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="24"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="24"/>
         <source>Server error: Package manager error</source>
         <translation>Ошибка сервера: Ошибка менеджера пакетов</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="25"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="25"/>
         <source>The sudo package is not pre-installed on the server</source>
         <translation>Пакет sudo не установлен на сервере по умолчанию</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="26"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="26"/>
         <source>The server user&apos;s home directory is not accessible</source>
         <translation>Домашний каталог пользователя сервера недоступен</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="27"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="27"/>
         <source>Action not allowed in sudoers</source>
         <translation>Действие не разрешено в sudoers</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="28"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="28"/>
         <source>The user&apos;s password is required</source>
         <translation>Требуется пароль пользователя</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="29"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="29"/>
         <source>Docker error: runc doesn&apos;t work on cgroups v2</source>
         <translation>Docker error: runc не работает на cgroups v2</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="30"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="30"/>
         <source>Server error: cgroup mountpoint does not exist</source>
         <translation>Server error: cgroup mountpoint не существует</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="31"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="31"/>
         <source>Docker error: The pull rate limit has been reached</source>
         <translation>Docker error: достигнут лимит скорости вытягивания</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="32"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="32"/>
         <source>Server error: Linux kernel is too old</source>
         <translation>Ошибка сервера: ядро Linux слишком старое</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="34"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="34"/>
         <source>Server error: invalid or unreadable XRay server configuration</source>
         <translation>Ошибка сервера: неверная или нечитаемая конфигурация сервера XRay</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="37"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="37"/>
         <source>Server error: XRay server has no VLESS clients</source>
         <translation>Ошибка сервера: сервер XRay не содержит пользователей VLESS</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="40"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="40"/>
         <source>Server error: failed to read XRay Reality keys from the server</source>
         <translation>Ошибка сервера: не удалось считать ключи XRay Reality с сервера</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="42"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="42"/>
         <source>Server error: The default container runtime available for installation on this server is not supported.
  Install Docker Engine on the server manually and try again.</source>
         <translation>Ошибка сервера: Среда выполнения контейнеров, доступная для установки на этом сервере по умолчанию, не поддерживается.
  Установите Docker Engine на сервер вручную и повторите попытку.</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="43"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="43"/>
         <source>Container runtime error: The container runtime service is not running.
  Check the container runtime service on the server, or wait about a minute and try again.</source>
         <translation>Ошибка среды выполнения контейнеров: Служба среды выполнения контейнеров не запущена.
  Проверьте службу среды выполнения контейнеров на сервере или подождите около минуты и повторите попытку.</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="46"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="46"/>
         <source>SSH request was denied</source>
         <translation>SSH-запрос был отклонён</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="47"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="47"/>
         <source>SSH request was interrupted</source>
         <translation>SSH-запрос был прерван</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="48"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="48"/>
         <source>SSH internal error</source>
         <translation>Внутренняя ошибка SSH</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="49"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="49"/>
         <source>Invalid private key or invalid passphrase entered</source>
         <translation>Введен неверный закрытый ключ или неверная парольная фраза</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="50"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="50"/>
         <source>The selected private key format is not supported, use openssh ED25519 key types or PEM key types</source>
         <translation>Выбранный формат закрытого ключа не поддерживается, используйте типы ключей openssh ED25519 или PEM</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="51"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="51"/>
         <source>Timeout connecting to server</source>
         <translation>Тайм-аут подключения к серверу</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="54"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="54"/>
         <source>SCP error: Generic failure</source>
         <translation>Ошибка SCP: общий сбой</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="70"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="70"/>
         <source>The config does not contain any containers and credentials for connecting to the server</source>
         <translation>Конфигурация не содержит каких-либо контейнеров и учетных данных для подключения к серверу</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="71"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="71"/>
         <source>Backup files cannot be imported here. Use &apos;Restore from backup&apos; instead.</source>
         <translation>Файл резервной копии не может быть импортирован здесь. Воспользуйтесь &apos;Восстановить из резервной копии&apos;.</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="72"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="72"/>
         <source>Backup file is corrupted or has invalid format</source>
         <translation>Файл резервной копии поврежден или имеет неверный формат</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="73"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="73"/>
         <source>This legacy Amnezia subscription format is no longer supported</source>
         <translation>Этот устаревший формат подписки Amnezia больше не поддерживается</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="74"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="74"/>
         <source>This protocol is no longer supported. Please select another protocol or remove this container from the server settings.</source>
         <translation>Этот протокол больше не поддерживается. Пожалуйста, выберите другой протокол или удалите этот контейнер из настроек сервера.</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="76"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="76"/>
         <source>VPN Protocols is not installed.
  Please install VPN container at first</source>
         <translation>VPN-протоколы не установлены.
 Пожалуйста, установите протокол</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="82"/>
-        <location filename="../core/utils/errorStrings.cpp" line="91"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="82"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="91"/>
         <source>Error when retrieving configuration from API</source>
         <translation>Ошибка при получении конфигурации из API</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="83"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="83"/>
         <source>This config has already been added to the application</source>
         <translation>Данная конфигурация уже была добавлена в приложение</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="92"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="92"/>
         <source>A migration error has occurred. Please contact our technical support</source>
         <translation>Произошла ошибка миграции. Обратитесь в нашу техническую поддержку</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="93"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="93"/>
         <source>Please update the application to use this feature</source>
         <translation>Пожалуйста, обновите приложение, чтобы использовать эту функцию</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="94"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="94"/>
         <source>Your Amnezia Premium subscription has expired.
  Please check your email for renewal instructions.
  If you haven&apos;t received an email, please contact our support.</source>
@@ -601,283 +6527,287 @@ Already installed containers were found on the server. All installed containers 
 Если вы не получили письмо, пожалуйста, свяжитесь с нашей службой поддержки.</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="95"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="95"/>
         <source>Unable to process purchase</source>
         <translation>Не удалось обработать покупку</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="96"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="96"/>
         <source>No active subscription found</source>
         <translation>Активная подписка не найдена</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="97"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="97"/>
         <source>No purchased subscriptions found. Please purchase a subscription first</source>
         <translation>Платные подписки не найдены. Сначала оформите подписку</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="98"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="98"/>
         <source>This email address has already been used to activate a trial</source>
         <translation>Этот адрес электронной почты уже использовался для активации пробного периода</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="99"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="99"/>
         <source>CAPTCHA verification is required</source>
         <translation>Требуется подтверждение CAPTCHA</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="100"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="100"/>
         <source>CAPTCHA was incorrect. Please try again</source>
         <translation>CAPTCHA неверна. Пожалуйста, попробуйте снова</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="101"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="101"/>
         <source>CAPTCHA refreshed. Please try again</source>
         <translation>CAPTCHA обновлена. Пожалуйста, попробуйте снова</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="102"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="102"/>
         <source>Too many requests. Please try again later</source>
         <translation>Слишком много запросов. Пожалуйста, попробуйте еще раз позже</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="117"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="117"/>
         <source>ErrorCode: %1. </source>
         <translation>Код ошибки: %1. </translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="57"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="57"/>
         <source>OpenVPN config missing</source>
         <translation>Отсутствует конфигурация OpenVPN</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="58"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="58"/>
         <source>OpenVPN management server error</source>
         <translation>Серверная ошибка управлением OpenVPN</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="61"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="61"/>
         <source>OpenVPN executable missing</source>
         <translation>Отсутствует исполняемый файл OpenVPN</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="62"/>
+        <source>Shadowsocks (ss-local) executable missing</source>
+        <translation type="vanished">Отсутствует исполняемый файл Shadowsocks (ss-local)</translation>
+    </message>
+    <message>
+        <source>Cloak (ck-client) executable missing</source>
+        <translation type="vanished">Отсутствует исполняемый файл Cloak (ck-client)</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="62"/>
         <source>Amnezia helper service error</source>
         <translation>Ошибка вспомогательной службы Amnezia</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="63"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="63"/>
         <source>OpenSSL failed</source>
         <translation>Ошибка OpenSSL</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="66"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="66"/>
         <source>Can&apos;t connect: another VPN connection is active</source>
         <translation>Невозможно подключиться: активно другое VPN-соединение</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="67"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="67"/>
         <source>Can&apos;t setup OpenVPN TAP network adapter</source>
         <translation>Невозможно настроить сетевой адаптер OpenVPN TAP</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="68"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="68"/>
         <source>VPN pool error: no available addresses</source>
         <translation>Ошибка пула VPN: нет доступных адресов</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="75"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="75"/>
         <source>Unable to open config file</source>
         <translation>Не удалось открыть файл конфигурации</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="79"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="79"/>
         <source>VPN connection error</source>
         <translation>Ошибка VPN-соединения</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="84"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="84"/>
         <source>In the response from the server, an empty config was received</source>
         <translation>В ответе от сервера была получена пустая конфигурация</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="85"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="85"/>
         <source>SSL error occurred</source>
         <translation>Произошла ошибка SSL</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="86"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="86"/>
         <source>Server response timeout on api request</source>
         <translation>Тайм-аут ответа сервера на запрос API</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="87"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="87"/>
         <source>Missing AGW public key</source>
         <translation>Отсутствует публичный ключ AGW</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="88"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="88"/>
         <source>Failed to decrypt response payload</source>
         <translation>Не удалось расшифровать ответ полезной нагрузки</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="89"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="89"/>
         <source>Missing list of available services</source>
         <translation>Отсутствует список доступных сервисов</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="90"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="90"/>
         <source>The limit of allowed configurations per subscription has been exceeded</source>
         <translation>Превышен лимит разрешенных конфигураций для одной подписки</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="105"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="105"/>
         <source>QFile error: The file could not be opened</source>
         <translation>Ошибка QFile: не удалось открыть файл</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="106"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="106"/>
         <source>QFile error: An error occurred when reading from the file</source>
         <translation>Ошибка QFile: произошла ошибка при чтении из файла</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="107"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="107"/>
         <source>QFile error: The file could not be accessed</source>
         <translation>Ошибка QFile: не удалось получить доступ к файлу</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="108"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="108"/>
         <source>QFile error: An unspecified error occurred</source>
         <translation>Ошибка QFile: произошла неизвестная ошибка</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="109"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="109"/>
         <source>QFile error: A fatal error occurred</source>
         <translation>Ошибка QFile: произошла фатальная ошибка</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="110"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="110"/>
         <source>QFile error: The operation was aborted</source>
         <translation>Ошибка QFile: операция была прервана</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="114"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="114"/>
         <source>Internal error</source>
         <translation>Внутренняя ошибка</translation>
     </message>
     <message>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="73"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="73"/>
         <source>IPsec</source>
         <translation>IPsec</translation>
     </message>
     <message>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="80"/>
-        <location filename="../core/protocols/protocolUtils.cpp" line="72"/>
-        <source>MTProxy (Telegram)</source>
-        <translation>MTProxy (Telegram)</translation>
-    </message>
-    <message>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="81"/>
-        <location filename="../core/protocols/protocolUtils.cpp" line="73"/>
-        <source>Telemt (Telegram)</source>
-        <translation>Telemt (Telegram)</translation>
-    </message>
-    <message>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="91"/>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="93"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="91"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="93"/>
         <source>This protocol is no longer supported.</source>
         <translation>Этот протокол больше не поддерживается.</translation>
     </message>
     <message>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="107"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="107"/>
         <source>IKEv2/IPsec -  Modern stable protocol, a bit faster than others, restores connection after signal loss. It has native support on the latest versions of Android and iOS.</source>
         <translation>IKEv2/IPsec — современный стабильный протокол, немного быстрее других, восстанавливает соединение после потери сигнала. Он имеет встроенную поддержку в последних версиях Android и iOS.</translation>
     </message>
     <message>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="114"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="114"/>
         <source>Create a file vault on your server to securely store and transfer files.</source>
         <translation>Создайте на сервере файловое хранилище для безопасного хранения и передачи файлов.</translation>
     </message>
     <message>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="118"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="118"/>
         <source>Telegram MTProto proxy server</source>
         <translation>Telegram MTProto прокси сервер</translation>
     </message>
     <message>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="120"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="120"/>
         <source>Telegram MTProto proxy (Telemt, Rust)</source>
         <translation>Telegram MTProto прокси (Telemt, Rust)</translation>
     </message>
     <message>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="185"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="185"/>
         <source>DNS Service</source>
         <translation>Сервис DNS</translation>
     </message>
     <message>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="193"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="193"/>
         <source>Telegram MTProto proxy server. Allows Telegram clients to connect through your server using the MTProto protocol. Supports FakeTLS mode for bypassing DPI-based blocking.</source>
         <translation>Telegram MTProto прокси сервер. Позволяет подключаться пользователям Telegram через ваш сервер используя протокол MTProto. Поддерживает режим FakeTLS для обхода блокировок на основе DPI.</translation>
     </message>
     <message>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="198"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="198"/>
         <source>Telegram MTProto proxy powered by Telemt (Rust). Supports secure and TLS fronting modes with optional traffic masking.</source>
         <translation>Telegram MTProto прокси разработанный с помощью Telemt (Rust). Поддерживает безопасный режим и режим TLS fronting с возможностью маскировки трафика.</translation>
     </message>
     <message>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="330"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="330"/>
         <source>Automatic</source>
-        <translation>Автоматическая</translation>
+        <translation type="unfinished">Автоматическая</translation>
     </message>
     <message>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="338"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="338"/>
         <source>AmneziaWG protocol will be installed. It provides high connection speed and ensures stable operation even in the most challenging network conditions.</source>
-        <translation>Будет установлен протокол AmneziaWG. Он обеспечивает высокую скорость соединения и гарантирует стабильную работу даже в самых сложных условиях.</translation>
+        <translation type="unfinished">Будет установлен протокол AmneziaWG. Он обеспечивает высокую скорость соединения и гарантирует стабильную работу даже в самых сложных условиях.</translation>
     </message>
     <message>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="78"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="78"/>
         <source>SFTP file sharing service</source>
         <translation>SFTP-сервис для обмена файлами</translation>
     </message>
     <message>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="76"/>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="184"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="76"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="184"/>
         <source>Website in Tor network</source>
         <translation>Веб-сайт в сети Tor</translation>
     </message>
     <message>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="77"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="77"/>
         <source>AmneziaDNS</source>
         <translation>AmneziaDNS</translation>
     </message>
     <message>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="88"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="88"/>
         <source>OpenVPN is the most popular VPN protocol, with flexible configuration options. It uses its own security protocol with SSL/TLS for key exchange.</source>
         <translation>OpenVPN — самый популярный VPN-протокол с гибкой настройкой. Имеет собственный протокол безопасности с SSL/TLS для обмена ключами.</translation>
     </message>
     <message>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="95"/>
+        <source>Shadowsocks masks VPN traffic, making it resemble normal web traffic, but it may still be detected by certain analysis systems.</source>
+        <translation type="vanished">Shadowsocks маскирует VPN-трафик, делая его похожим на обычный веб-трафик, но он все равно может быть обнаружен некоторыми системами анализа.</translation>
+    </message>
+    <message>
+        <source>OpenVPN over Cloak - OpenVPN with VPN masquerading as web traffic and protection against active-probing detection. It is very resistant to detection, but offers low speed.</source>
+        <translation type="vanished">OpenVPN over Cloak — OpenVPN с маскировкой под веб-трафик , а также с защитой от обнаружения и систем анализа трафика. Он очень устойчив к обнаружению, но имеет низкую скорость работы в сравнении с другими похожими протоколами.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="95"/>
         <source>WireGuard - popular VPN protocol with high performance, high speed and low power consumption.</source>
         <translation>WireGuard — популярный VPN-протокол с высокой производительностью, высокой скоростью и низким энергопотреблением.</translation>
     </message>
     <message>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="98"/>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="101"/>
-        <location filename="../ui/models/containersModel.cpp" line="41"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="98"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="101"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/models/containersModel.cpp" line="41"/>
         <source>AmneziaWG is a special protocol from Amnezia based on WireGuard. It provides high connection speed and ensures stable operation even in the most challenging network conditions.</source>
         <translation>AmneziaWG — специальный протокол от Amnezia, основанный на WireGuard. Он обеспечивает высокую скорость соединения и гарантирует стабильную работу даже в самых сложных условиях.</translation>
     </message>
     <message>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="104"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="104"/>
         <source>XRay with REALITY masks VPN traffic as web traffic and protects against active probing. It is highly resistant to detection and offers high speed.</source>
         <translation>XRay с REALITY маскирует VPN-трафик под веб-трафик. Обладает высокой устойчивостью к обнаружению и обеспечивает высокую скорость соединения.</translation>
     </message>
     <message>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="116"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="116"/>
         <source></source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="128"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="128"/>
         <source>OpenVPN is one of the most popular and reliable VPN protocols. It uses SSL/TLS encryption, supports a wide variety of devices and operating systems, and is continuously improved by the community due to its open-source nature. It provides a good balance between speed and security but is easily recognized by DPI systems, making it susceptible to blocking.
 
 Features:
@@ -894,7 +6824,54 @@ Features:
 * Работает по TCP и UDP</translation>
     </message>
     <message>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="139"/>
+        <source>Shadowsocks is based on the SOCKS5 protocol and encrypts connections using AEAD cipher. Although designed to be discreet, it doesn&apos;t mimic a standard HTTPS connection and can be detected by some DPI systems. Due to limited support in Amnezia, we recommend using the AmneziaWG protocol.
+
+Features:
+* Available in AmneziaVPN only on desktop platforms
+* Customizable encryption protocol
+* Detectable by some DPI systems
+* Operates over TCP protocol
+</source>
+        <translation type="vanished">Shadowsocks основан на протоколе SOCKS5 и шифрует соединение алгоритмом AEAD. Он разработан так, чтобы быть малозаметным, однако не идентичен HTTPS, поэтому может распознаваться некоторыми системами DPI. В связи с ограниченной поддержкой в Amnezia, рекомендуем использовать протокол AmneziaWG.
+
+Особенности:
+* Доступен только на ПК в AmneziaVPN
+* Настраиваемое шифрование
+* Может обнаруживаться некоторыми DPI-системами
+* Работает по протоколу TCP</translation>
+    </message>
+    <message>
+        <source>This combination includes the OpenVPN protocol and the Cloak plugin, specifically designed to protect against blocking.
+
+OpenVPN securely encrypts all internet traffic between your device and the server.
+
+The Cloak plugin further protects the connection from DPI detection. It modifies traffic metadata to disguise VPN traffic as regular web traffic and prevents detection through active probing. If an incoming connection fails authentication, Cloak serves a fake website, making your VPN invisible to traffic analysis systems.
+
+In regions with heavy internet censorship, we strongly recommend using OpenVPN with Cloak from your first connection.
+
+Features:
+* Available on all AmneziaVPN platforms
+* High power consumption on mobile devices
+* Flexible configuration options
+* Undetectable by DPI systems
+* Operates over TCP protocol on port 443</source>
+        <translation type="vanished">Эта комбинация состоит из протокола OpenVPN и плагина Cloak, специально разработанных для защиты от блокировок.
+
+OpenVPN надёжно шифрует весь интернет-трафик между вами и сервером.
+
+Плагин Cloak дополнительно защищает соединение от распознавания системами DPI. Он изменяет метаданные трафика, маскируя VPN-подключение под обычный веб-трафик, и предотвращает обнаружение с помощью активного зондирования. Если попытка подключения не прошла аутентификацию, Cloak выдаёт поддельный веб-сайт, делая VPN невидимым для анализирующих систем.
+
+Если в вашем регионе сильная интернет-цензура, мы рекомендуем сразу использовать OpenVPN с плагином Cloak.
+
+Особенности:
+* Доступен на всех платформах AmneziaVPN
+* Высокое энергопотребление на мобильных устройствах
+* Гибкие настройки
+* Незаметен для систем DPI-анализа
+* Использует протокол TCP на порту 443</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="139"/>
         <source>WireGuard is a modern, streamlined VPN protocol offering stable connectivity and excellent performance across all devices. It uses fixed encryption settings, delivering lower latency and higher data transfer speeds compared to OpenVPN. However, WireGuard is easily identifiable by DPI systems due to its distinctive packet signatures, making it susceptible to blocking.
 
 Features:
@@ -915,7 +6892,7 @@ Features:
 * Работает по протоколу UDP</translation>
     </message>
     <message>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="149"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="149"/>
         <source>AmneziaWG is a modern VPN protocol based on WireGuard, combining simplified architecture with high performance across all devices. It addresses WireGuard&apos;s main vulnerability (easy detection by DPI systems) through advanced obfuscation techniques, making VPN traffic indistinguishable from regular internet traffic.
 
 AmneziaWG is an excellent choice for those seeking a fast, stealthy VPN connection.
@@ -938,7 +6915,7 @@ Features:
 * Работает по протоколу UDP</translation>
     </message>
     <message>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="161"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="161"/>
         <source>REALITY is an innovative protocol developed by the creators of XRay, designed specifically to combat high levels of internet censorship. REALITY identifies censorship systems during the TLS handshake, redirecting suspicious traffic seamlessly to legitimate websites like google.com while providing genuine TLS certificates. This allows VPN traffic to blend indistinguishably with regular web traffic without special configuration.
 Unlike older protocols such as VMess, VLESS, and XTLS-Vision, REALITY incorporates an advanced built-in &quot;friend-or-foe&quot; detection mechanism, effectively protecting against DPI and other traffic analysis methods.
 
@@ -962,7 +6939,7 @@ REALITY распознаёт системы блокировки во время
 * Работает по протоколу TCP</translation>
     </message>
     <message>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="174"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="174"/>
         <source>IKEv2, combined with IPSec encryption, is a modern and reliable VPN protocol. It reconnects quickly when switching networks or devices, making it ideal for dynamic network environments. While it provides good security and speed, it&apos;s easily recognized by DPI systems and susceptible to blocking.
 
 Features:
@@ -981,7 +6958,7 @@ Features:
 * Работает по UDP (порты 500 и 4500)</translation>
     </message>
     <message>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="187"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="187"/>
         <source>After installation, Amnezia will create a
 
  file storage on your server. You will be able to access it using
@@ -1027,191 +7004,295 @@ FileZilla или другие SFTP-клиенты, а также смонтир�
 			</translation>
     </message>
     <message>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="110"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="110"/>
         <source>Deploy a WordPress site on the Tor network in two clicks.</source>
         <translation>Разверните сайт на WordPress в сети Tor в два клика.</translation>
     </message>
     <message>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="112"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="112"/>
         <source>Replace the current DNS server with your own. This will increase your privacy level.</source>
         <translation>Замените текущий DNS-сервер на свой собственный. Это повысит уровень вашей конфиденциальности.</translation>
     </message>
     <message>
-        <location filename="../core/utils/errorStrings.cpp" line="12"/>
+        <source>Entry not found</source>
+        <translation type="vanished">Запись не найдена</translation>
+    </message>
+    <message>
+        <source>Access to keychain denied</source>
+        <translation type="vanished">Доступ к брелоку запрещен</translation>
+    </message>
+    <message>
+        <source>No keyring daemon</source>
+        <translation type="vanished">Отсутствует демон брелоков</translation>
+    </message>
+    <message>
+        <source>Already unlocked</source>
+        <translation type="vanished">Уже разблокировано</translation>
+    </message>
+    <message>
+        <source>No such keyring</source>
+        <translation type="vanished">Нет такого брелока</translation>
+    </message>
+    <message>
+        <source>Bad arguments</source>
+        <translation type="vanished">Неверные аргументы</translation>
+    </message>
+    <message>
+        <source>I/O error</source>
+        <translation type="vanished">Ошибка ввода/вывода</translation>
+    </message>
+    <message>
+        <source>Cancelled</source>
+        <translation type="vanished">Отменено</translation>
+    </message>
+    <message>
+        <source>Keyring already exists</source>
+        <translation type="vanished">Брелок уже существует</translation>
+    </message>
+    <message>
+        <source>No match</source>
+        <translation type="vanished">Нет совпадений</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/errorStrings.cpp" line="12"/>
         <source>Unknown error</source>
         <translation>Неизвестная ошибка</translation>
     </message>
     <message>
-        <location filename="../core/protocols/protocolUtils.cpp" line="70"/>
+        <source>error 0x%1: %2</source>
+        <translation type="vanished">Ошибка 0x%1: %2</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/protocols/protocolUtils.cpp" line="70"/>
         <source>SFTP service</source>
         <translation>SFTP-сервис</translation>
     </message>
     <message>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="79"/>
-        <location filename="../core/utils/containers/containerUtils.cpp" line="191"/>
-        <location filename="../core/protocols/protocolUtils.cpp" line="71"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/protocols/protocolUtils.cpp" line="71"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="79"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="191"/>
         <source>SOCKS5 proxy server</source>
         <translation>Прокси-сервер SOCKS5</translation>
     </message>
     <message>
-        <location filename="../core/protocols/protocolUtils.cpp" line="221"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/protocols/protocolUtils.cpp" line="72"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="80"/>
+        <source>MTProxy (Telegram)</source>
+        <translation>MTProxy (Telegram)</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/protocols/protocolUtils.cpp" line="73"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/containers/containerUtils.cpp" line="81"/>
+        <source>Telemt (Telegram)</source>
+        <translation>Telemt (Telegram)</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/models/protocols/awgProtocolConfig.cpp" line="400"/>
+        <source> (version 3)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/models/protocols/awgProtocolConfig.cpp" line="401"/>
         <source> (version 2)</source>
         <translation> (версия 2)</translation>
     </message>
     <message>
-        <location filename="../core/protocols/protocolUtils.cpp" line="222"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/models/protocols/awgProtocolConfig.cpp" line="402"/>
         <source> (version 1.5)</source>
         <translation> (версия 1.5)</translation>
     </message>
     <message>
-        <location filename="../core/utils/serialization/vmess_new.cpp" line="57"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/serialization/vmess_new.cpp" line="57"/>
         <source>vmess:// url is invalid</source>
         <translation>vmess:// URL-адрес недействителен</translation>
     </message>
     <message>
-        <location filename="../core/utils/serialization/vmess_new.cpp" line="82"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/serialization/vmess_new.cpp" line="82"/>
         <source>Invalid streamSettings protocol: </source>
         <translation>Неверный протокол streamSettings: </translation>
     </message>
     <message>
-        <location filename="../core/utils/serialization/vmess_new.cpp" line="148"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/serialization/vmess_new.cpp" line="148"/>
         <source>Unknown transport method: </source>
         <translation>Неизвестный метод транспорта: </translation>
     </message>
     <message>
-        <location filename="../core/utils/serialization/vmess.cpp" line="130"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/serialization/vmess.cpp" line="130"/>
         <source>VMess string should start with &apos;vmess://&apos;</source>
         <translation>Строка VMess должна начинаться с &apos;vmess://&apos;</translation>
     </message>
     <message>
-        <location filename="../core/utils/serialization/vmess.cpp" line="137"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/serialization/vmess.cpp" line="137"/>
         <source>VMess string should be a valid base64 string</source>
         <translation>Строка VMess должна быть действительной base64-строкой</translation>
     </message>
     <message>
-        <location filename="../core/utils/serialization/vmess.cpp" line="154"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/serialization/vmess.cpp" line="154"/>
         <source>JSON should not be empty</source>
         <translation>JSON не должен быть пустым</translation>
     </message>
     <message>
-        <location filename="../core/utils/serialization/vless.cpp" line="45"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/serialization/vless.cpp" line="45"/>
         <source>VLESS link should start with vless://</source>
         <translation>Ссылка VLESS должна начинаться с vless://</translation>
     </message>
     <message>
-        <location filename="../core/utils/serialization/vless.cpp" line="53"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/serialization/vless.cpp" line="53"/>
         <source>link parse failed: %1</source>
         <translation>не удалось выполнить разбор ссылки: %1</translation>
     </message>
     <message>
-        <location filename="../core/utils/serialization/vless.cpp" line="61"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/serialization/vless.cpp" line="61"/>
         <source>empty host</source>
         <translation>пустой хост</translation>
     </message>
     <message>
-        <location filename="../core/utils/serialization/vless.cpp" line="70"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/serialization/vless.cpp" line="70"/>
         <source>missing port</source>
         <translation>отсутствует порт</translation>
     </message>
     <message>
-        <location filename="../core/utils/serialization/vless.cpp" line="85"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/serialization/vless.cpp" line="85"/>
         <source>missing uuid</source>
         <translation>отсутствует UUID</translation>
     </message>
     <message>
-        <location filename="../core/utils/serialization/ssd.cpp" line="54"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/serialization/ssd.cpp" line="54"/>
         <source>Invalid ssd link: json: field %1 must exist</source>
         <translation>Неверная SSD-ссылка: JSON: поле %1 должно существовать</translation>
     </message>
     <message>
-        <location filename="../core/utils/serialization/ssd.cpp" line="61"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/serialization/ssd.cpp" line="61"/>
         <source>Invalid ssd link: json: field %1 must be valid port number</source>
         <translation>Неверная SSD-ссылка: JSON: поле %1 должно быть действительным номером порта</translation>
     </message>
     <message>
-        <location filename="../core/utils/serialization/ssd.cpp" line="68"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/serialization/ssd.cpp" line="68"/>
         <source>Invalid ssd link: json: field %1 must be of type &apos;string&apos;</source>
         <translation>Неверная SSD-ссылка: JSON: поле %1 должно иметь тип &apos;string&apos;</translation>
     </message>
     <message>
-        <location filename="../core/utils/serialization/ssd.cpp" line="75"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/serialization/ssd.cpp" line="75"/>
         <source>Invalid ssd link: json: field %1 must be an array</source>
         <translation>Неверная SSD-ссылка: JSON: поле %1 должно быть массивом</translation>
     </message>
     <message>
-        <location filename="../core/utils/serialization/ssd.cpp" line="82"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/serialization/ssd.cpp" line="82"/>
         <source>Skipping invalid ssd server: server must be an object</source>
         <translation>Пропуск недействительного SSD-сервера: сервер должен быть объектом</translation>
     </message>
     <message>
-        <location filename="../core/utils/serialization/ssd.cpp" line="88"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/serialization/ssd.cpp" line="88"/>
         <source>Skipping invalid ssd server: missing required field %1</source>
         <translation>Пропуск недействительного SSD-сервера: отсутствует обязательное поле %1</translation>
     </message>
     <message>
-        <location filename="../core/utils/serialization/ssd.cpp" line="95"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/serialization/ssd.cpp" line="95"/>
         <source>Skipping invalid ssd server: field %1 should be of type &apos;string&apos;</source>
         <translation>Пропуск недействительного SSD-сервера: поле %1 должно иметь тип &apos;string&apos;</translation>
     </message>
     <message>
-        <location filename="../core/utils/serialization/ssd.cpp" line="104"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/serialization/ssd.cpp" line="104"/>
         <source>Invalid ssd link: should begin with ssd://</source>
         <translation>Неверная SSD-ссылка: должна начинаться с ssd://</translation>
     </message>
     <message>
-        <location filename="../core/utils/serialization/ssd.cpp" line="114"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/serialization/ssd.cpp" line="114"/>
         <source>Invalid ssd link: base64 parse failed</source>
         <translation>Неверная SSD-ссылка: не удалось выполнить разбор base64</translation>
     </message>
     <message>
-        <location filename="../core/utils/serialization/ssd.cpp" line="121"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/serialization/ssd.cpp" line="121"/>
         <source>Invalid ssd link: json parse failed</source>
         <translation>Неверная SSD-ссылка: не удалось выполнить разбор JSON</translation>
     </message>
     <message>
-        <location filename="../core/utils/serialization/ssd.cpp" line="144"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/serialization/ssd.cpp" line="144"/>
         <source>Invalid ssd link: rc4-md5 encryption is not supported by v2ray-core</source>
         <translation>Неверная SSD-ссылка: шифрование rc4-md5 не поддерживается v2ray-core</translation>
     </message>
     <message>
-        <location filename="../core/utils/serialization/ss.cpp" line="51"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/serialization/ss.cpp" line="51"/>
         <source>SS URI is too short</source>
         <translation>SS URI слишком короткий</translation>
     </message>
     <message>
-        <location filename="../core/utils/serialization/ss.cpp" line="74"/>
-        <location filename="../core/utils/serialization/ss.cpp" line="109"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/serialization/ss.cpp" line="74"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/serialization/ss.cpp" line="109"/>
         <source>Can&apos;t find the colon separator between method and password</source>
         <translation>Невозможно найти разделитель-двоеточие между методом и паролем</translation>
     </message>
     <message>
-        <location filename="../core/utils/serialization/ss.cpp" line="83"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/serialization/ss.cpp" line="83"/>
         <source>Can&apos;t find the at separator between password and hostname</source>
         <translation>Невозможно найти разделитель-собаку между паролем и именем хоста</translation>
     </message>
     <message>
-        <location filename="../core/utils/serialization/ss.cpp" line="92"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/utils/serialization/ss.cpp" line="92"/>
         <source>Can&apos;t find the colon separator between hostname and port</source>
         <translation>Невозможно найти разделитель-двоеточие между именем хоста и портом</translation>
+    </message>
+    <message>
+        <source>AmneziaWG Legacy is a outdated version of AmneziaWG protocol. To upgrade, install AmneziaWG and recreate users.</source>
+        <translation type="vanished">AmneziaWG Legacy является устаревшей версией протокола AmneziaWG. Для обновления установите AmneziaWG и пересоздайте пользователей.</translation>
+    </message>
+</context>
+<context>
+    <name>RenameServerDrawer</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Components/RenameServerDrawer.qml" line="30"/>
+        <source>Server name</source>
+        <translation>Имя сервера</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Components/RenameServerDrawer.qml" line="41"/>
+        <source>Save</source>
+        <translation>Сохранить</translation>
     </message>
 </context>
 <context>
     <name>SecureServersRepository</name>
     <message>
-        <location filename="../core/repositories/secureServersRepository.cpp" line="212"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/repositories/secureServersRepository.cpp" line="212"/>
         <source>Server</source>
-        <translation>Сервер</translation>
+        <translation type="unfinished">Сервер</translation>
+    </message>
+</context>
+<context>
+    <name>SelectLanguageDrawer</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Components/SelectLanguageDrawer.qml" line="48"/>
+        <source>Choose language</source>
+        <translation>Выберите язык</translation>
+    </message>
+</context>
+<context>
+    <name>ServersListView</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Components/ServersListView.qml" line="70"/>
+        <source>Subscription expired. Please renew</source>
+        <translation>Подписка закончилась. Пожалуйста, продлите её</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Components/ServersListView.qml" line="70"/>
+        <source>Subscription expiring soon</source>
+        <translation>Подписка скоро закончится</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Components/ServersListView.qml" line="83"/>
+        <source>Unable change server while there is an active connection</source>
+        <translation>Невозможно изменить сервер во время активного соединения</translation>
     </message>
 </context>
 <context>
     <name>ServersUiController</name>
     <message>
-        <location filename="../ui/controllers/serversUiController.cpp" line="96"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/serversUiController.cpp" line="98"/>
         <source>Legacy API v1 configs are no longer supported. Remove this server to continue.</source>
         <translation>Устаревшие конфигурации API v1 больше не поддерживаются. Удалите этот сервер чтобы продолжить.</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/serversUiController.cpp" line="97"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/serversUiController.cpp" line="99"/>
         <source>Use the remove action to delete this legacy config.</source>
         <translation>Воспользуйтесь действием &quot;Удалить&quot; чтобы удалить эту устаревшую конфигурацию.</translation>
     </message>
@@ -1219,135 +7300,243 @@ FileZilla или другие SFTP-клиенты, а также смонтир�
 <context>
     <name>ServicesCatalogController</name>
     <message>
-        <location filename="../core/controllers/api/servicesCatalogController.cpp" line="176"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/controllers/api/servicesCatalogController.cpp" line="176"/>
         <source>%1/mo</source>
         <comment>IAP: price per month in plan subtitle</comment>
-        <translation>%1/мес</translation>
+        <translation type="unfinished">%1/мес</translation>
     </message>
     <message>
-        <location filename="../core/controllers/api/servicesCatalogController.cpp" line="196"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/controllers/api/servicesCatalogController.cpp" line="196"/>
         <source>from %1 per month</source>
         <comment>IAP: card footer minimum monthly price from StoreKit</comment>
-        <translation>от %1 в месяц</translation>
+        <translation type="unfinished">от %1 в месяц</translation>
+    </message>
+</context>
+<context>
+    <name>Settings</name>
+    <message>
+        <source>Server #1</source>
+        <translation type="vanished">Сервер #1</translation>
+    </message>
+    <message>
+        <source>Server</source>
+        <translation type="vanished">Сервер</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsController</name>
+    <message>
+        <source>Can&apos;t open file: %1</source>
+        <translation type="vanished">Невозможно открыть файл: %1</translation>
+    </message>
+    <message>
+        <source>All settings have been reset to default values</source>
+        <translation type="vanished">Все настройки сброшены до значений по умолчанию</translation>
+    </message>
+    <message>
+        <source>Backup file is corrupted</source>
+        <translation type="vanished">Файл резервной копии поврежден</translation>
     </message>
 </context>
 <context>
     <name>SettingsUiController</name>
     <message>
-        <location filename="../ui/controllers/settingsUiController.cpp" line="183"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/settingsUiController.cpp" line="183"/>
         <source>All settings have been reset to default values</source>
-        <translation>Все настройки сброшены до значений по умолчанию</translation>
+        <translation type="unfinished">Все настройки сброшены до значений по умолчанию</translation>
+    </message>
+</context>
+<context>
+    <name>SitesController</name>
+    <message>
+        <source>Hostname not look like ip adress or domain name</source>
+        <translation type="vanished">Имя хоста не похоже на IP-адрес или доменное имя</translation>
+    </message>
+    <message>
+        <source>New site added: %1</source>
+        <translation type="vanished">Добавлен новый сайт: %1</translation>
+    </message>
+    <message>
+        <source>Site removed: %1</source>
+        <translation type="vanished">Сайт удален: %1</translation>
+    </message>
+    <message>
+        <source>Site list cleared!</source>
+        <translation type="vanished">Список сайтов очищен!</translation>
+    </message>
+    <message>
+        <source>Can&apos;t open file: %1</source>
+        <translation type="vanished">Невозможно открыть файл: %1</translation>
+    </message>
+    <message>
+        <source>Failed to parse JSON data from file: %1</source>
+        <translation type="vanished">Не удалось разобрать JSON-данные из файла: %1</translation>
+    </message>
+    <message>
+        <source>The JSON data is not an array in file: %1</source>
+        <translation type="vanished">JSON-данные не являются массивом в файле: %1</translation>
+    </message>
+    <message>
+        <source>Import completed</source>
+        <translation type="vanished">Импорт завершен</translation>
+    </message>
+    <message>
+        <source>Export completed</source>
+        <translation type="vanished">Экспорт завершен</translation>
+    </message>
+</context>
+<context>
+    <name>SubscriptionExpiredDrawer</name>
+    <message>
+        <source>Amnezia Premium subscription has expired</source>
+        <translation type="vanished">Подписка Amnezia Premium закончилась</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Components/SubscriptionExpiredDrawer.qml" line="46"/>
+        <source> subscription has expired</source>
+        <translation> - срок действия подписки истёк</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Components/SubscriptionExpiredDrawer.qml" line="59"/>
+        <source>Renew to continue using VPN</source>
+        <translation>Продлите подписку, чтобы продолжить использовать VPN</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Components/SubscriptionExpiredDrawer.qml" line="71"/>
+        <source>Renew</source>
+        <translation>Продлить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Components/SubscriptionExpiredDrawer.qml" line="95"/>
+        <source>Support</source>
+        <translation>Поддержка</translation>
     </message>
 </context>
 <context>
     <name>SubscriptionUiController</name>
     <message>
-        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="218"/>
-        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="268"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/api/subscriptionUiController.cpp" line="218"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/api/subscriptionUiController.cpp" line="268"/>
         <source>This subscription has already been added</source>
-        <translation>Эта подписка уже добавлена</translation>
+        <translation type="unfinished">Эта подписка уже добавлена</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="225"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/api/subscriptionUiController.cpp" line="225"/>
         <source>%1 has been added to the app</source>
-        <translation>%1 добавлено в приложение</translation>
+        <translation type="unfinished">%1 добавлено в приложение</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="275"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/api/subscriptionUiController.cpp" line="275"/>
         <source>Subscription restored successfully</source>
         <translation>Подписка успешно восстановлена</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="472"/>
-        <source>This email address has already been used to activate a trial. Like the service? Upgrade to Premium</source>
-        <translation>Этот email уже использовался для активации пробного периода. Понравился сервис? Оформите подписку Premium</translation>
-    </message>
-    <message>
-        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="651"/>
-        <source>API config removed</source>
-        <translation>Конфигурация API удалена</translation>
-    </message>
-    <message>
-        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="303"/>
-        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="356"/>
-        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="479"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/api/subscriptionUiController.cpp" line="303"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/api/subscriptionUiController.cpp" line="356"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/api/subscriptionUiController.cpp" line="479"/>
         <source>%1 installed successfully.</source>
-        <translation>%1 успешно установлен.</translation>
+        <translation type="unfinished">%1 успешно установлен.</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="318"/>
-        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="364"/>
-        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="391"/>
-        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="422"/>
-        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="450"/>
-        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="514"/>
-        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="607"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/api/subscriptionUiController.cpp" line="318"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/api/subscriptionUiController.cpp" line="364"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/api/subscriptionUiController.cpp" line="391"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/api/subscriptionUiController.cpp" line="422"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/api/subscriptionUiController.cpp" line="450"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/api/subscriptionUiController.cpp" line="514"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/api/subscriptionUiController.cpp" line="607"/>
         <source>Enter the digits from the image to continue</source>
         <translation>Введите цифры с изображения чтобы продолжить</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="532"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/api/subscriptionUiController.cpp" line="472"/>
+        <source>This email address has already been used to activate a trial. Like the service? Upgrade to Premium</source>
+        <translation>Этот email уже использовался для активации пробного периода. Понравился сервис? Оформите подписку Premium</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/api/subscriptionUiController.cpp" line="532"/>
         <source>API config reloaded</source>
-        <translation>Конфигурация API перезагружена</translation>
+        <translation type="unfinished">Конфигурация API перезагружена</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="536"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/api/subscriptionUiController.cpp" line="536"/>
         <source>Successfully changed the country of connection to %1</source>
-        <translation>Страна подключения изменена на %1</translation>
+        <translation type="unfinished">Страна подключения изменена на %1</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="660"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/api/subscriptionUiController.cpp" line="651"/>
+        <source>API config removed</source>
+        <translation>Конфигурация API удалена</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/api/subscriptionUiController.cpp" line="660"/>
         <source>Server &apos;%1&apos; was removed</source>
-        <translation>Сервер &apos;%1&apos; был удален</translation>
+        <translation type="unfinished">Сервер &apos;%1&apos; был удален</translation>
     </message>
 </context>
 <context>
     <name>SystemTrayNotificationHandler</name>
     <message>
-        <location filename="../ui/utils/systemTrayNotificationHandler.cpp" line="28"/>
-        <location filename="../ui/utils/systemTrayNotificationHandler.cpp" line="62"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/utils/systemTrayNotificationHandler.cpp" line="26"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/utils/systemTrayNotificationHandler.cpp" line="75"/>
         <source>Show</source>
         <translation>Показать</translation>
     </message>
     <message>
-        <location filename="../ui/utils/systemTrayNotificationHandler.cpp" line="32"/>
-        <location filename="../ui/utils/systemTrayNotificationHandler.cpp" line="63"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/utils/systemTrayNotificationHandler.cpp" line="30"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/utils/systemTrayNotificationHandler.cpp" line="76"/>
         <source>Connect</source>
         <translation>Подключиться</translation>
     </message>
     <message>
-        <location filename="../ui/utils/systemTrayNotificationHandler.cpp" line="33"/>
-        <location filename="../ui/utils/systemTrayNotificationHandler.cpp" line="64"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/utils/systemTrayNotificationHandler.cpp" line="31"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/utils/systemTrayNotificationHandler.cpp" line="77"/>
         <source>Disconnect</source>
         <translation>Отключиться</translation>
     </message>
     <message>
-        <location filename="../ui/utils/systemTrayNotificationHandler.cpp" line="37"/>
-        <location filename="../ui/utils/systemTrayNotificationHandler.cpp" line="65"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/utils/systemTrayNotificationHandler.cpp" line="35"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/utils/systemTrayNotificationHandler.cpp" line="78"/>
         <source>Visit Website</source>
         <translation>Посетить сайт</translation>
     </message>
     <message>
-        <location filename="../ui/utils/systemTrayNotificationHandler.cpp" line="43"/>
-        <location filename="../ui/utils/systemTrayNotificationHandler.cpp" line="66"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/utils/systemTrayNotificationHandler.cpp" line="41"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/utils/systemTrayNotificationHandler.cpp" line="79"/>
         <source>Quit</source>
         <translation>Закрыть</translation>
     </message>
 </context>
 <context>
+    <name>TermsAndPrivacyText</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Components/TermsAndPrivacyText.qml" line="23"/>
+        <source>By continuing, you agree to the &lt;a href=&quot;%1&quot; style=&quot;color: %3;&quot;&gt;Terms of Use&lt;/a&gt; and &lt;a href=&quot;%2&quot; style=&quot;color: %3;&quot;&gt;Privacy Policy&lt;/a&gt;</source>
+        <translation>Продолжая, вы соглашаетесь с &lt;a href=&quot;%1&quot; style=&quot;color: %3;&quot;&gt;Условиями использования&lt;/a&gt; и &lt;a href=&quot;%2&quot; style=&quot;color: %3;&quot;&gt;Политикой конфиденциальности&lt;/a&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>TextFieldWithHeaderType</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/Controls2/TextFieldWithHeaderType.qml" line="145"/>
+        <source>The field can&apos;t be empty</source>
+        <translation>Поле не может быть пустым</translation>
+    </message>
+</context>
+<context>
     <name>UpdateUiController</name>
     <message>
-        <location filename="../ui/controllers/updateUiController.cpp" line="20"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/updateUiController.cpp" line="20"/>
         <source>New version released: %1</source>
         <translation>Вышла новая версия: %1</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/updateUiController.cpp" line="23"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/updateUiController.cpp" line="23"/>
         <source>New version released: %1 (%2)</source>
         <translation>Вышла новая версия: %1 (%2)</translation>
     </message>
     <message>
-        <location filename="../ui/controllers/updateUiController.cpp" line="34"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/controllers/updateUiController.cpp" line="34"/>
         <source>Failed to load changelog text</source>
         <translation>Не удалось загрузить текст списка изменений</translation>
     </message>
@@ -1355,50 +7544,49 @@ FileZilla или другие SFTP-клиенты, а также смонтир�
 <context>
     <name>VpnConnection</name>
     <message>
-        <location filename="../vpnConnection.cpp" line="513"/>
         <source>Mbps</source>
-        <translation>Мбит/с</translation>
+        <translation type="vanished">Мбит/с</translation>
     </message>
 </context>
 <context>
     <name>VpnProtocol</name>
     <message>
-        <location filename="../core/protocols/vpnProtocol.cpp" line="135"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/protocols/vpnProtocol.cpp" line="135"/>
         <source>Unknown</source>
         <translation>Неизвестный</translation>
     </message>
     <message>
-        <location filename="../core/protocols/vpnProtocol.cpp" line="136"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/protocols/vpnProtocol.cpp" line="136"/>
         <source>Disconnected</source>
         <translation>Отключено</translation>
     </message>
     <message>
-        <location filename="../core/protocols/vpnProtocol.cpp" line="137"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/protocols/vpnProtocol.cpp" line="137"/>
         <source>Preparing</source>
         <translation>Подготовка</translation>
     </message>
     <message>
-        <location filename="../core/protocols/vpnProtocol.cpp" line="138"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/protocols/vpnProtocol.cpp" line="138"/>
         <source>Connecting...</source>
         <translation>Подключение...</translation>
     </message>
     <message>
-        <location filename="../core/protocols/vpnProtocol.cpp" line="139"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/protocols/vpnProtocol.cpp" line="139"/>
         <source>Connected</source>
         <translation>Подключено</translation>
     </message>
     <message>
-        <location filename="../core/protocols/vpnProtocol.cpp" line="140"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/protocols/vpnProtocol.cpp" line="140"/>
         <source>Disconnecting...</source>
         <translation>Отключение...</translation>
     </message>
     <message>
-        <location filename="../core/protocols/vpnProtocol.cpp" line="141"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/protocols/vpnProtocol.cpp" line="141"/>
         <source>Reconnecting...</source>
         <translation>Переподключение...</translation>
     </message>
     <message>
-        <location filename="../core/protocols/vpnProtocol.cpp" line="142"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/core/protocols/vpnProtocol.cpp" line="142"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
@@ -1406,22 +7594,22 @@ FileZilla или другие SFTP-клиенты, а также смонтир�
 <context>
     <name>XrayConfigModel</name>
     <message>
-        <location filename="../ui/models/protocols/xrayConfigModel.cpp" line="655"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/models/protocols/xrayConfigModel.cpp" line="707"/>
         <source>Port must be in the range of 1 to 65535</source>
         <translation>Порт должен быть в диапазоне от 1 до 65535</translation>
     </message>
     <message>
-        <location filename="../ui/models/protocols/xrayConfigModel.cpp" line="661"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/models/protocols/xrayConfigModel.cpp" line="713"/>
         <source>SNI: enter a valid IP address or domain name</source>
         <translation>SNI: введите действительный IP-адрес или доменное имя</translation>
     </message>
     <message>
-        <location filename="../ui/models/protocols/xrayConfigModel.cpp" line="667"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/models/protocols/xrayConfigModel.cpp" line="719"/>
         <source>Host: enter a valid IP address or domain name</source>
         <translation>Хост: введите действительный IP-адрес или доменное имя</translation>
     </message>
     <message>
-        <location filename="../ui/models/protocols/xrayConfigModel.cpp" line="670"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/models/protocols/xrayConfigModel.cpp" line="722"/>
         <source>Path must start with &quot;/&quot;</source>
         <translation>Путь должен начинаться с &quot;/&quot;</translation>
     </message>
@@ -1429,9 +7617,60 @@ FileZilla или другие SFTP-клиенты, а также смонтир�
 <context>
     <name>XrayConfigSnapshotsModel</name>
     <message>
-        <location filename="../ui/models/protocols/xrayConfigSnapshotsModel.cpp" line="153"/>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/models/protocols/xrayConfigSnapshotsModel.cpp" line="153"/>
         <source>Invalid JSON format</source>
         <translation>Неверный формат JSON</translation>
+    </message>
+</context>
+<context>
+    <name>amnezia::ContainerProps</name>
+    <message>
+        <source>Automatic</source>
+        <translation type="vanished">Автоматическая</translation>
+    </message>
+    <message>
+        <source>AmneziaWG protocol will be installed. It provides high connection speed and ensures stable operation even in the most challenging network conditions.</source>
+        <translation type="vanished">Будет установлен протокол AmneziaWG. Он обеспечивает высокую скорость соединения и гарантирует стабильную работу даже в самых сложных условиях.</translation>
+    </message>
+</context>
+<context>
+    <name>main2</name>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/main2.qml" line="285"/>
+        <source>Private key passphrase</source>
+        <translation>Парольная фраза для закрытого ключа</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/main2.qml" line="306"/>
+        <source>Save</source>
+        <translation>Сохранить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/main2.qml" line="400"/>
+        <source>This subscription format is no longer supported</source>
+        <translation>Этот формат подписки больше не поддерживается</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/main2.qml" line="401"/>
+        <source>This legacy Amnezia subscription type can no longer be used to connect in this application version.
+Remove the server from the app to continue.</source>
+        <translation>Этот устаревший тип подписки Amnezia больше нельзя использовать для подключения в этой версии приложения.
+Удалите сервер из приложения, чтобы продолжить.</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/main2.qml" line="402"/>
+        <source>Continue</source>
+        <translation type="unfinished">Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/main2.qml" line="403"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Отменить</translation>
+    </message>
+    <message>
+        <location filename="../../../../../../../Desktop/Claude/amnezia-client/client/ui/qml/main2.qml" line="407"/>
+        <source>Cannot remove server during active connection</source>
+        <translation type="unfinished">Невозможно удалить сервер во время активного соединения</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
ru_RU.ts on dev has 237 entries in 28 contexts, all of them from C++, and the QML contexts are missing, so the pages themselves are untranslated. On the same commit uk_UA has 979 entries and zh_CN has 1104.

Looks accidental. lupdate over the C++ folders alone finds 216 texts in 28 contexts, which is what dev has, and adding client/ui/qml finds 1224 in 128. The QML files are not sources of the target, they only reach the build through qml.qrc.

Regenerated with lupdate over both, starting from the last revision that still had the QML contexts, and the gaps filled from my #2923. Nothing that is on dev today is removed or reworded, I checked entry by entry. lrelease gives 234 translations on dev and 1071 finished here.

The screenshots run the same strings, copied from the real pages, through the two compiled .qm files. Left is before, right is dev today.

| Before | Today on dev |
| --- | --- |
| ![translated](https://raw.githubusercontent.com/WkdXeqtr/amnezia-client/pr-screens-tv-focus/screens/ru_proof_before.png) | ![untranslated](https://raw.githubusercontent.com/WkdXeqtr/amnezia-client/pr-screens-tv-focus/screens/ru_proof_after.png) |
