### PR TITLE
Use Firefox fingerprint for REALITY compatibility

### DIFF
--- a/client/core/configurators/xrayConfigurator.cpp
+++ b/client/core/configurators/xrayConfigurator.cpp
@@ -119,6 +119,36 @@ namespace {
             c.replace(legacyListen, listenOk);
             changed = true;
         }
+
+        QJsonParseError parseError;
+        QJsonDocument document = QJsonDocument::fromJson(c.toUtf8(), &parseError);
+        if (parseError.error == QJsonParseError::NoError && document.isObject()) {
+            QJsonObject root = document.object();
+            QJsonArray outbounds = root.value(amnezia::protocols::xray::outbounds).toArray();
+            for (qsizetype i = 0; i < outbounds.size(); ++i) {
+                QJsonObject outbound = outbounds.at(i).toObject();
+                QJsonObject stream = outbound.value(amnezia::protocols::xray::streamSettings).toObject();
+                if (stream.value(amnezia::protocols::xray::security).toString() != QLatin1String("reality"))
+                    continue;
+
+                QJsonObject reality = stream.value(amnezia::protocols::xray::realitySettings).toObject();
+                if (reality.value(amnezia::protocols::xray::fingerprint).toString()
+                        .compare(QLatin1String("chrome"), Qt::CaseInsensitive) != 0) {
+                    continue;
+                }
+
+                reality[amnezia::protocols::xray::fingerprint] =
+                        QString::fromLatin1(amnezia::protocols::xray::defaultFingerprint);
+                stream[amnezia::protocols::xray::realitySettings] = reality;
+                outbound[amnezia::protocols::xray::streamSettings] = stream;
+                outbounds[i] = outbound;
+                changed = true;
+            }
+            if (changed) {
+                root[amnezia::protocols::xray::outbounds] = outbounds;
+                c = QJsonDocument(root).toJson(QJsonDocument::Compact);
+            }
+        }
         if (changed) {
             pc.setNativeConfig(c);
         }

--- a/client/core/controllers/selfhosted/exportController.cpp
+++ b/client/core/controllers/selfhosted/exportController.cpp
@@ -321,7 +321,8 @@ ExportController::ExportResult ExportController::generateXrayConfig(const QStrin
         vlessServer.serverName = realitySettings.value(amnezia::protocols::xray::serverName).toString();
         vlessServer.publicKey = realitySettings.value(amnezia::protocols::xray::publicKey).toString();
         vlessServer.shortId = realitySettings.value(amnezia::protocols::xray::shortId).toString();
-        vlessServer.fingerprint = realitySettings.value(amnezia::protocols::xray::fingerprint).toString("chrome");
+        vlessServer.fingerprint = realitySettings.value(amnezia::protocols::xray::fingerprint)
+                                          .toString(amnezia::protocols::xray::defaultFingerprint);
         vlessServer.spiderX = realitySettings.value(amnezia::protocols::xray::spiderX).toString("");
     } else if (vlessServer.security == "tls") {
         QJsonObject tlsSettings = streamSettings.value("tlsSettings").toObject();

--- a/client/core/protocols/xrayProtocol.cpp
+++ b/client/core/protocols/xrayProtocol.cpp
@@ -9,6 +9,7 @@
 #include "ipc.h"
 
 #include <QCryptographicHash>
+#include <QJsonArray>
 #include <QJsonDocument>
 #include <QTimer>
 #include <QJsonObject>
@@ -80,6 +81,32 @@ ErrorCode XrayProtocol::start()
     m_socksUser = creds.username;
     m_socksPassword = creds.password;
     m_socksPort = creds.port;
+
+    // Compatibility workaround for amnezia-xray-bindings 1.3.0: REALITY with
+    // the chrome uTLS fingerprint may connect successfully but blackhole all
+    // payload traffic. Normalize existing/imported profiles at runtime too.
+    QJsonArray outbounds = m_xrayConfig.value(amnezia::protocols::xray::outbounds).toArray();
+    for (qsizetype i = 0; i < outbounds.size(); ++i) {
+        QJsonObject outbound = outbounds.at(i).toObject();
+        QJsonObject stream = outbound.value(amnezia::protocols::xray::streamSettings).toObject();
+        if (stream.value(amnezia::protocols::xray::security).toString() != QLatin1String("reality"))
+            continue;
+
+        QJsonObject reality = stream.value(amnezia::protocols::xray::realitySettings).toObject();
+        if (reality.value(amnezia::protocols::xray::fingerprint).toString()
+                .compare(QLatin1String("chrome"), Qt::CaseInsensitive) != 0) {
+            continue;
+        }
+
+        reality[amnezia::protocols::xray::fingerprint] =
+                QString::fromLatin1(amnezia::protocols::xray::defaultFingerprint);
+        stream[amnezia::protocols::xray::realitySettings] = reality;
+        outbound[amnezia::protocols::xray::streamSettings] = stream;
+        outbounds[i] = outbound;
+        qWarning() << "XrayProtocol: replaced incompatible REALITY chrome fingerprint with"
+                   << amnezia::protocols::xray::defaultFingerprint;
+    }
+    m_xrayConfig[amnezia::protocols::xray::outbounds] = outbounds;
 
     QString xrayConfigStr = QJsonDocument(m_xrayConfig).toJson(QJsonDocument::Compact);
     if (xrayConfigStr.isEmpty()) {

--- a/client/core/utils/constants/protocolConstants.h
+++ b/client/core/utils/constants/protocolConstants.h
@@ -63,7 +63,11 @@ namespace amnezia
             constexpr char defaultSecurity[] = "reality";
             constexpr char defaultFlow[] = "xtls-rprx-vision";
             constexpr char defaultTransport[] = "raw";
-            constexpr char defaultFingerprint[] = "chrome";
+            // The Xray bindings bundled with AmneziaVPN 5.0.0.5 can establish a
+            // REALITY connection with the chrome fingerprint while silently
+            // blackholing payload traffic. Firefox is interoperable with the
+            // same REALITY servers and is the safe compatibility default.
+            constexpr char defaultFingerprint[] = "firefox";
             constexpr char defaultSni[] = "www.googletagmanager.com";
             constexpr char defaultAlpn[] = "HTTP/2";
 

--- a/client/core/utils/serialization/transfer.h
+++ b/client/core/utils/serialization/transfer.h
@@ -54,7 +54,7 @@ struct VlessServerObject
     QString serverName;  // SNI
     QString publicKey;
     QString shortId;
-    QString fingerprint = "chrome";
+    QString fingerprint = "firefox";
     QString spiderX = "";
     JSONSTRUCT_COMPARE(VlessServerObject, address, id, port, flow, encryption)
     JSONSTRUCT_REGISTER(VlessServerObject, F(address, id, port, flow, encryption, network, security, serverName, publicKey, shortId, fingerprint, spiderX))

--- a/client/server_scripts/xray/template.json
+++ b/client/server_scripts/xray/template.json
@@ -34,7 +34,7 @@
                 "network": "tcp",
                 "security": "reality",
                 "realitySettings": {
-                    "fingerprint": "chrome",
+                    "fingerprint": "firefox",
                     "serverName": "$XRAY_SITE_NAME",
                     "publicKey": "$XRAY_PUBLIC_KEY",
                     "shortId": "$XRAY_SHORT_ID",


### PR DESCRIPTION
## What changed

- use `firefox` as the default uTLS fingerprint for VLESS REALITY profiles;
- normalize REALITY profiles using `chrome` when native configs are imported or migrated;
- apply the same compatibility normalization at runtime so existing desktop profiles recover without being recreated;
- keep generated and exported configurations consistent with the new default.

## Why

On AmneziaVPN 5.0.0.5 for Windows, a REALITY connection using the `chrome` fingerprint can report a successful connection while all payload traffic is blackholed. DNS requests and HTTP traffic time out even though the tunnel interface and TCP connection are present.

Changing only the fingerprint from `chrome` to `firefox` makes the same VLESS REALITY configuration and server work. This is consistent with the behavior reported in #2704.

This PR is deliberately presented as a compatibility workaround. It does not claim to fix the underlying issue in amnezia-xray-bindings, Xray core, or uTLS.

## User impact

New, imported, and existing VLESS REALITY profiles no longer get stuck in a false "connected" state with no usable traffic when they use the affected Chrome fingerprint.

## Validation

- built the Windows x64 Release client from tag `5.0.0.5`;
- packaged the result successfully with Qt Installer Framework;
- tested the same REALITY server/configuration on Windows:
  - `chrome`: connected status, but DNS and payload traffic timed out;
  - `firefox`: DNS resolution, HTTPS browsing, and public-IP verification worked through the VPS;
- `git diff --check` passes.
