### PR TITLE
fix(windows): ignore unroutable split tunnel addresses

### DIFF
--- a/client/platforms/windows/daemon/windowssplittunnel.cpp
+++ b/client/platforms/windows/daemon/windowssplittunnel.cpp
@@ -514,6 +514,7 @@ bool WindowsSplitTunnel::getAddress(int adapterIndex, IN_ADDR* out_ipv4,
   }
   auto guard = qScopeGuard([table]() { FreeMibTable(table); });
 
+  // Select addresses Windows can use as a source on this interface.
   const MIB_UNICASTIPADDRESS_ROW* bestIpv4 = nullptr;
   const MIB_UNICASTIPADDRESS_ROW* bestIpv6 = nullptr;
   for (ULONG i = 0; i < table->NumEntries; i++) {
@@ -528,6 +529,7 @@ bool WindowsSplitTunnel::getAddress(int adapterIndex, IN_ADDR* out_ipv4,
       if (!addr.isGlobal()) {
         continue;
       }
+      // Prefer an address that completed duplicate-address detection.
       if (bestIpv4 != nullptr && bestIpv4->DadState >= row->DadState) {
         continue;
       }
@@ -543,6 +545,7 @@ bool WindowsSplitTunnel::getAddress(int adapterIndex, IN_ADDR* out_ipv4,
         continue;
       }
       QHostAddress other(bestIpv6->Address.Ipv6.sin6_addr.s6_addr);
+      // Prefer globally routable IPv6 over unique-local addresses.
       if (addr.isUniqueLocalUnicast() && !other.isUniqueLocalUnicast()) {
         continue;
       }

--- a/client/platforms/windows/daemon/windowssplittunnel.cpp
+++ b/client/platforms/windows/daemon/windowssplittunnel.cpp
@@ -4,8 +4,10 @@
 
 #include "windowssplittunnel.h"
 
+#include <iphlpapi.h>
 #include <qassert.h>
 
+#include <cstring>
 #include <memory>
 
 #include "../windowscommons.h"
@@ -22,9 +24,10 @@
 
 #include <QCoreApplication>
 #include <QFileInfo>
-#include <QNetworkInterface>
+#include <QHostAddress>
 #include <QScopeGuard>
 #include <QUrl>
+#include <QtEndian>
 
 #pragma region
 
@@ -502,32 +505,64 @@ std::vector<std::byte> WindowsSplitTunnel::generateIPConfiguration(
 }
 bool WindowsSplitTunnel::getAddress(int adapterIndex, IN_ADDR* out_ipv4,
                                     IN6_ADDR* out_ipv6) {
-  QNetworkInterface target =
-      QNetworkInterface::interfaceFromIndex(adapterIndex);
-  logger.debug() << "Getting adapter info for:" << target.humanReadableName();
-
-  auto get = [&target](QAbstractSocket::NetworkLayerProtocol protocol) {
-    for (auto address : target.addressEntries()) {
-      if (address.ip().protocol() != protocol) {
-        continue;
-      }
-      return address.ip().toString().toStdWString();
-    }
-    return std::wstring{};
-  };
-  auto ipv4 = get(QAbstractSocket::IPv4Protocol);
-  auto ipv6 = get(QAbstractSocket::IPv6Protocol);
-
-  if (InetPtonW(AF_INET, ipv4.c_str(), out_ipv4) != 1) {
-    logger.debug() << "Ipv4 Conversation error" << WSAGetLastError();
+  MIB_UNICASTIPADDRESS_TABLE* table;
+  DWORD result = GetUnicastIpAddressTable(AF_UNSPEC, &table);
+  if (result != NO_ERROR) {
+    logger.warning() << "GetUnicastIpAddressTable() failed:"
+                     << WindowsUtils::getErrorMessage(result);
     return false;
   }
-  if (ipv6.empty()) {
-    std::memset(out_ipv6, 0x00, sizeof(IN6_ADDR));
-    return true;
+  auto guard = qScopeGuard([table]() { FreeMibTable(table); });
+
+  const MIB_UNICASTIPADDRESS_ROW* bestIpv4 = nullptr;
+  const MIB_UNICASTIPADDRESS_ROW* bestIpv6 = nullptr;
+  for (ULONG i = 0; i < table->NumEntries; i++) {
+    const MIB_UNICASTIPADDRESS_ROW* row = &table->Table[i];
+    if (row->InterfaceIndex != adapterIndex || row->SkipAsSource) {
+      continue;
+    }
+
+    if (row->Address.si_family == AF_INET) {
+      quint32 rawAddr = row->Address.Ipv4.sin_addr.s_addr;
+      QHostAddress addr(qFromBigEndian<quint32>(rawAddr));
+      if (!addr.isGlobal()) {
+        continue;
+      }
+      if (bestIpv4 != nullptr && bestIpv4->DadState >= row->DadState) {
+        continue;
+      }
+      bestIpv4 = row;
+    } else if (row->Address.si_family == AF_INET6) {
+      QHostAddress addr(row->Address.Ipv6.sin6_addr.s6_addr);
+      if (!addr.isGlobal()) {
+        continue;
+      }
+
+      if (bestIpv6 == nullptr) {
+        bestIpv6 = row;
+        continue;
+      }
+      QHostAddress other(bestIpv6->Address.Ipv6.sin6_addr.s6_addr);
+      if (addr.isUniqueLocalUnicast() && !other.isUniqueLocalUnicast()) {
+        continue;
+      }
+      if (bestIpv6->DadState >= row->DadState) {
+        continue;
+      }
+      bestIpv6 = row;
+    }
   }
-  if (InetPtonW(AF_INET6, ipv6.c_str(), out_ipv6) != 1) {
-    logger.debug() << "Ipv6 Conversation error" << WSAGetLastError();
+
+  if (bestIpv4 == nullptr) {
+    return false;
+  }
+  out_ipv4->s_addr = bestIpv4->Address.Ipv4.sin_addr.s_addr;
+
+  if (bestIpv6 != nullptr) {
+    std::memcpy(out_ipv6, &bestIpv6->Address.Ipv6.sin6_addr,
+                sizeof(IN6_ADDR));
+  } else {
+    std::memset(out_ipv6, 0x00, sizeof(IN6_ADDR));
   }
   return true;
 }


### PR DESCRIPTION
## Summary

- read split-tunnel source addresses from the Windows unicast address table
- ignore addresses marked `SkipAsSource` and non-routable addresses such as link-local IPv6
- prefer usable addresses with the best duplicate-address-detection state and zero an unavailable IPv6 address

## Problem

`WindowsSplitTunnel::getAddress()` selected the first IPv4 and IPv6 entries exposed by `QNetworkInterface`. On common IPv4 networks where Windows assigns only a link-local `fe80::/10` IPv6 address, that unusable address was registered with the split-tunnel driver as the physical internet address. Excluded applications could then lose connectivity or continue through the VPN.

The selection now follows Windows source-address metadata and only registers addresses that can actually be used for outbound traffic. This ports the relevant address-selection fix from [Mozilla VPN #10225](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10225), whose split-tunnel implementation is the source of this code.

This addresses the link-local source-selection failure behind reports such as #2165 and #2586. It is independent of the on-link route-capture fix in #2835.

## Verification

- `git diff --check origin/dev...HEAD`
- verified the affected topology locally: the physical adapter has a preferred RFC 1918 IPv4 address and only a preferred link-local IPv6 address; the new policy selects IPv4 and leaves IPv6 unset
- compared address filtering and DAD-state preference with the reviewed Mozilla implementation
- confirmed the patch does not alter firewall rules or route capture
- Codacy Static Code Analysis passed with no annotations
