### PR TITLE
fix: preserve site split tunneling for IPv4-only AWG configs

### DIFF
--- a/client/mozilla/localsocketcontroller.cpp
+++ b/client/mozilla/localsocketcontroller.cpp
@@ -177,8 +177,9 @@ void LocalSocketController::activate(const QJsonObject &rawConfig) {
 
   QJsonArray plainAllowedIP = wgConfig.value(amnezia::configKey::allowedIps).toArray();
   QJsonArray defaultAllowedIP = { "0.0.0.0/0", "::/0" };
+  const bool useOnlyForwardSites = splitTunnelType == 1 && plainAllowedIP.contains("0.0.0.0/0");
 
-  if (plainAllowedIP != defaultAllowedIP && !plainAllowedIP.isEmpty()) {
+  if (plainAllowedIP != defaultAllowedIP && !plainAllowedIP.isEmpty() && !useOnlyForwardSites) {
     // Use AllowedIP list from WG config because of higher priority
     for (auto v : plainAllowedIP) {
       QString ipRange = v.toString();

--- a/client/vpnConnection.cpp
+++ b/client/vpnConnection.cpp
@@ -417,7 +417,11 @@ void VpnConnection::appendSplitTunnelingConfig()
         allowSiteBasedSplitTunneling = false;
         auto configData = m_vpnConfiguration.value(protocolName + "_config_data").toObject();
         if (configData.value(configKey::allowedIps).isString()) {
-            QJsonArray allowedIpsJsonArray = QJsonArray::fromStringList(configData.value(configKey::allowedIps).toString().split(", "));
+            QJsonArray allowedIpsJsonArray;
+            const QString allowedIps = configData.value(configKey::allowedIps).toString();
+            for (const QString &allowedIp : allowedIps.split(",", Qt::SkipEmptyParts)) {
+                allowedIpsJsonArray.append(allowedIp.trimmed());
+            }
             configData.insert(configKey::allowedIps, allowedIpsJsonArray);
             m_vpnConfiguration.insert(protocolName + "_config_data", configData);
         } else if (configData.value(configKey::allowedIps).isUndefined()) {
@@ -454,7 +458,7 @@ void VpnConnection::appendSplitTunnelingConfig()
         }
 
         QJsonArray allowedIpsJsonArray = configData.value(configKey::allowedIps).toArray();
-        if (allowedIpsJsonArray.contains("0.0.0.0/0") && allowedIpsJsonArray.contains("::/0")) {
+        if (allowedIpsJsonArray.contains("0.0.0.0/0")) {
             allowSiteBasedSplitTunneling = true;
         }
     }
@@ -464,7 +468,11 @@ void VpnConnection::appendSplitTunnelingConfig()
     if (m_appSettingsRepository->isSitesSplitTunnelingEnabled()) {
         routeMode = m_appSettingsRepository->routeMode();
 
-        if (allowSiteBasedSplitTunneling) {
+        if (!allowSiteBasedSplitTunneling) {
+            qWarning()
+                    << "VpnConnection::appendSplitTunnelingConfig: site split tunneling requires an IPv4 default route";
+            routeMode = amnezia::RouteMode::VpnAllSites;
+        } else {
             QStringList sites;
             const QVariantMap &m = m_appSettingsRepository->vpnSites(routeMode);
             for (auto i = m.constBegin(); i != m.constEnd(); ++i) {


### PR DESCRIPTION
Fixes #2907.

Imported AmneziaWG configurations may contain `0.0.0.0/0` without an IPv6 default route. Treat the IPv4 default route as sufficient for IPv4 site split tunneling, and normalize legacy comma-separated `AllowedIPs` values before checking it.

For the only-forward-sites mode, prefer the selected site list over the imported IPv4 default route. Configurations without an IPv4 default route fall back to full tunnel instead of sending a split mode with an empty site list.

Testing:
- `git diff --check`
- focused route-decision checks for IPv4-only, dual-stack, only-forward-sites, legacy string, and custom-CIDR cases

Not run: end-to-end macOS route test, which requires an imported `amnezia-awg` configuration.
