### PR TITLE
fix(windows): preserve routes from virtual VPN interfaces

### DIFF
--- a/client/platforms/windows/daemon/windowsroutemonitor.cpp
+++ b/client/platforms/windows/daemon/windowsroutemonitor.cpp
@@ -270,6 +270,7 @@ void WindowsRouteMonitor::updateCapturedRoutes(int family, void* ptable) {
     return;
   }
 
+  QHash<quint64, bool> hardwareInterfaces;
   for (ULONG i = 0; i < table->NumEntries; i++) {
     MIB_IPFORWARD_ROW2* row = &table->Table[i];
     // Ignore routes into the VPN interface.
@@ -283,6 +284,25 @@ void WindowsRouteMonitor::updateCapturedRoutes(int family, void* ptable) {
     // Ignore routes of our own creation.
     if ((row->Protocol == MIB_IPPROTO_NETMGMT) &&
         (row->Metric == EXCLUSION_ROUTE_METRIC)) {
+      continue;
+    }
+    // Do not clone routes from other virtual interfaces, such as Cisco
+    // AnyConnect. Keep them on their original interface; cloning them to
+    // Amnezia would redirect the other VPN's control and private-network
+    // traffic.
+    if (!hardwareInterfaces.contains(row->InterfaceLuid.Value)) {
+      MIB_IF_ROW2 interfaceRow{};
+      interfaceRow.InterfaceLuid.Value = row->InterfaceLuid.Value;
+      const bool isHardwareInterface =
+          GetIfEntry2(&interfaceRow) != NO_ERROR ||
+          interfaceRow.InterfaceAndOperStatusFlags.HardwareInterface;
+      hardwareInterfaces.insert(row->InterfaceLuid.Value,
+                                isHardwareInterface);
+    }
+    if (!hardwareInterfaces.value(row->InterfaceLuid.Value)) {
+      logger.debug() << "Skipping route from virtual interface"
+                     << row->InterfaceIndex
+                     << row->DestinationPrefix.PrefixLength;
       continue;
     }
     // Ignore routes which should be excluded.


### PR DESCRIPTION
## Problem

On Windows, when Cisco AnyConnect is already connected and Amnezia is connected afterwards, the Cisco connection can be lost.

## Cause

With default route capture enabled, WindowsRouteMonitor cloned routes from all non-Amnezia interfaces into the Amnezia interface. This included routes owned by virtual VPN adapters, so Cisco control and private-network traffic could be redirected into the Amnezia tunnel.

## Fix

Skip routes whose interface is reported by GetIfEntry2 as a non-hardware interface. The original route remains on its virtual interface. Interface classification is cached by interface LUID.

Hardware-interface routes and Amnezia's own routes keep their existing behavior. If the interface lookup fails, the implementation preserves the previous behavior and treats the route as hardware-backed.

## Validation

- Release 5.0.0.5 build passed.
- Verified that Cisco AnyConnect and Amnezia WireGuard adapters are classified as virtual and Cisco routes are excluded from capture.
- The project has no registered CTest tests.
- Live Cisco AnyConnect + Amnezia connection testing remains to be completed on a Windows host.