### PR TITLE
test: cover CIDR split-tunneling imports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,8 @@ project(${PROJECT} VERSION ${AMNEZIAVPN_VERSION}
         HOMEPAGE_URL "https://amnezia.org/"
 )
 
+include(CTest)
+
 # trigger conan to kick off `conan install` globally
 find_package(OpenSSL REQUIRED)
 if (PREBUILTS_ONLY)
@@ -75,6 +77,10 @@ endif()
 
 
 add_subdirectory(client)
+
+if(BUILD_TESTING AND NOT IOS AND NOT ANDROID AND NOT MACOS_NE)
+    add_subdirectory(tests)
+endif()
 
 if(NOT IOS AND NOT ANDROID AND NOT MACOS_NE)
     add_subdirectory(service)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,44 @@
+find_package(Qt6 REQUIRED COMPONENTS Core Network Test)
+
+qt_add_executable(ip_split_tunneling_controller_test
+    ipSplitTunnelingControllerTest.cpp
+    ${CMAKE_SOURCE_DIR}/client/core/controllers/ipSplitTunnelingController.cpp
+    ${CMAKE_SOURCE_DIR}/client/core/controllers/ipSplitTunnelingController.h
+    ${CMAKE_SOURCE_DIR}/client/core/repositories/secureAppSettingsRepository.cpp
+    ${CMAKE_SOURCE_DIR}/client/core/repositories/secureAppSettingsRepository.h
+    ${CMAKE_SOURCE_DIR}/client/secureQSettings.cpp
+    ${CMAKE_SOURCE_DIR}/client/secureQSettings.h
+    ${CMAKE_SOURCE_DIR}/client/core/utils/networkUtilities.cpp
+    ${CMAKE_SOURCE_DIR}/client/core/utils/networkUtilities.h
+    ${CMAKE_SOURCE_DIR}/common/crypto/cryptoUtils.cpp
+    ${CMAKE_SOURCE_DIR}/common/crypto/cryptoUtils.h
+)
+
+set_target_properties(ip_split_tunneling_controller_test PROPERTIES
+    AUTOMOC ON
+)
+
+target_include_directories(ip_split_tunneling_controller_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/client
+    ${CMAKE_SOURCE_DIR}/common
+    ${CMAKE_SOURCE_DIR}
+    ${CMAKE_BINARY_DIR}/client
+    ${CMAKE_BINARY_DIR}/3rd/qtkeychain
+    ${CMAKE_SOURCE_DIR}/client/3rd/qtkeychain/qtkeychain
+)
+
+target_compile_definitions(ip_split_tunneling_controller_test PRIVATE
+    CLIENT_KEYCHAIN_NAME_STR="AmneziaVPN-Test-Keychain"
+    DEV_AGW_ENDPOINT=""
+)
+
+target_link_libraries(ip_split_tunneling_controller_test PRIVATE
+    Qt6::Core
+    Qt6::Network
+    Qt6::Test
+    qt6keychain
+    OpenSSL::Crypto
+)
+
+add_test(NAME ip_split_tunneling_controller_test
+    COMMAND ip_split_tunneling_controller_test)

--- a/tests/ipSplitTunnelingControllerTest.cpp
+++ b/tests/ipSplitTunnelingControllerTest.cpp
@@ -1,0 +1,111 @@
+#include <QtTest>
+#include <QSettings>
+#include <QTemporaryDir>
+
+#include "core/controllers/ipSplitTunnelingController.h"
+#include "core/repositories/secureAppSettingsRepository.h"
+#include "secureQSettings.h"
+
+class IpSplitTunnelingControllerTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void initTestCase();
+    void init();
+    void cleanup();
+
+    void importPreservesCidr();
+    void manualAddPreservesCidr();
+    void exportAndImportPreservesCidr();
+    void normalizesUrlPathButKeepsDomain();
+
+private:
+    QTemporaryDir m_settingsDir;
+    SecureQSettings *m_settings = nullptr;
+    SecureAppSettingsRepository *m_repository = nullptr;
+    IpSplitTunnelingController *m_controller = nullptr;
+};
+
+void IpSplitTunnelingControllerTest::initTestCase()
+{
+    QVERIFY(m_settingsDir.isValid());
+    QSettings::setDefaultFormat(QSettings::IniFormat);
+    QSettings::setPath(QSettings::IniFormat, QSettings::UserScope, m_settingsDir.path());
+}
+
+void IpSplitTunnelingControllerTest::init()
+{
+    m_settings = new SecureQSettings(
+        QStringLiteral("AmneziaVPN"), QStringLiteral("IpSplitTunnelingControllerTest"), this, false);
+    m_settings->clearSettings();
+    m_repository = new SecureAppSettingsRepository(m_settings, this);
+    m_controller = new IpSplitTunnelingController(m_repository, this);
+}
+
+void IpSplitTunnelingControllerTest::cleanup()
+{
+    delete m_controller;
+    m_controller = nullptr;
+    delete m_repository;
+    m_repository = nullptr;
+    delete m_settings;
+    m_settings = nullptr;
+}
+
+void IpSplitTunnelingControllerTest::importPreservesCidr()
+{
+    const QByteArray json = R"json([
+        {"hostname":"1.192.0.0/10","ip":""},
+        {"hostname":"2.16.0.0/13","ips":[]}
+    ])json";
+    QString errorMessage;
+
+    QVERIFY2(m_controller->importSitesFromJson(json, true, errorMessage), qPrintable(errorMessage));
+
+    const auto sites = m_controller->getCurrentSites();
+    QCOMPARE(sites.size(), 2);
+    QCOMPARE(sites.at(0).first, QStringLiteral("1.192.0.0/10"));
+    QCOMPARE(sites.at(1).first, QStringLiteral("2.16.0.0/13"));
+}
+
+void IpSplitTunnelingControllerTest::manualAddPreservesCidr()
+{
+    QVERIFY(m_controller->addSite(QStringLiteral("1.192.0.0/10")));
+
+    const auto sites = m_controller->getCurrentSites();
+    QCOMPARE(sites.size(), 1);
+    QCOMPARE(sites.first().first, QStringLiteral("1.192.0.0/10"));
+}
+
+void IpSplitTunnelingControllerTest::exportAndImportPreservesCidr()
+{
+    const QByteArray json = R"json([
+        {"hostname":"1.192.0.0/10","ip":""},
+        {"hostname":"example.com","ip":"1.1.1.1"}
+    ])json";
+    QString errorMessage;
+    QVERIFY2(m_controller->importSitesFromJson(json, true, errorMessage), qPrintable(errorMessage));
+
+    const QByteArray exported = m_controller->exportSitesToJson();
+    m_controller->removeSites();
+    QVERIFY2(m_controller->importSitesFromJson(exported, true, errorMessage), qPrintable(errorMessage));
+
+    const auto sites = m_controller->getCurrentSites();
+    QCOMPARE(sites.size(), 2);
+    QCOMPARE(sites.at(0).first, QStringLiteral("1.192.0.0/10"));
+    QCOMPARE(sites.at(1).first, QStringLiteral("example.com"));
+}
+
+void IpSplitTunnelingControllerTest::normalizesUrlPathButKeepsDomain()
+{
+    QVERIFY(m_controller->addSite(QStringLiteral("https://example.com/path")));
+    QVERIFY(m_controller->addSite(QStringLiteral("plain.example.com")));
+
+    const auto sites = m_controller->getCurrentSites();
+    QCOMPARE(sites.size(), 2);
+    QCOMPARE(sites.at(0).first, QStringLiteral("example.com"));
+    QCOMPARE(sites.at(1).first, QStringLiteral("plain.example.com"));
+}
+
+QTEST_APPLESS_MAIN(IpSplitTunnelingControllerTest)


### PR DESCRIPTION
## Summary

- add desktop QtTest coverage for site-based split-tunneling CIDR entries
- verify manual additions and JSON import preserve IPv4 prefix lengths
- verify export/re-import round-trips CIDR entries
- keep URL path normalization and plain domain handling covered

This guards the normalization fix already present on `dev` (see #2939 and #3015) against regressions.

## Validation

- `git diff --check`
- Full CMake/CTest execution was not available in the local environment because Conan/Qt dependencies are not installed.

Related to #2939
