### PR TITLE
fix(windows): batch exclusion route updates

### DIFF
--- a/client/daemon/daemon.cpp
+++ b/client/daemon/daemon.cpp
@@ -10,6 +10,7 @@
 #include <QJsonObject>
 #include <QJsonValue>
 #include <QMetaEnum>
+#include <QSet>
 #include <QTimer>
 
 #include "leakdetector.h"
@@ -132,9 +133,7 @@ bool Daemon::activate(const InterfaceConfig& config) {
   }
 
   // Configure routing for excluded addresses.
-  for (const QString& i : config.m_excludedAddresses) {
-    addExclusionRoute(IPAddress(i));
-  }
+  addExclusionRoutes(config.m_excludedAddresses);
 
   // Add the peer to this interface.
   if (!wgutils()->updatePeer(config)) {
@@ -209,16 +208,33 @@ bool Daemon::parseStringList(const QJsonObject& obj, const QString& name,
   return true;
 }
 
-bool Daemon::addExclusionRoute(const IPAddress& prefix) {
-  if (m_excludedAddrSet.contains(prefix)) {
-    m_excludedAddrSet[prefix]++;
-    return true;
+bool Daemon::addExclusionRoutes(const QStringList& addresses) {
+  QHash<IPAddress, int> newPrefixes;
+  for (const QString& address : addresses) {
+    IPAddress prefix(address);
+    auto iterator = m_excludedAddrSet.find(prefix);
+    if (iterator != m_excludedAddrSet.end()) {
+      iterator.value()++;
+    } else {
+      newPrefixes[prefix]++;
+    }
   }
-  if (!wgutils()->addExclusionRoute(prefix)) {
-    return false;
+
+  const QList<IPAddress> addedPrefixes =
+      wgutils()->addExclusionRoutes(newPrefixes.keys());
+  const QSet<IPAddress> addedPrefixSet(addedPrefixes.begin(),
+                                      addedPrefixes.end());
+
+  bool result = true;
+  for (auto iterator = newPrefixes.constBegin();
+       iterator != newPrefixes.constEnd(); ++iterator) {
+    if (addedPrefixSet.contains(iterator.key())) {
+      m_excludedAddrSet[iterator.key()] = iterator.value();
+    } else {
+      result = false;
+    }
   }
-  m_excludedAddrSet[prefix] = 1;
-  return true;
+  return result;
 }
 
 bool Daemon::delExclusionRoute(const IPAddress& prefix) {
@@ -546,9 +562,7 @@ bool Daemon::switchServer(const InterfaceConfig& config) {
       m_connections.value(config.m_hopType).m_config;
 
   // Configure routing for new excluded addresses.
-  for (const QString& i : config.m_excludedAddresses) {
-    addExclusionRoute(IPAddress(i));
-  }
+  addExclusionRoutes(config.m_excludedAddresses);
 
   // Activate the new peer and its routes.
   if (!wgutils()->updatePeer(config)) {

--- a/client/daemon/daemon.h
+++ b/client/daemon/daemon.h
@@ -57,7 +57,7 @@ class Daemon : public QObject {
 
  private:
   bool maybeUpdateResolvers(const InterfaceConfig& config);
-  bool addExclusionRoute(const IPAddress& address);
+  bool addExclusionRoutes(const QStringList& addresses);
   bool delExclusionRoute(const IPAddress& address);
 
  protected:

--- a/client/daemon/wireguardutils.h
+++ b/client/daemon/wireguardutils.h
@@ -45,6 +45,17 @@ class WireguardUtils : public QObject {
   virtual bool deleteRoutePrefix(const IPAddress& prefix) = 0;
   
   virtual bool addExclusionRoute(const IPAddress& prefix) = 0;
+  virtual QList<IPAddress> addExclusionRoutes(
+      const QList<IPAddress>& prefixes) {
+    QList<IPAddress> addedPrefixes;
+    addedPrefixes.reserve(prefixes.size());
+    for (const IPAddress& prefix : prefixes) {
+      if (addExclusionRoute(prefix)) {
+        addedPrefixes.append(prefix);
+      }
+    }
+    return addedPrefixes;
+  }
   virtual bool deleteExclusionRoute(const IPAddress& prefix) = 0;
 
   virtual bool excludeLocalNetworks(const QList<IPAddress>& addresses) = 0;

--- a/client/platforms/windows/daemon/windowsroutemonitor.cpp
+++ b/client/platforms/windows/daemon/windowsroutemonitor.cpp
@@ -4,7 +4,9 @@
 
 #include "windowsroutemonitor.h"
 
+#include <QPair>
 #include <QScopeGuard>
+#include <QSet>
 
 #include "leakdetector.h"
 #include "logger.h"
@@ -115,26 +117,36 @@ void WindowsRouteMonitor::updateInterfaceMetrics(int family) {
   }
 }
 
-void WindowsRouteMonitor::updateExclusionRoute(MIB_IPFORWARD_ROW2* data,
-                                               void* ptable) {
+QList<const MIB_IPFORWARD_ROW2*>
+WindowsRouteMonitor::exclusionRouteCandidates(void* ptable) const {
   PMIB_IPFORWARD_TABLE2 table = reinterpret_cast<PMIB_IPFORWARD_TABLE2>(ptable);
+  QList<const MIB_IPFORWARD_ROW2*> candidates;
+  candidates.reserve(table->NumEntries);
+  for (ULONG i = 0; i < table->NumEntries; i++) {
+    const MIB_IPFORWARD_ROW2* row = &table->Table[i];
+    if (row->InterfaceLuid.Value == m_luid) {
+      continue;
+    }
+    if ((row->Protocol == MIB_IPPROTO_NETMGMT) &&
+        (row->Metric == EXCLUSION_ROUTE_METRIC)) {
+      continue;
+    }
+    candidates.append(row);
+  }
+  return candidates;
+}
+
+void WindowsRouteMonitor::updateExclusionRoute(
+    MIB_IPFORWARD_ROW2* data,
+    const QList<const MIB_IPFORWARD_ROW2*>& routeCandidates) {
   SOCKADDR_INET nexthop = {};
   quint64 bestLuid = 0;
   int bestMatch = -1;
   ULONG bestMetric = ULONG_MAX;
 
   nexthop.si_family = data->DestinationPrefix.Prefix.si_family;
-  for (ULONG i = 0; i < table->NumEntries; i++) {
-    MIB_IPFORWARD_ROW2* row = &table->Table[i];
-    // Ignore routes into the VPN interface.
-    if (row->InterfaceLuid.Value == m_luid) {
-      continue;
-    }
+  for (const MIB_IPFORWARD_ROW2* row : routeCandidates) {
     if (row->DestinationPrefix.PrefixLength < bestMatch) {
-      continue;
-    }
-    // Ignore routes of our own creation.
-    if ((row->Protocol == data->Protocol) && (row->Metric == data->Metric)) {
       continue;
     }
 
@@ -366,70 +378,102 @@ void WindowsRouteMonitor::updateCapturedRoutes(int family, void* ptable) {
 }
 
 bool WindowsRouteMonitor::addExclusionRoute(const IPAddress& prefix) {
-  logger.debug() << "Adding exclusion route for" << prefix.toString();
+  return addExclusionRoutes({prefix}).contains(prefix);
+}
 
-  // Silently ignore non-routeable addresses.
-  QHostAddress addr = prefix.address();
-  if (addr.isLoopback() || addr.isBroadcast() || addr.isLinkLocal() ||
-      addr.isMulticast()) {
-    return true;
-  }
+QList<IPAddress> WindowsRouteMonitor::addExclusionRoutes(
+    const QList<IPAddress>& prefixes) {
+  QList<IPAddress> addedPrefixes;
+  QList<QPair<IPAddress, MIB_IPFORWARD_ROW2*>> pendingRoutes;
+  QSet<IPAddress> pendingPrefixes;
 
-  if (m_exclusionRoutes.contains(prefix)) {
-    logger.warning() << "Exclusion route already exists";
-    return false;
-  }
+  addedPrefixes.reserve(prefixes.size());
+  pendingRoutes.reserve(prefixes.size());
+  pendingPrefixes.reserve(prefixes.size());
 
-  // Allocate and initialize the MIB routing table row.
-  MIB_IPFORWARD_ROW2* data = new MIB_IPFORWARD_ROW2;
-  InitializeIpForwardEntry(data);
-  if (prefix.address().protocol() == QAbstractSocket::IPv6Protocol) {
-    Q_IPV6ADDR buf = prefix.address().toIPv6Address();
-
-    memcpy(&data->DestinationPrefix.Prefix.Ipv6.sin6_addr, &buf, sizeof(buf));
-    data->DestinationPrefix.Prefix.Ipv6.sin6_family = AF_INET6;
-    data->DestinationPrefix.PrefixLength = prefix.prefixLength();
+  if (prefixes.size() == 1) {
+    logger.debug() << "Adding exclusion route for" << prefixes.first().toString();
   } else {
-    quint32 buf = prefix.address().toIPv4Address();
-
-    data->DestinationPrefix.Prefix.Ipv4.sin_addr.s_addr = htonl(buf);
-    data->DestinationPrefix.Prefix.Ipv4.sin_family = AF_INET;
-    data->DestinationPrefix.PrefixLength = prefix.prefixLength();
+    logger.debug() << "Adding" << prefixes.size() << "exclusion routes";
   }
-  data->NextHop.si_family = data->DestinationPrefix.Prefix.si_family;
 
-  // Set the rest of the flags for a static route.
-  data->ValidLifetime = 0xffffffff;
-  data->PreferredLifetime = 0xffffffff;
-  data->Metric = EXCLUSION_ROUTE_METRIC;
-  data->Protocol = MIB_IPPROTO_NETMGMT;
-  data->Loopback = false;
-  data->AutoconfigureAddress = false;
-  data->Publish = false;
-  data->Immortal = false;
-  data->Age = 0;
+  for (const IPAddress& prefix : prefixes) {
+    // Silently ignore non-routeable addresses.
+    QHostAddress addr = prefix.address();
+    if (addr.isLoopback() || addr.isBroadcast() || addr.isLinkLocal() ||
+        addr.isMulticast()) {
+      addedPrefixes.append(prefix);
+      continue;
+    }
+
+    if (m_exclusionRoutes.contains(prefix) || pendingPrefixes.contains(prefix)) {
+      logger.warning() << "Exclusion route already exists";
+      continue;
+    }
+
+    // Allocate and initialize the MIB routing table row.
+    MIB_IPFORWARD_ROW2* data = new MIB_IPFORWARD_ROW2;
+    InitializeIpForwardEntry(data);
+    if (prefix.address().protocol() == QAbstractSocket::IPv6Protocol) {
+      Q_IPV6ADDR buf = prefix.address().toIPv6Address();
+
+      memcpy(&data->DestinationPrefix.Prefix.Ipv6.sin6_addr, &buf, sizeof(buf));
+      data->DestinationPrefix.Prefix.Ipv6.sin6_family = AF_INET6;
+      data->DestinationPrefix.PrefixLength = prefix.prefixLength();
+    } else {
+      quint32 buf = prefix.address().toIPv4Address();
+
+      data->DestinationPrefix.Prefix.Ipv4.sin_addr.s_addr = htonl(buf);
+      data->DestinationPrefix.Prefix.Ipv4.sin_family = AF_INET;
+      data->DestinationPrefix.PrefixLength = prefix.prefixLength();
+    }
+    data->NextHop.si_family = data->DestinationPrefix.Prefix.si_family;
+
+    // Set the rest of the flags for a static route.
+    data->ValidLifetime = 0xffffffff;
+    data->PreferredLifetime = 0xffffffff;
+    data->Metric = EXCLUSION_ROUTE_METRIC;
+    data->Protocol = MIB_IPPROTO_NETMGMT;
+    data->Loopback = false;
+    data->AutoconfigureAddress = false;
+    data->Publish = false;
+    data->Immortal = false;
+    data->Age = 0;
+
+    pendingRoutes.append(qMakePair(prefix, data));
+    pendingPrefixes.insert(prefix);
+  }
+
+  if (pendingRoutes.isEmpty()) {
+    return addedPrefixes;
+  }
 
   PMIB_IPFORWARD_TABLE2 table;
-  int family;
-  if (prefix.address().protocol() == QAbstractSocket::IPv6Protocol) {
-    family = AF_INET6;
-  } else {
-    family = AF_INET;
-  }
-
-  DWORD result = GetIpForwardTable2(family, &table);
+  DWORD result = GetIpForwardTable2(AF_UNSPEC, &table);
   if (result != NO_ERROR) {
     logger.error() << "Failed to fetch routing table:" << result;
-    delete data;
-    return false;
+    for (const auto& route : pendingRoutes) {
+      delete route.second;
+    }
+    return addedPrefixes;
   }
-  updateInterfaceMetrics(family);
-  updateCapturedRoutes(family, table);
-  updateExclusionRoute(data, table);
-  FreeMibTable(table);
+  auto tableGuard = qScopeGuard([&] { FreeMibTable(table); });
 
-  m_exclusionRoutes[prefix] = data;
-  return true;
+  updateInterfaceMetrics(AF_UNSPEC);
+  const QList<const MIB_IPFORWARD_ROW2*> routeCandidates =
+      exclusionRouteCandidates(table);
+
+  // Make the full batch visible before reconciling captured routes.
+  for (const auto& route : pendingRoutes) {
+    m_exclusionRoutes.insert(route.first, route.second);
+  }
+  updateCapturedRoutes(AF_UNSPEC, table);
+
+  for (const auto& route : pendingRoutes) {
+    updateExclusionRoute(route.second, routeCandidates);
+    addedPrefixes.append(route.first);
+  }
+  return addedPrefixes;
 }
 
 bool WindowsRouteMonitor::deleteExclusionRoute(const IPAddress& prefix) {
@@ -492,8 +536,10 @@ void WindowsRouteMonitor::routeChanged() {
 
   updateInterfaceMetrics(AF_UNSPEC);
   updateCapturedRoutes(AF_UNSPEC, table);
+  const QList<const MIB_IPFORWARD_ROW2*> routeCandidates =
+      exclusionRouteCandidates(table);
   for (MIB_IPFORWARD_ROW2* data : m_exclusionRoutes) {
-    updateExclusionRoute(data, table);
+    updateExclusionRoute(data, routeCandidates);
   }
 
   FreeMibTable(table);

--- a/client/platforms/windows/daemon/windowsroutemonitor.h
+++ b/client/platforms/windows/daemon/windowsroutemonitor.h
@@ -12,6 +12,7 @@
 #include <ws2ipdef.h>
 
 #include <QHash>
+#include <QList>
 #include <QMap>
 #include <QObject>
 
@@ -27,6 +28,7 @@ class WindowsRouteMonitor final : public QObject {
   void setDetaultRouteCapture(bool enable);
 
   bool addExclusionRoute(const IPAddress& prefix);
+  QList<IPAddress> addExclusionRoutes(const QList<IPAddress>& prefixes);
   bool deleteExclusionRoute(const IPAddress& prefix);
   void flushExclusionRoutes() { return flushRouteTable(m_exclusionRoutes); };
 
@@ -42,7 +44,10 @@ class WindowsRouteMonitor final : public QObject {
   static QHostAddress prefixToAddress(const IP_ADDRESS_PREFIX* dest);
 
   void flushRouteTable(QHash<IPAddress, MIB_IPFORWARD_ROW2*>& table);
-  void updateExclusionRoute(MIB_IPFORWARD_ROW2* data, void* table);
+  QList<const MIB_IPFORWARD_ROW2*> exclusionRouteCandidates(void* table) const;
+  void updateExclusionRoute(
+      MIB_IPFORWARD_ROW2* data,
+      const QList<const MIB_IPFORWARD_ROW2*>& routeCandidates);
   void updateInterfaceMetrics(int family);
   void updateCapturedRoutes(int family);
   void updateCapturedRoutes(int family, void* table);

--- a/client/platforms/windows/daemon/wireguardutilswindows.cpp
+++ b/client/platforms/windows/daemon/wireguardutilswindows.cpp
@@ -189,8 +189,9 @@ bool WireguardUtilsWindows::updatePeer(const InterfaceConfig& config) {
 
   // Exclude the server address, except for multihop exit servers.
   if (m_routeMonitor && config.m_hopType != InterfaceConfig::MultiHopExit) {
-    m_routeMonitor->addExclusionRoute(IPAddress(config.m_serverIpv4AddrIn));
-    m_routeMonitor->addExclusionRoute(IPAddress(config.m_serverIpv6AddrIn));
+    m_routeMonitor->addExclusionRoutes(
+        {IPAddress(config.m_serverIpv4AddrIn),
+         IPAddress(config.m_serverIpv6AddrIn)});
   }
 
   QString reply = m_tunnel.uapiCommand(message);
@@ -312,6 +313,11 @@ bool WireguardUtilsWindows::addExclusionRoute(const IPAddress& prefix) {
   return m_routeMonitor->addExclusionRoute(prefix);
 }
 
+QList<IPAddress> WireguardUtilsWindows::addExclusionRoutes(
+    const QList<IPAddress>& prefixes) {
+  return m_routeMonitor->addExclusionRoutes(prefixes);
+}
+
 bool WireguardUtilsWindows::deleteExclusionRoute(const IPAddress& prefix) {
   return m_routeMonitor->deleteExclusionRoute(prefix);
 }
@@ -321,12 +327,8 @@ bool WireguardUtilsWindows::excludeLocalNetworks(
   // If the interface isn't up then something went horribly wrong.
   Q_ASSERT(m_routeMonitor);
   // For each destination - attempt to exclude it from the VPN tunnel.
-  bool result = true;
-  for (const IPAddress& prefix : addresses) {
-    if (!m_routeMonitor->addExclusionRoute(prefix)) {
-      result = false;
-    }
-  }
+  bool result =
+      m_routeMonitor->addExclusionRoutes(addresses).size() == addresses.size();
   // Permit LAN traffic through the firewall.
   if (!m_firewall->enableLanBypass(addresses)) {
     result = false;

--- a/client/platforms/windows/daemon/wireguardutilswindows.h
+++ b/client/platforms/windows/daemon/wireguardutilswindows.h
@@ -42,6 +42,8 @@ class WireguardUtilsWindows final : public WireguardUtils {
   bool deleteRoutePrefix(const IPAddress& prefix) override;
 
   bool addExclusionRoute(const IPAddress& prefix) override;
+  QList<IPAddress> addExclusionRoutes(
+      const QList<IPAddress>& prefixes) override;
   bool deleteExclusionRoute(const IPAddress& prefix) override;
 
   bool WireguardUtilsWindows::excludeLocalNetworks(const QList<IPAddress>& addresses) override;


### PR DESCRIPTION
## Summary

- batch excluded-address route installation across daemon and Windows routing layers
- preserve per-prefix success tracking and exclusion reference counts
- filter VPN and self-created routes once before reconciling exclusion routes

## Why

The Windows route monitor fetched and scanned the full routing table once for every excluded CIDR. Each inserted route enlarged the next snapshot, making connection setup quadratic for large split-routing lists. Route-change reconciliation repeated the same scan across all self-created routes.

The new batch path takes one route-table and interface-metric snapshot, reuses the physical route candidates for every exclusion, and exposes the complete batch before captured-route reconciliation.

## Verification

- `git diff --check`
- focused call-path inspection confirms one `GetIpForwardTable2(AF_UNSPEC, ...)` and one `updateInterfaceMetrics(AF_UNSPEC)` per exclusion batch
- operation-count model for 12,840 exclusions and 35 baseline routes: connection row visits drop from 82,875,780 to 449,435; route-change visits drop from 165,315,000 to 462,275

Fixes #3020
