### PR TITLE
fix(windows): stabilize site split tunneling

### DIFF
--- a/client/core/controllers/ipSplitTunnelingController.cpp
+++ b/client/core/controllers/ipSplitTunnelingController.cpp
@@ -1,7 +1,10 @@
 #include "ipSplitTunnelingController.h"
 #include "core/utils/networkUtilities.h"
-#include <QJsonObject>
 #include <QDebug>
+#include <QJsonObject>
+#include <QUrl>
+
+#include <algorithm>
 
 IpSplitTunnelingController::IpSplitTunnelingController(SecureAppSettingsRepository* appSettingsRepository, QObject* parent)
     : QObject(parent),
@@ -81,13 +84,28 @@ bool IpSplitTunnelingController::addSite(const QString &hostname)
         return false;
     }
     
-    if (NetworkUtilities::ipAddressWithSubnetRegExp().exactMatch(normalizedHostname)) {
+    if (validateIpv4Cidr(normalizedHostname)) {
         processSite(normalizedHostname, {});
         return true;
     }
     
     if (addSiteInternal(normalizedHostname, {})) {
-        QHostInfo::lookupHost(normalizedHostname, this, SLOT(onHostResolved(QHostInfo)));
+        const RouteMode routeMode = m_currentRouteMode;
+        QHostInfo::lookupHost(normalizedHostname, this,
+                              [this, routeMode, normalizedHostname](const QHostInfo &hostInfo) {
+            QStringList allIpv4;
+            for (const QHostAddress &address : hostInfo.addresses()) {
+                if (address.protocol() == QAbstractSocket::NetworkLayerProtocol::IPv4Protocol) {
+                    allIpv4.append(address.toString());
+                }
+            }
+            allIpv4.removeDuplicates();
+            allIpv4.sort();
+
+            if (!allIpv4.isEmpty()) {
+                processSiteAfterResolve(routeMode, normalizedHostname, allIpv4);
+            }
+        });
         return true;
     }
     
@@ -150,53 +168,101 @@ void IpSplitTunnelingController::fillSites()
 
 QString IpSplitTunnelingController::normalizeHostname(const QString &hostname) const
 {
-    QString normalized = hostname;
-    normalized.replace("https://", "");
-    normalized.replace("http://", "");
-    normalized.replace("ftp://", "");
-
-    if (NetworkUtilities::ipAddressWithSubnetRegExp().exactMatch(normalized)) {
-        return normalized;
+    const QString candidate = hostname.trimmed();
+    if (candidate.isEmpty()) {
+        return {};
     }
 
-    const QStringList parts = normalized.split("/", Qt::SkipEmptyParts);
-    return parts.isEmpty() ? QString() : parts.first();
+    if (validateIpv4Cidr(candidate)) {
+        return candidate;
+    }
+
+    const qsizetype slashIndex = candidate.indexOf('/');
+    if (slashIndex > 0 && NetworkUtilities::checkIPv4Format(candidate.left(slashIndex))) {
+        return {};
+    }
+
+    const QString urlText = candidate.contains("://") ? candidate : QStringLiteral("https://") + candidate;
+    const QUrl url(urlText, QUrl::StrictMode);
+    if (!url.isValid() || url.host().isEmpty()) {
+        return {};
+    }
+
+    QString normalized = QString::fromLatin1(QUrl::toAce(url.host())).toLower();
+    while (normalized.endsWith('.')) {
+        normalized.chop(1);
+    }
+    return normalized;
 }
 
 bool IpSplitTunnelingController::validateHostname(const QString &hostname) const
 {
-    if (hostname.isEmpty()) {
+    if (validateIpv4Cidr(hostname)) {
+        return true;
+    }
+
+    if (hostname.isEmpty() || hostname.size() > 253 || !hostname.contains('.') || hostname.contains('/')) {
         return false;
     }
-    if (!hostname.contains(".") && !NetworkUtilities::ipAddressWithSubnetRegExp().exactMatch(hostname)) {
+
+    const QStringList labels = hostname.split('.', Qt::KeepEmptyParts);
+    if (labels.constLast().size() < 2) {
         return false;
     }
-    return true;
-}
-
-
-void IpSplitTunnelingController::onHostResolved(const QHostInfo &hostInfo)
-{
-    const QList<QHostAddress> &addresses = hostInfo.addresses();
-    QString hostname = hostInfo.hostName();
-
-    QStringList allIpv4;
-    for (const QHostAddress &addr : addresses) {
-        if (addr.protocol() == QAbstractSocket::NetworkLayerProtocol::IPv4Protocol) {
-            allIpv4.append(addr.toString());
+    for (const QString &label : labels) {
+        if (label.isEmpty() || label.size() > 63 || !label.front().isLetterOrNumber() || !label.back().isLetterOrNumber()) {
+            return false;
+        }
+        for (const QChar character : label) {
+            if (!character.isLetterOrNumber() && character != '-') {
+                return false;
+            }
         }
     }
-    allIpv4.removeDuplicates();
-    qDebug() << "[SplitTunneling] Host resolved:" << hostname
-             << "-> adding all IPv4 addresses to list:" << allIpv4;
 
-    if (!allIpv4.isEmpty()) {
-        processSiteAfterResolve(hostname, allIpv4);
-    }
+    return std::any_of(labels.constLast().cbegin(), labels.constLast().cend(), [](QChar character) {
+        return character.isLetter();
+    });
 }
 
-void IpSplitTunnelingController::processSiteAfterResolve(const QString &hostname, const QStringList &ips)
+bool IpSplitTunnelingController::validateIpv4Cidr(const QString &value) const
 {
+    const QStringList parts = value.split('/', Qt::KeepEmptyParts);
+    if (parts.size() == 1) {
+        return NetworkUtilities::ipAddressRegExp().match(parts.constFirst()).hasMatch();
+    }
+    if (parts.size() != 2 || !NetworkUtilities::ipAddressRegExp().match(parts.constFirst()).hasMatch()) {
+        return false;
+    }
+
+    const QString prefix = parts.constLast();
+    if (prefix.isEmpty() || (prefix.size() > 1 && prefix.startsWith('0'))) {
+        return false;
+    }
+    for (const QChar character : prefix) {
+        if (character < '0' || character > '9') {
+            return false;
+        }
+    }
+
+    bool converted = false;
+    const int prefixLength = prefix.toInt(&converted);
+    return converted && prefixLength >= 0 && prefixLength <= 32;
+}
+
+void IpSplitTunnelingController::processSiteAfterResolve(RouteMode routeMode, const QString &hostname,
+                                                         const QStringList &ips)
+{
+    const QVariantMap sites = m_appSettingsRepository->vpnSites(routeMode);
+    if (!sites.contains(hostname)) {
+        return;
+    }
+
+    m_appSettingsRepository->addVpnSite(routeMode, hostname, ips);
+    if (m_currentRouteMode != routeMode) {
+        return;
+    }
+
     for (int i = 0; i < m_sites.size(); i++) {
         if (m_sites[i].first == hostname) {
             for (const QString &ip : ips) {
@@ -207,7 +273,6 @@ void IpSplitTunnelingController::processSiteAfterResolve(const QString &hostname
             break;
         }
     }
-    m_appSettingsRepository->addVpnSite(m_currentRouteMode, hostname, ips);
 }
 
 void IpSplitTunnelingController::processSite(const QString &hostname, const QStringList &ips)
@@ -234,33 +299,51 @@ bool IpSplitTunnelingController::importSitesFromJson(const QByteArray& jsonData,
     QMap<QString, QStringList> sites;
     
     for (auto jsonValue : jsonArray) {
-        QJsonObject jsonObject = jsonValue.toObject();
-        QString hostname = jsonObject.value("hostname").toString("");
+        if (!jsonValue.isObject()) {
+            continue;
+        }
 
-        QStringList ips;
-        if (jsonObject.value("ips").isArray()) {
-            const QJsonArray ipsArray = jsonObject.value("ips").toArray();
-            for (const auto &ipValue : ipsArray) {
-                ips.append(ipValue.toString());
-            }
-        }
-        const QString singleIp = jsonObject.value("ip").toString("");
-        if (!singleIp.isEmpty()) {
-            ips.append(singleIp);
-        }
-        ips.removeAll(QString());
-        ips.removeDuplicates();
-        
+        const QJsonObject jsonObject = jsonValue.toObject();
+        QString hostname = jsonObject.value("hostname").toString("");
         QString normalizedHostname = normalizeHostname(hostname);
-        
+
         if (!validateHostname(normalizedHostname)) {
             qDebug() << normalizedHostname << " not look like ip adress or domain name";
             continue;
         }
-        
-        sites.insert(normalizedHostname, ips);
+
+        QStringList ips;
+        if (jsonObject.value("ips").isArray()) {
+            const QJsonArray ipsArray = jsonObject.value("ips").toArray();
+            for (const QJsonValue &ipValue : ipsArray) {
+                const QString ip = ipValue.toString().trimmed();
+                if (!ip.contains('/') && validateIpv4Cidr(ip)) {
+                    ips.append(ip);
+                }
+            }
+        }
+
+        const QString legacyIp = jsonObject.value("ip").toString().trimmed();
+        if (!legacyIp.contains('/') && validateIpv4Cidr(legacyIp)) {
+            ips.append(legacyIp);
+        }
+        ips.removeDuplicates();
+        ips.sort();
+
+        QStringList mergedIps = sites.value(normalizedHostname);
+        for (const QString &ip : ips) {
+            if (!mergedIps.contains(ip)) {
+                mergedIps.append(ip);
+            }
+        }
+        sites.insert(normalizedHostname, mergedIps);
     }
-    
+
+    if (sites.isEmpty()) {
+        errorMessage = tr("The JSON data does not contain valid sites");
+        return false;
+    }
+
     addSites(sites, replaceExisting);
     
     return true;
@@ -280,13 +363,10 @@ QByteArray IpSplitTunnelingController::exportSitesToJson() const
             ipsArray.append(ip);
         }
         jsonObject["ips"] = ipsArray;
-        // Keep the legacy "ip" field (first address) for backward compatibility.
         jsonObject["ip"] = site.second.isEmpty() ? QString() : site.second.first();
-
         jsonArray.append(jsonObject);
     }
     
     QJsonDocument jsonDocument(jsonArray);
     return jsonDocument.toJson();
 }
-

--- a/client/core/controllers/ipSplitTunnelingController.h
+++ b/client/core/controllers/ipSplitTunnelingController.h
@@ -25,6 +25,7 @@ public:
     explicit IpSplitTunnelingController(SecureAppSettingsRepository* appSettingsRepository, QObject* parent = nullptr);
 
     bool addSite(const QString &hostname);
+
     void addSites(const QMap<QString, QStringList> &sites, bool replaceExisting);
     bool removeSite(const QString &hostname);
     void removeSites();
@@ -33,20 +34,26 @@ public:
 
     RouteMode getRouteMode() const;
     bool isSplitTunnelingEnabled() const;
+
     QVector<QPair<QString, QStringList>> getCurrentSites() const;
 
     bool importSitesFromJson(const QByteArray& jsonData, bool replaceExisting, QString &errorMessage);
-    QByteArray exportSitesToJson() const;
 
-private slots:
-    void onHostResolved(const QHostInfo &hostInfo);
+    QByteArray exportSitesToJson() const;
 
 private:
     void fillSites();
+
     bool addSiteInternal(const QString &hostname, const QStringList &ips);
+
     QString normalizeHostname(const QString &hostname) const;
+
     bool validateHostname(const QString &hostname) const;
-    void processSiteAfterResolve(const QString &hostname, const QStringList &ips);
+
+    bool validateIpv4Cidr(const QString &value) const;
+
+    void processSiteAfterResolve(RouteMode routeMode, const QString &hostname, const QStringList &ips);
+
     void processSite(const QString &hostname, const QStringList &ips);
 
     SecureAppSettingsRepository* m_appSettingsRepository;
@@ -55,4 +62,3 @@ private:
 };
 
 #endif // IPSPLITTUNNELINGCONTROLLER_H
-

--- a/client/core/repositories/secureAppSettingsRepository.cpp
+++ b/client/core/repositories/secureAppSettingsRepository.cpp
@@ -122,9 +122,13 @@ QVariantMap SecureAppSettingsRepository::vpnSites(RouteMode mode) const
 
 QStringList SecureAppSettingsRepository::siteIpList(const QVariant &value)
 {
-    // QVariant::toStringList() handles both a QStringList/QVariantList and a single QString
-    // (a single string is returned as a one-element list), which covers the legacy format.
     QStringList result = value.toStringList();
+    if (result.isEmpty()) {
+        const QString legacyValue = value.toString();
+        if (!legacyValue.isEmpty()) {
+            result.append(legacyValue);
+        }
+    }
     result.removeAll(QString());
     result.removeDuplicates();
     return result;
@@ -140,20 +144,22 @@ bool SecureAppSettingsRepository::addVpnSite(RouteMode mode, const QString &site
     QVariantMap sites = vpnSites(mode);
     const bool siteExisted = sites.contains(site);
 
-    if (siteExisted && ips.isEmpty())
+    if (siteExisted && ips.isEmpty()) {
         return false;
+    }
 
     QStringList mergedIps = siteIpList(sites.value(site));
     bool changed = !siteExisted;
     for (const QString &ip : ips) {
-        if (!ip.isEmpty() && !mergedIps.contains(ip)) {
+        if (NetworkUtilities::checkIPv4Format(ip) && !mergedIps.contains(ip)) {
             mergedIps.append(ip);
             changed = true;
         }
     }
 
-    if (!changed)
+    if (!changed) {
         return false;
+    }
 
     sites.insert(site, mergedIps);
     setVpnSites(mode, sites);
@@ -169,8 +175,9 @@ void SecureAppSettingsRepository::addVpnSites(RouteMode mode, const QMap<QString
 
         QStringList mergedIps = siteIpList(allSites.value(site));
         for (const QString &ip : i.value()) {
-            if (!ip.isEmpty() && !mergedIps.contains(ip))
+            if (NetworkUtilities::checkIPv4Format(ip) && !mergedIps.contains(ip)) {
                 mergedIps.append(ip);
+            }
         }
 
         allSites.insert(site, mergedIps);
@@ -178,6 +185,37 @@ void SecureAppSettingsRepository::addVpnSites(RouteMode mode, const QMap<QString
 
     setVpnSites(mode, allSites);
     emit sitesChanged(mode);
+}
+
+void SecureAppSettingsRepository::replaceVpnSiteIps(RouteMode mode, const QMap<QString, QStringList> &sites)
+{
+    QVariantMap allSites = vpnSites(mode);
+    bool changed = false;
+
+    for (auto i = sites.constBegin(); i != sites.constEnd(); ++i) {
+        if (!allSites.contains(i.key())) {
+            continue;
+        }
+
+        QStringList validIps;
+        for (const QString &ip : i.value()) {
+            if (NetworkUtilities::checkIPv4Format(ip) && !validIps.contains(ip)) {
+                validIps.append(ip);
+            }
+        }
+        validIps.sort();
+        if (validIps.isEmpty() || siteIpList(allSites.value(i.key())) == validIps) {
+            continue;
+        }
+
+        allSites.insert(i.key(), validIps);
+        changed = true;
+    }
+
+    if (changed) {
+        setVpnSites(mode, allSites);
+        emit sitesChanged(mode);
+    }
 }
 
 void SecureAppSettingsRepository::removeVpnSite(RouteMode mode, const QString &site)

--- a/client/core/repositories/secureAppSettingsRepository.h
+++ b/client/core/repositories/secureAppSettingsRepository.h
@@ -38,14 +38,17 @@ public:
 
     RouteMode routeMode() const;
     void setRouteMode(RouteMode mode);
+
     bool addVpnSite(RouteMode mode, const QString &site, const QStringList &ips = {});
+
     void addVpnSites(RouteMode mode, const QMap<QString, QStringList> &sites);
+
+    void replaceVpnSiteIps(RouteMode mode, const QMap<QString, QStringList> &sites);
+
     void removeVpnSite(RouteMode mode, const QString &site);
     void removeAllVpnSites(RouteMode mode);
     QVariantMap vpnSites(RouteMode mode) const;
 
-    // Normalizes a stored vpn site value into a list of IPs.
-    // Supports both the legacy format (a single IP string) and the current one (a list of IPs).
     static QStringList siteIpList(const QVariant &value);
     bool isSitesSplitTunnelingEnabled() const;
     void setSitesSplitTunnelingEnabled(bool enabled);
@@ -126,4 +129,3 @@ private:
 };
 
 #endif // SECUREAPPSETTINGSREPOSITORY_H
-

--- a/client/daemon/daemon.cpp
+++ b/client/daemon/daemon.cpp
@@ -132,9 +132,20 @@ bool Daemon::activate(const InterfaceConfig& config) {
   }
 
   // Configure routing for excluded addresses.
-  for (const QString& i : config.m_excludedAddresses) {
-    addExclusionRoute(IPAddress(i));
+  QList<IPAddress> excludedPrefixes;
+  excludedPrefixes.reserve(config.m_excludedAddresses.size());
+  for (const QString& address : config.m_excludedAddresses) {
+    excludedPrefixes.append(IPAddress(address));
   }
+  if (!addExclusionRoutes(excludedPrefixes)) {
+    logger.error() << "Failed to configure one or more exclusion routes";
+    return false;
+  }
+  auto exclusionRoutesGuard = qScopeGuard([this, &excludedPrefixes] {
+    for (const IPAddress& prefix : excludedPrefixes) {
+      delExclusionRoute(prefix);
+    }
+  });
 
   // Add the peer to this interface.
   if (!wgutils()->updatePeer(config)) {
@@ -159,6 +170,7 @@ bool Daemon::activate(const InterfaceConfig& config) {
   if (status) {
     m_connections[config.m_hopType] = ConnectionState(config);
     m_handshakeTimer.start(HANDSHAKE_POLL_MSEC);
+    exclusionRoutesGuard.dismiss();
     emit_failure_guard.dismiss();
     return true;
   }
@@ -209,15 +221,31 @@ bool Daemon::parseStringList(const QJsonObject& obj, const QString& name,
   return true;
 }
 
-bool Daemon::addExclusionRoute(const IPAddress& prefix) {
-  if (m_excludedAddrSet.contains(prefix)) {
-    m_excludedAddrSet[prefix]++;
-    return true;
+bool Daemon::addExclusionRoutes(const QList<IPAddress>& prefixes) {
+  QHash<IPAddress, int> requestedPrefixes;
+  for (const IPAddress& prefix : prefixes) {
+    requestedPrefixes[prefix] = requestedPrefixes.value(prefix) + 1;
   }
-  if (!wgutils()->addExclusionRoute(prefix)) {
+
+  QList<IPAddress> freshPrefixes;
+  freshPrefixes.reserve(requestedPrefixes.size());
+  for (auto iterator = requestedPrefixes.constBegin();
+       iterator != requestedPrefixes.constEnd(); ++iterator) {
+    if (!m_excludedAddrSet.contains(iterator.key())) {
+      freshPrefixes.append(iterator.key());
+    }
+  }
+
+  if (!wgutils()->addExclusionRoutes(freshPrefixes)) {
     return false;
   }
-  m_excludedAddrSet[prefix] = 1;
+
+  for (auto iterator = requestedPrefixes.constBegin();
+       iterator != requestedPrefixes.constEnd(); ++iterator) {
+    m_excludedAddrSet[iterator.key()] =
+        m_excludedAddrSet.value(iterator.key()) + iterator.value();
+  }
+
   return true;
 }
 
@@ -227,8 +255,11 @@ bool Daemon::delExclusionRoute(const IPAddress& prefix) {
     m_excludedAddrSet[prefix]--;
     return true;
   }
+  if (!wgutils()->deleteExclusionRoute(prefix)) {
+    return false;
+  }
   m_excludedAddrSet.remove(prefix);
-  return wgutils()->deleteExclusionRoute(prefix);
+  return true;
 }
 
 // static
@@ -546,25 +577,47 @@ bool Daemon::switchServer(const InterfaceConfig& config) {
       m_connections.value(config.m_hopType).m_config;
 
   // Configure routing for new excluded addresses.
-  for (const QString& i : config.m_excludedAddresses) {
-    addExclusionRoute(IPAddress(i));
+  QList<IPAddress> excludedPrefixes;
+  excludedPrefixes.reserve(config.m_excludedAddresses.size());
+  for (const QString& address : config.m_excludedAddresses) {
+    excludedPrefixes.append(IPAddress(address));
   }
+  if (!addExclusionRoutes(excludedPrefixes)) {
+    logger.error() << "Server switch failed to configure exclusion routes";
+    return false;
+  }
+  auto exclusionRoutesGuard = qScopeGuard([this, &excludedPrefixes] {
+    for (const IPAddress& prefix : excludedPrefixes) {
+      delExclusionRoute(prefix);
+    }
+  });
 
   // Activate the new peer and its routes.
   if (!wgutils()->updatePeer(config)) {
     logger.error() << "Server switch failed to update the wireguard interface";
     return false;
   }
+  QList<IPAddress> updatedPrefixes;
   for (const IPAddress& ip : config.m_allowedIPAddressRanges) {
     if (!wgutils()->updateRoutePrefix(ip)) {
       logger.error() << "Server switch failed to update the routing table";
-      break;
+      for (const IPAddress& updatedPrefix : updatedPrefixes) {
+        if (!lastConfig.m_allowedIPAddressRanges.contains(updatedPrefix)) {
+          wgutils()->deleteRoutePrefix(updatedPrefix);
+        }
+      }
+      if (!wgutils()->updatePeer(lastConfig)) {
+        logger.error() << "Server switch failed to restore the previous peer";
+      }
+      return false;
     }
+    updatedPrefixes.append(ip);
   }
+  exclusionRoutesGuard.dismiss();
 
   // Remove routing entries for the old peer.
   for (const QString& i : lastConfig.m_excludedAddresses) {
-    delExclusionRoute(QHostAddress(i));
+    delExclusionRoute(IPAddress(i));
   }
   for (const IPAddress& ip : lastConfig.m_allowedIPAddressRanges) {
     if (!config.m_allowedIPAddressRanges.contains(ip)) {

--- a/client/daemon/daemon.h
+++ b/client/daemon/daemon.h
@@ -57,8 +57,10 @@ class Daemon : public QObject {
 
  private:
   bool maybeUpdateResolvers(const InterfaceConfig& config);
-  bool addExclusionRoute(const IPAddress& address);
+
   bool delExclusionRoute(const IPAddress& address);
+
+  bool addExclusionRoutes(const QList<IPAddress>& prefixes);
 
  protected:
   virtual bool run(Op op, const InterfaceConfig& config) {

--- a/client/daemon/wireguardutils.h
+++ b/client/daemon/wireguardutils.h
@@ -5,7 +5,9 @@
 #ifndef WIREGUARDUTILS_H
 #define WIREGUARDUTILS_H
 
-#define _WINSOCKAPI_
+#ifndef _WINSOCKAPI_
+    #define _WINSOCKAPI_
+#endif
 
 #include <QCoreApplication>
 #include <QHostAddress>
@@ -46,6 +48,24 @@ class WireguardUtils : public QObject {
   
   virtual bool addExclusionRoute(const IPAddress& prefix) = 0;
   virtual bool deleteExclusionRoute(const IPAddress& prefix) = 0;
+
+  virtual bool addExclusionRoutes(const QList<IPAddress>& prefixes) {
+    QList<IPAddress> addedPrefixes;
+    addedPrefixes.reserve(prefixes.size());
+
+    for (const IPAddress& prefix : prefixes) {
+      if (!addExclusionRoute(prefix)) {
+        for (auto iterator = addedPrefixes.crbegin();
+             iterator != addedPrefixes.crend(); ++iterator) {
+          deleteExclusionRoute(*iterator);
+        }
+        return false;
+      }
+      addedPrefixes.append(prefix);
+    }
+
+    return true;
+  }
 
   virtual bool excludeLocalNetworks(const QList<IPAddress>& addresses) = 0;
 };

--- a/client/platforms/windows/daemon/windowsroutemonitor.cpp
+++ b/client/platforms/windows/daemon/windowsroutemonitor.cpp
@@ -5,6 +5,7 @@
 #include "windowsroutemonitor.h"
 
 #include <QScopeGuard>
+#include <QVector>
 
 #include "leakdetector.h"
 #include "logger.h"
@@ -19,24 +20,26 @@ Logger logger("WindowsRouteMonitor");
 // way to other routing entries.
 constexpr const ULONG EXCLUSION_ROUTE_METRIC = 0x5e72;
 
-// Called by the kernel on route changes - perform some basic filtering and
-// invoke the routeChanged slot to do the real work.
+constexpr int ROUTE_CHANGE_DEBOUNCE_MSEC = 50;
+
 static void routeChangeCallback(PVOID context, PMIB_IPFORWARD_ROW2 row,
                                 MIB_NOTIFICATION_TYPE type) {
   WindowsRouteMonitor* monitor = (WindowsRouteMonitor*)context;
   Q_UNUSED(type);
 
   // Ignore route changes that we created.
-  if ((row->Protocol == MIB_IPPROTO_NETMGMT) &&
-      (row->Metric == EXCLUSION_ROUTE_METRIC)) {
-    return;
-  }
-  if (monitor->getLuid() == row->InterfaceLuid.Value) {
-    return;
+  if (row != nullptr) {
+    if ((row->Protocol == MIB_IPPROTO_NETMGMT) &&
+        (row->Metric == EXCLUSION_ROUTE_METRIC)) {
+      return;
+    }
+    if (monitor->getLuid() == row->InterfaceLuid.Value) {
+      return;
+    }
   }
 
-  // Invoke the route changed signal to do the real work in Qt.
-  QMetaObject::invokeMethod(monitor, "routeChanged", Qt::QueuedConnection);
+  QMetaObject::invokeMethod(monitor, "scheduleRouteChanged",
+                            Qt::QueuedConnection);
 }
 
 // Perform prefix matching comparison on IP addresses in host order.
@@ -63,24 +66,37 @@ WindowsRouteMonitor::WindowsRouteMonitor(quint64 luid, QObject* parent)
   MZ_COUNT_CTOR(WindowsRouteMonitor);
   logger.debug() << "WindowsRouteMonitor created.";
 
-  NotifyRouteChange2(AF_INET, routeChangeCallback, this, FALSE, &m_routeHandle);
+  m_routeChangedDebounce.setSingleShot(true);
+  m_routeChangedDebounce.setInterval(ROUTE_CHANGE_DEBOUNCE_MSEC);
+  connect(&m_routeChangedDebounce, &QTimer::timeout, this,
+          &WindowsRouteMonitor::routeChanged);
+
+  DWORD result =
+      NotifyRouteChange2(AF_INET, routeChangeCallback, this, FALSE,
+                         &m_routeHandle);
+  if (result != NO_ERROR) {
+    logger.error() << "Failed to subscribe to route changes:" << result;
+    m_routeHandle = INVALID_HANDLE_VALUE;
+  }
 }
 
 WindowsRouteMonitor::~WindowsRouteMonitor() {
   MZ_COUNT_DTOR(WindowsRouteMonitor);
-  CancelMibChangeNotify2(m_routeHandle);
+  if (m_routeHandle != INVALID_HANDLE_VALUE) {
+    CancelMibChangeNotify2(m_routeHandle);
+  }
 
   flushRouteTable(m_exclusionRoutes);
   flushRouteTable(m_clonedRoutes);
   logger.debug() << "WindowsRouteMonitor destroyed.";
 }
 
-void WindowsRouteMonitor::updateInterfaceMetrics(int family) {
-  PMIB_IPINTERFACE_TABLE table;
+bool WindowsRouteMonitor::updateInterfaceMetrics(int family) {
+  PMIB_IPINTERFACE_TABLE table = nullptr;
   DWORD result = GetIpInterfaceTable(family, &table);
   if (result != NO_ERROR) {
     logger.warning() << "Failed to retrive interface table." << result;
-    return;
+    return false;
   }
   auto guard = qScopeGuard([&] { FreeMibTable(table); });
 
@@ -113,9 +129,11 @@ void WindowsRouteMonitor::updateInterfaceMetrics(int family) {
       m_interfaceMetricsIpv6[row->InterfaceLuid.Value] = row->Metric;
     }
   }
+
+  return true;
 }
 
-void WindowsRouteMonitor::updateExclusionRoute(MIB_IPFORWARD_ROW2* data,
+bool WindowsRouteMonitor::updateExclusionRoute(MIB_IPFORWARD_ROW2* data,
                                                void* ptable) {
   PMIB_IPFORWARD_TABLE2 table = reinterpret_cast<PMIB_IPFORWARD_TABLE2>(ptable);
   SOCKADDR_INET nexthop = {};
@@ -181,10 +199,17 @@ void WindowsRouteMonitor::updateExclusionRoute(MIB_IPFORWARD_ROW2* data,
     }
   }
 
+  if (bestMatch < 0) {
+    logger.error() << "No physical route found for exclusion"
+                   << prefixToAddress(&data->DestinationPrefix).toString()
+                   << "/" << data->DestinationPrefix.PrefixLength;
+    return false;
+  }
+
   // If neither the interface nor next-hop have changed, then do nothing.
   if (data->InterfaceLuid.Value == bestLuid &&
       memcmp(&nexthop, &data->NextHop, sizeof(SOCKADDR_INET)) == 0) {
-    return;
+    return true;
   }
 
   // Delete the previous routing table entry, if any.
@@ -192,6 +217,7 @@ void WindowsRouteMonitor::updateExclusionRoute(MIB_IPFORWARD_ROW2* data,
     DWORD result = DeleteIpForwardEntry2(data);
     if ((result != NO_ERROR) && (result != ERROR_NOT_FOUND)) {
       logger.error() << "Failed to delete route:" << result;
+      return false;
     }
   }
 
@@ -200,10 +226,21 @@ void WindowsRouteMonitor::updateExclusionRoute(MIB_IPFORWARD_ROW2* data,
   memcpy(&data->NextHop, &nexthop, sizeof(SOCKADDR_INET));
   if (data->InterfaceLuid.Value != 0) {
     DWORD result = CreateIpForwardEntry2(data);
+    if (result == ERROR_OBJECT_ALREADY_EXISTS) {
+      logger.warning() << "Exclusion route is already owned by another entry";
+      data->InterfaceLuid.Value = 0;
+      return true;
+    }
     if (result != NO_ERROR) {
       logger.error() << "Failed to update route:" << result;
+      data->InterfaceLuid.Value = 0;
+      memset(&data->NextHop, 0, sizeof(SOCKADDR_INET));
+      data->NextHop.si_family = data->DestinationPrefix.Prefix.si_family;
+      return false;
     }
   }
+
+  return true;
 }
 
 // static
@@ -256,12 +293,15 @@ void WindowsRouteMonitor::updateCapturedRoutes(int family) {
     return;
   }
 
-  PMIB_IPFORWARD_TABLE2 table;
+  PMIB_IPFORWARD_TABLE2 table = nullptr;
   DWORD error = GetIpForwardTable2(family, &table);
   if (error != NO_ERROR) {
-    updateCapturedRoutes(family, table);
-    FreeMibTable(table);
+    logger.error() << "Failed to fetch routing table:" << error;
+    return;
   }
+
+  updateCapturedRoutes(family, table);
+  FreeMibTable(table);
 }
 
 void WindowsRouteMonitor::updateCapturedRoutes(int family, void* ptable) {
@@ -270,6 +310,7 @@ void WindowsRouteMonitor::updateCapturedRoutes(int family, void* ptable) {
     return;
   }
 
+  QSet<IPAddress> captureFailures;
   for (ULONG i = 0; i < table->NumEntries; i++) {
     MIB_IPFORWARD_ROW2* row = &table->Table[i];
     // Ignore routes into the VPN interface.
@@ -303,6 +344,9 @@ void WindowsRouteMonitor::updateCapturedRoutes(int family, void* ptable) {
       data->Age++;
       continue;
     }
+    if (captureFailures.contains(prefix)) {
+      continue;
+    }
     logger.debug() << "Capturing route to" << prefix.toString();
 
     // Clone the route and direct it into the VPN tunnel.
@@ -328,6 +372,9 @@ void WindowsRouteMonitor::updateCapturedRoutes(int family, void* ptable) {
     if (result != NO_ERROR) {
       logger.error() << "Failed to update route:" << result;
       delete data;
+      if (result == ERROR_OBJECT_ALREADY_EXISTS) {
+        captureFailures.insert(prefix);
+      }
     } else {
       m_clonedRoutes.insert(prefix, data);
       data->Age++;
@@ -366,70 +413,158 @@ void WindowsRouteMonitor::updateCapturedRoutes(int family, void* ptable) {
 }
 
 bool WindowsRouteMonitor::addExclusionRoute(const IPAddress& prefix) {
-  logger.debug() << "Adding exclusion route for" << prefix.toString();
+  return addExclusionRoutes(QList<IPAddress>{prefix});
+}
 
-  // Silently ignore non-routeable addresses.
-  QHostAddress addr = prefix.address();
-  if (addr.isLoopback() || addr.isBroadcast() || addr.isLinkLocal() ||
-      addr.isMulticast()) {
+bool WindowsRouteMonitor::addExclusionRoutes(
+    const QList<IPAddress>& prefixes) {
+  using PendingRoute = QPair<IPAddress, MIB_IPFORWARD_ROW2*>;
+
+  QVector<PendingRoute> pendingIpv4;
+  QVector<PendingRoute> pendingIpv6;
+  pendingIpv4.reserve(prefixes.size());
+  pendingIpv6.reserve(prefixes.size());
+  QSet<IPAddress> pendingPrefixes;
+
+  auto releasePending = [](QVector<PendingRoute>& pending) {
+    for (const PendingRoute& route : pending) {
+      delete route.second;
+    }
+    pending.clear();
+  };
+
+  for (const IPAddress& prefix : prefixes) {
+    const QHostAddress address = prefix.address();
+    const auto protocol = address.protocol();
+    if (protocol != QAbstractSocket::IPv4Protocol &&
+        protocol != QAbstractSocket::IPv6Protocol) {
+      logger.error() << "Invalid exclusion prefix:" << prefix.toString();
+      releasePending(pendingIpv4);
+      releasePending(pendingIpv6);
+      return false;
+    }
+
+    // Silently ignore non-routeable addresses.
+    if (address.isLoopback() || address.isBroadcast() ||
+        address.isLinkLocal() || address.isMulticast()) {
+      continue;
+    }
+    if (m_exclusionRoutes.contains(prefix) ||
+        pendingPrefixes.contains(prefix)) {
+      continue;
+    }
+
+    MIB_IPFORWARD_ROW2* data = new MIB_IPFORWARD_ROW2;
+    InitializeIpForwardEntry(data);
+    if (protocol == QAbstractSocket::IPv6Protocol) {
+      Q_IPV6ADDR buffer = address.toIPv6Address();
+      memcpy(&data->DestinationPrefix.Prefix.Ipv6.sin6_addr, &buffer,
+             sizeof(buffer));
+      data->DestinationPrefix.Prefix.Ipv6.sin6_family = AF_INET6;
+    } else {
+      quint32 buffer = address.toIPv4Address();
+      data->DestinationPrefix.Prefix.Ipv4.sin_addr.s_addr = htonl(buffer);
+      data->DestinationPrefix.Prefix.Ipv4.sin_family = AF_INET;
+    }
+    data->DestinationPrefix.PrefixLength = prefix.prefixLength();
+    data->NextHop.si_family = data->DestinationPrefix.Prefix.si_family;
+    data->ValidLifetime = 0xffffffff;
+    data->PreferredLifetime = 0xffffffff;
+    data->Metric = EXCLUSION_ROUTE_METRIC;
+    data->Protocol = MIB_IPPROTO_NETMGMT;
+    data->Loopback = false;
+    data->AutoconfigureAddress = false;
+    data->Publish = false;
+    data->Immortal = false;
+    data->Age = 0;
+
+    PendingRoute route(prefix, data);
+    if (protocol == QAbstractSocket::IPv6Protocol) {
+      pendingIpv6.append(route);
+    } else {
+      pendingIpv4.append(route);
+    }
+    pendingPrefixes.insert(prefix);
+  }
+
+  if (pendingIpv4.isEmpty() && pendingIpv6.isEmpty()) {
     return true;
   }
 
-  if (m_exclusionRoutes.contains(prefix)) {
-    logger.warning() << "Exclusion route already exists";
-    return false;
+  for (const PendingRoute& route : pendingIpv4) {
+    m_exclusionRoutes.insert(route.first, route.second);
+  }
+  for (const PendingRoute& route : pendingIpv6) {
+    m_exclusionRoutes.insert(route.first, route.second);
   }
 
-  // Allocate and initialize the MIB routing table row.
-  MIB_IPFORWARD_ROW2* data = new MIB_IPFORWARD_ROW2;
-  InitializeIpForwardEntry(data);
-  if (prefix.address().protocol() == QAbstractSocket::IPv6Protocol) {
-    Q_IPV6ADDR buf = prefix.address().toIPv6Address();
+  auto processFamily = [this](int family,
+                              const QVector<PendingRoute>& pending) {
+    if (pending.isEmpty()) {
+      return true;
+    }
 
-    memcpy(&data->DestinationPrefix.Prefix.Ipv6.sin6_addr, &buf, sizeof(buf));
-    data->DestinationPrefix.Prefix.Ipv6.sin6_family = AF_INET6;
-    data->DestinationPrefix.PrefixLength = prefix.prefixLength();
-  } else {
-    quint32 buf = prefix.address().toIPv4Address();
+    logger.debug() << "Batch exclusion install:" << pending.size()
+                   << (family == AF_INET6 ? "IPv6" : "IPv4") << "routes";
 
-    data->DestinationPrefix.Prefix.Ipv4.sin_addr.s_addr = htonl(buf);
-    data->DestinationPrefix.Prefix.Ipv4.sin_family = AF_INET;
-    data->DestinationPrefix.PrefixLength = prefix.prefixLength();
+    PMIB_IPFORWARD_TABLE2 table = nullptr;
+    DWORD result = GetIpForwardTable2(family, &table);
+    if (result != NO_ERROR) {
+      logger.error() << "Failed to fetch routing table:" << result;
+      return false;
+    }
+    auto tableGuard = qScopeGuard([table] { FreeMibTable(table); });
+
+    if (!updateInterfaceMetrics(family)) {
+      return false;
+    }
+    for (const PendingRoute& route : pending) {
+      if (!updateExclusionRoute(route.second, table)) {
+        logger.error() << "Failed to install exclusion route"
+                       << route.first.toString();
+        return false;
+      }
+    }
+
+    updateCapturedRoutes(family, table);
+    return true;
+  };
+
+  const bool installed = processFamily(AF_INET, pendingIpv4) &&
+                         processFamily(AF_INET6, pendingIpv6);
+  if (installed) {
+    return true;
   }
-  data->NextHop.si_family = data->DestinationPrefix.Prefix.si_family;
 
-  // Set the rest of the flags for a static route.
-  data->ValidLifetime = 0xffffffff;
-  data->PreferredLifetime = 0xffffffff;
-  data->Metric = EXCLUSION_ROUTE_METRIC;
-  data->Protocol = MIB_IPPROTO_NETMGMT;
-  data->Loopback = false;
-  data->AutoconfigureAddress = false;
-  data->Publish = false;
-  data->Immortal = false;
-  data->Age = 0;
+  auto rollback = [this](const QVector<PendingRoute>& pending) {
+    for (const PendingRoute& route : pending) {
+      MIB_IPFORWARD_ROW2* data = m_exclusionRoutes.take(route.first);
+      if (data == nullptr) {
+        continue;
+      }
+      if (data->InterfaceLuid.Value != 0) {
+        DWORD result = DeleteIpForwardEntry2(data);
+        if (result != NO_ERROR && result != ERROR_NOT_FOUND) {
+          logger.error() << "Failed to roll back exclusion route"
+                         << route.first.toString() << "result:" << result;
+          m_exclusionRoutes.insert(route.first, data);
+          continue;
+        }
+      }
+      delete data;
+    }
+  };
+  rollback(pendingIpv4);
+  rollback(pendingIpv6);
 
-  PMIB_IPFORWARD_TABLE2 table;
-  int family;
-  if (prefix.address().protocol() == QAbstractSocket::IPv6Protocol) {
-    family = AF_INET6;
-  } else {
-    family = AF_INET;
+  if (!pendingIpv4.isEmpty()) {
+    updateCapturedRoutes(AF_INET);
+  }
+  if (!pendingIpv6.isEmpty()) {
+    updateCapturedRoutes(AF_INET6);
   }
 
-  DWORD result = GetIpForwardTable2(family, &table);
-  if (result != NO_ERROR) {
-    logger.error() << "Failed to fetch routing table:" << result;
-    delete data;
-    return false;
-  }
-  updateInterfaceMetrics(family);
-  updateCapturedRoutes(family, table);
-  updateExclusionRoute(data, table);
-  FreeMibTable(table);
-
-  m_exclusionRoutes[prefix] = data;
-  return true;
+  return false;
 }
 
 bool WindowsRouteMonitor::deleteExclusionRoute(const IPAddress& prefix) {
@@ -441,11 +576,14 @@ bool WindowsRouteMonitor::deleteExclusionRoute(const IPAddress& prefix) {
     return true;
   }
 
-  DWORD result = DeleteIpForwardEntry2(data);
-  if ((result != ERROR_NOT_FOUND) && (result != NO_ERROR)) {
-    logger.error() << "Failed to delete route to"
-                   << prefix.toString()
-                   << "result:" << result;
+  if (data->InterfaceLuid.Value != 0) {
+    DWORD result = DeleteIpForwardEntry2(data);
+    if ((result != ERROR_NOT_FOUND) && (result != NO_ERROR)) {
+      logger.error() << "Failed to delete route to" << prefix.toString()
+                     << "result:" << result;
+      m_exclusionRoutes.insert(prefix, data);
+      return false;
+    }
   }
 
   // Captured routes might have changed.
@@ -459,11 +597,12 @@ void WindowsRouteMonitor::flushRouteTable(
     QHash<IPAddress, MIB_IPFORWARD_ROW2*>& table) {
   for (auto i = table.begin(); i != table.end(); i++) {
     MIB_IPFORWARD_ROW2* data = i.value();
-    DWORD result = DeleteIpForwardEntry2(data);
-    if ((result != ERROR_NOT_FOUND) && (result != NO_ERROR)) {
-      logger.error() << "Failed to delete route to"
-                     << i.key().toString()
-                     << "result:" << result;
+    if (data->InterfaceLuid.Value != 0) {
+      DWORD result = DeleteIpForwardEntry2(data);
+      if ((result != ERROR_NOT_FOUND) && (result != NO_ERROR)) {
+        logger.error() << "Failed to delete route to" << i.key().toString()
+                       << "result:" << result;
+      }
     }
     delete data;
   }
@@ -480,21 +619,30 @@ void WindowsRouteMonitor::setDetaultRouteCapture(bool enable) {
   }
 }
 
+void WindowsRouteMonitor::scheduleRouteChanged() {
+  if (!m_routeChangedDebounce.isActive()) {
+    m_routeChangedDebounce.start();
+  }
+}
+
 void WindowsRouteMonitor::routeChanged() {
   logger.debug() << "Routes changed";
 
-  PMIB_IPFORWARD_TABLE2 table;
+  PMIB_IPFORWARD_TABLE2 table = nullptr;
   DWORD result = GetIpForwardTable2(AF_UNSPEC, &table);
   if (result != NO_ERROR) {
     logger.error() << "Failed to fetch routing table:" << result;
     return;
   }
+  auto tableGuard = qScopeGuard([table] { FreeMibTable(table); });
 
-  updateInterfaceMetrics(AF_UNSPEC);
+  if (!updateInterfaceMetrics(AF_UNSPEC)) {
+    return;
+  }
   updateCapturedRoutes(AF_UNSPEC, table);
   for (MIB_IPFORWARD_ROW2* data : m_exclusionRoutes) {
-    updateExclusionRoute(data, table);
+    if (!updateExclusionRoute(data, table)) {
+      logger.error() << "Failed to refresh an exclusion route";
+    }
   }
-
-  FreeMibTable(table);
 }

--- a/client/platforms/windows/daemon/windowsroutemonitor.cpp
+++ b/client/platforms/windows/daemon/windowsroutemonitor.cpp
@@ -223,7 +223,7 @@ bool WindowsRouteMonitor::updateExclusionRoute(MIB_IPFORWARD_ROW2* data,
 
   // Update the routing table entry.
   data->InterfaceLuid.Value = bestLuid;
-  memcpy(&data->NextHop, &nexthop, sizeof(SOCKADDR_INET));
+  data->NextHop = nexthop;
   if (data->InterfaceLuid.Value != 0) {
     DWORD result = CreateIpForwardEntry2(data);
     if (result == ERROR_OBJECT_ALREADY_EXISTS) {
@@ -234,7 +234,7 @@ bool WindowsRouteMonitor::updateExclusionRoute(MIB_IPFORWARD_ROW2* data,
     if (result != NO_ERROR) {
       logger.error() << "Failed to update route:" << result;
       data->InterfaceLuid.Value = 0;
-      memset(&data->NextHop, 0, sizeof(SOCKADDR_INET));
+      data->NextHop = {};
       data->NextHop.si_family = data->DestinationPrefix.Prefix.si_family;
       return false;
     }
@@ -457,9 +457,14 @@ bool WindowsRouteMonitor::addExclusionRoutes(
     MIB_IPFORWARD_ROW2* data = new MIB_IPFORWARD_ROW2;
     InitializeIpForwardEntry(data);
     if (protocol == QAbstractSocket::IPv6Protocol) {
-      Q_IPV6ADDR buffer = address.toIPv6Address();
-      memcpy(&data->DestinationPrefix.Prefix.Ipv6.sin6_addr, &buffer,
-             sizeof(buffer));
+      const Q_IPV6ADDR buffer = address.toIPv6Address();
+      static_assert(
+          sizeof(buffer.c) ==
+          sizeof(data->DestinationPrefix.Prefix.Ipv6.sin6_addr.s6_addr));
+      for (int index = 0; index < static_cast<int>(sizeof(buffer.c)); ++index) {
+        data->DestinationPrefix.Prefix.Ipv6.sin6_addr.s6_addr[index] =
+            buffer[index];
+      }
       data->DestinationPrefix.Prefix.Ipv6.sin6_family = AF_INET6;
     } else {
       quint32 buffer = address.toIPv4Address();

--- a/client/platforms/windows/daemon/windowsroutemonitor.h
+++ b/client/platforms/windows/daemon/windowsroutemonitor.h
@@ -12,8 +12,11 @@
 #include <ws2ipdef.h>
 
 #include <QHash>
+#include <QList>
 #include <QMap>
 #include <QObject>
+#include <QSet>
+#include <QTimer>
 
 #include "ipaddress.h"
 
@@ -22,11 +25,15 @@ class WindowsRouteMonitor final : public QObject {
 
  public:
   WindowsRouteMonitor(quint64 luid, QObject* parent);
+
   ~WindowsRouteMonitor();
 
   void setDetaultRouteCapture(bool enable);
 
   bool addExclusionRoute(const IPAddress& prefix);
+
+  bool addExclusionRoutes(const QList<IPAddress>& prefixes);
+
   bool deleteExclusionRoute(const IPAddress& prefix);
   void flushExclusionRoutes() { return flushRouteTable(m_exclusionRoutes); };
 
@@ -35,6 +42,8 @@ class WindowsRouteMonitor final : public QObject {
  public slots:
   void routeChanged();
 
+  void scheduleRouteChanged();
+
  private:
   bool isRouteExcluded(const IP_ADDRESS_PREFIX* dest) const;
   static bool routeContainsDest(const IP_ADDRESS_PREFIX* route,
@@ -42,9 +51,12 @@ class WindowsRouteMonitor final : public QObject {
   static QHostAddress prefixToAddress(const IP_ADDRESS_PREFIX* dest);
 
   void flushRouteTable(QHash<IPAddress, MIB_IPFORWARD_ROW2*>& table);
-  void updateExclusionRoute(MIB_IPFORWARD_ROW2* data, void* table);
-  void updateInterfaceMetrics(int family);
+  bool updateExclusionRoute(MIB_IPFORWARD_ROW2* data, void* table);
+
+  bool updateInterfaceMetrics(int family);
+
   void updateCapturedRoutes(int family);
+
   void updateCapturedRoutes(int family, void* table);
 
   QHash<IPAddress, MIB_IPFORWARD_ROW2*> m_exclusionRoutes;
@@ -57,6 +69,7 @@ class WindowsRouteMonitor final : public QObject {
 
   const quint64 m_luid = 0;
   HANDLE m_routeHandle = INVALID_HANDLE_VALUE;
+  QTimer m_routeChangedDebounce;
 };
 
 #endif /* WINDOWSROUTEMONITOR_H */

--- a/client/platforms/windows/daemon/wireguardutilswindows.cpp
+++ b/client/platforms/windows/daemon/wireguardutilswindows.cpp
@@ -8,18 +8,161 @@
 #include <iphlpapi.h>
 #include <windows.h>
 #include <winsock2.h>
+#include <winsvc.h>
 #include <ws2ipdef.h>
 
 #include <QFileInfo>
+#include <QScopeGuard>
 
 #include "leakdetector.h"
 #include "logger.h"
 #include "windowsfirewall.h"
 
 #pragma comment(lib, "iphlpapi.lib")
+#pragma comment(lib, "advapi32.lib")
 
 namespace {
 Logger logger("WireguardUtilsWindows");
+
+constexpr qsizetype WCM_SUSPEND_ROUTE_THRESHOLD = 500;
+constexpr LONG NT_STATUS_SUCCESS = 0;
+
+using NtProcessFunction = LONG(NTAPI*)(HANDLE);
+NtProcessFunction ntSuspendProcess = nullptr;
+NtProcessFunction ntResumeProcess = nullptr;
+
+bool ensureNtProcessFunctions() {
+  static const bool initialized = [] {
+    HMODULE module = GetModuleHandleW(L"ntdll.dll");
+    if (module == nullptr) {
+      return false;
+    }
+
+    ntSuspendProcess = reinterpret_cast<NtProcessFunction>(
+        GetProcAddress(module, "NtSuspendProcess"));
+    ntResumeProcess = reinterpret_cast<NtProcessFunction>(
+        GetProcAddress(module, "NtResumeProcess"));
+    return ntSuspendProcess != nullptr && ntResumeProcess != nullptr;
+  }();
+  return initialized;
+}
+
+bool ensureDebugPrivilege() {
+  static const bool enabled = [] {
+    HANDLE token = nullptr;
+    if (!OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES,
+                          &token)) {
+      return false;
+    }
+    auto tokenGuard = qScopeGuard([token] { CloseHandle(token); });
+
+    TOKEN_PRIVILEGES privileges = {};
+    if (!LookupPrivilegeValueW(nullptr, SE_DEBUG_NAME,
+                               &privileges.Privileges[0].Luid)) {
+      return false;
+    }
+    privileges.PrivilegeCount = 1;
+    privileges.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
+
+    SetLastError(ERROR_SUCCESS);
+    if (!AdjustTokenPrivileges(token, FALSE, &privileges, sizeof(privileges),
+                               nullptr, nullptr)) {
+      return false;
+    }
+    return GetLastError() == ERROR_SUCCESS;
+  }();
+  return enabled;
+}
+
+DWORD getServiceProcessId(LPCWSTR serviceName) {
+  SC_HANDLE manager =
+      OpenSCManagerW(nullptr, nullptr, SC_MANAGER_CONNECT);
+  if (manager == nullptr) {
+    return 0;
+  }
+  auto managerGuard =
+      qScopeGuard([manager] { CloseServiceHandle(manager); });
+
+  SC_HANDLE service =
+      OpenServiceW(manager, serviceName, SERVICE_QUERY_STATUS);
+  if (service == nullptr) {
+    return 0;
+  }
+  auto serviceGuard =
+      qScopeGuard([service] { CloseServiceHandle(service); });
+
+  SERVICE_STATUS_PROCESS status = {};
+  DWORD bytesNeeded = 0;
+  if (!QueryServiceStatusEx(service, SC_STATUS_PROCESS_INFO,
+                            reinterpret_cast<LPBYTE>(&status), sizeof(status),
+                            &bytesNeeded)) {
+    return 0;
+  }
+  return status.dwProcessId;
+}
+
+class WcmServiceSuspender final {
+ public:
+  explicit WcmServiceSuspender(qsizetype routeCount) {
+    if (routeCount < WCM_SUSPEND_ROUTE_THRESHOLD) {
+      return;
+    }
+    if (!ensureNtProcessFunctions() || !ensureDebugPrivilege()) {
+      logger.warning() << "wcmSvc suspension is unavailable";
+      return;
+    }
+
+    const DWORD processId = getServiceProcessId(L"wcmSvc");
+    if (processId == 0) {
+      logger.warning() << "wcmSvc process was not found";
+      return;
+    }
+
+    m_process = OpenProcess(PROCESS_SUSPEND_RESUME, FALSE, processId);
+    if (m_process == nullptr) {
+      logger.warning() << "Failed to open wcmSvc process:" << GetLastError();
+      return;
+    }
+
+    const LONG status = ntSuspendProcess(m_process);
+    if (status != NT_STATUS_SUCCESS) {
+      logger.warning() << "Failed to suspend wcmSvc:" << status;
+      CloseHandle(m_process);
+      m_process = nullptr;
+      return;
+    }
+
+    m_suspended = true;
+    logger.debug() << "wcmSvc suspended for" << routeCount << "routes";
+  }
+
+  ~WcmServiceSuspender() {
+    if (m_process == nullptr) {
+      return;
+    }
+
+    if (m_suspended) {
+      LONG status = ntResumeProcess(m_process);
+      if (status != NT_STATUS_SUCCESS) {
+        status = ntResumeProcess(m_process);
+      }
+      if (status == NT_STATUS_SUCCESS) {
+        logger.debug() << "wcmSvc resumed";
+      } else {
+        logger.error() << "Failed to resume wcmSvc:" << status;
+      }
+    }
+    CloseHandle(m_process);
+  }
+
+  WcmServiceSuspender(const WcmServiceSuspender& other) = delete;
+
+  WcmServiceSuspender& operator=(const WcmServiceSuspender& other) = delete;
+
+ private:
+  HANDLE m_process = nullptr;
+  bool m_suspended = false;
+};
 };  // namespace
 
 std::unique_ptr<WireguardUtilsWindows> WireguardUtilsWindows::create(
@@ -309,7 +452,25 @@ bool WireguardUtilsWindows::deleteRoutePrefix(const IPAddress& prefix) {
 }
 
 bool WireguardUtilsWindows::addExclusionRoute(const IPAddress& prefix) {
+  if (!m_routeMonitor) {
+    logger.error() << "Route monitor is unavailable";
+    return false;
+  }
   return m_routeMonitor->addExclusionRoute(prefix);
+}
+
+bool WireguardUtilsWindows::addExclusionRoutes(
+    const QList<IPAddress>& prefixes) {
+  if (prefixes.isEmpty()) {
+    return true;
+  }
+  if (!m_routeMonitor) {
+    logger.error() << "Route monitor is unavailable";
+    return false;
+  }
+
+  WcmServiceSuspender suspender(prefixes.size());
+  return m_routeMonitor->addExclusionRoutes(prefixes);
 }
 
 bool WireguardUtilsWindows::deleteExclusionRoute(const IPAddress& prefix) {

--- a/client/platforms/windows/daemon/wireguardutilswindows.h
+++ b/client/platforms/windows/daemon/wireguardutilswindows.h
@@ -42,6 +42,9 @@ class WireguardUtilsWindows final : public WireguardUtils {
   bool deleteRoutePrefix(const IPAddress& prefix) override;
 
   bool addExclusionRoute(const IPAddress& prefix) override;
+
+  bool addExclusionRoutes(const QList<IPAddress>& prefixes) override;
+
   bool deleteExclusionRoute(const IPAddress& prefix) override;
 
   bool WireguardUtilsWindows::excludeLocalNetworks(const QList<IPAddress>& addresses) override;

--- a/client/vpnConnection.cpp
+++ b/client/vpnConnection.cpp
@@ -36,13 +36,45 @@
 
 using namespace ProtocolUtils;
 
+namespace
+{
+#ifdef AMNEZIA_DESKTOP
+    constexpr int splitDnsConcurrentLookupLimit = 16;
+    constexpr int splitDnsPreparationTimeoutMs = 10000;
+#endif
+
+    QStringList parseAllowedIps(const QString &allowedIps)
+    {
+        QStringList result;
+        const QStringList values = allowedIps.split(',', Qt::SkipEmptyParts);
+        for (const QString &value : values) {
+            const QString normalizedValue = value.trimmed();
+            if (!normalizedValue.isEmpty()) {
+                result.append(normalizedValue);
+            }
+        }
+        result.removeDuplicates();
+        return result;
+    }
+}
+
 VpnConnection::VpnConnection(SecureServersRepository* serversRepository, SecureAppSettingsRepository* appSettingsRepository, QObject *parent)
     : QObject(parent),
       m_serversRepository(serversRepository),
       m_appSettingsRepository(appSettingsRepository),
       m_checkTimer(this),
       m_connectionState(Vpn::ConnectionState::Disconnected)
+#ifdef AMNEZIA_DESKTOP
+    , m_splitDnsTimeoutTimer(this)
+#endif
 {
+#ifdef AMNEZIA_DESKTOP
+    m_splitDnsTimeoutTimer.setSingleShot(true);
+    connect(&m_splitDnsTimeoutTimer, &QTimer::timeout, this, [this]() {
+        finishSplitTunnelingPreparation(m_splitDnsRequestId, true);
+    });
+#endif
+
 #if defined(Q_OS_IOS) || defined(MACOS_NE)
     m_checkTimer.setInterval(1000);
     connect(IosController::Instance(), &IosController::connectionStateChanged, this, &VpnConnection::setConnectionState);
@@ -52,6 +84,10 @@ VpnConnection::VpnConnection(SecureServersRepository* serversRepository, SecureA
 
 VpnConnection::~VpnConnection()
 {
+#ifdef AMNEZIA_DESKTOP
+    ++m_splitDnsRequestId;
+    cancelSplitTunnelingPreparation();
+#endif
 }
 
 void VpnConnection::onBytesChanged(quint64 receivedBytes, quint64 sentBytes)
@@ -334,11 +370,27 @@ void VpnConnection::connectToVpn(const QString &serverId, DockerContainer contai
                         .arg(ContainerUtils::containerToString(container))
              << m_appSettingsRepository->routeMode();
 
+#ifdef AMNEZIA_DESKTOP
+    ++m_splitDnsRequestId;
+    cancelSplitTunnelingPreparation();
+#endif
+
     m_remoteAddress = NetworkUtilities::getIPAddress(vpnConfiguration.value(configKey::hostName).toString());
     setConnectionState(Vpn::ConnectionState::Connecting);
-
     m_vpnConfiguration = vpnConfiguration;
+    m_currentContainer = container;
 
+#ifdef AMNEZIA_DESKTOP
+    if (prepareSplitTunnelingSites(container)) {
+        return;
+    }
+#endif
+
+    startVpnConnection(container);
+}
+
+void VpnConnection::startVpnConnection(DockerContainer container)
+{
 #ifdef AMNEZIA_DESKTOP
     if (m_vpnProtocol) {
         disconnect(m_vpnProtocol.data(), &VpnProtocol::protocolError, this, &VpnConnection::vpnProtocolError);
@@ -377,6 +429,126 @@ void VpnConnection::connectToVpn(const QString &serverId, DockerContainer contai
     }
 }
 
+#ifdef AMNEZIA_DESKTOP
+bool VpnConnection::prepareSplitTunnelingSites(DockerContainer container)
+{
+    if ((!ContainerUtils::isAwgContainer(container) && container != DockerContainer::WireGuard)
+        || !m_appSettingsRepository->isSitesSplitTunnelingEnabled()) {
+        return false;
+    }
+
+    const RouteMode routeMode = m_appSettingsRepository->routeMode();
+    if (routeMode == RouteMode::VpnAllSites) {
+        return false;
+    }
+
+    const QVariantMap sites = m_appSettingsRepository->vpnSites(routeMode);
+    for (auto i = sites.constBegin(); i != sites.constEnd(); ++i) {
+        const QString site = i.key().trimmed();
+        if (!site.isEmpty() && !NetworkUtilities::checkIpSubnetFormat(site)) {
+            m_pendingSplitDomains.append(site);
+        }
+    }
+    m_pendingSplitDomains.removeDuplicates();
+
+    if (m_pendingSplitDomains.isEmpty()) {
+        return false;
+    }
+
+    m_pendingSplitContainer = container;
+    m_pendingSplitRouteMode = routeMode;
+    m_resolvedSplitSites.clear();
+    m_activeSplitDnsLookups.clear();
+    m_splitDnsPreparationActive = true;
+    m_splitDnsTimeoutTimer.start(splitDnsPreparationTimeoutMs);
+
+    qDebug() << "VpnConnection::prepareSplitTunnelingSites: resolving"
+             << m_pendingSplitDomains.size() << "domains before activating WG/AWG";
+    startNextSplitDnsLookups(m_splitDnsRequestId);
+    return true;
+}
+
+void VpnConnection::startNextSplitDnsLookups(quint64 requestId)
+{
+    if (!m_splitDnsPreparationActive || requestId != m_splitDnsRequestId) {
+        return;
+    }
+
+    while (!m_pendingSplitDomains.isEmpty()
+           && m_activeSplitDnsLookups.size() < splitDnsConcurrentLookupLimit) {
+        const QString site = m_pendingSplitDomains.takeFirst();
+        const QSharedPointer<int> lookupId = QSharedPointer<int>::create(-1);
+        *lookupId = QHostInfo::lookupHost(site, this, [this, requestId, site, lookupId](const QHostInfo &hostInfo) {
+            if (!m_splitDnsPreparationActive || requestId != m_splitDnsRequestId) {
+                return;
+            }
+
+            m_activeSplitDnsLookups.remove(*lookupId);
+            QStringList resolvedIps;
+            for (const QHostAddress &address : hostInfo.addresses()) {
+                if (address.protocol() == QAbstractSocket::IPv4Protocol) {
+                    resolvedIps.append(address.toString());
+                }
+            }
+            resolvedIps.removeDuplicates();
+            resolvedIps.sort();
+            if (!resolvedIps.isEmpty()) {
+                m_resolvedSplitSites.insert(site, resolvedIps);
+            }
+
+            startNextSplitDnsLookups(requestId);
+        });
+        m_activeSplitDnsLookups.insert(*lookupId);
+    }
+
+    if (m_pendingSplitDomains.isEmpty() && m_activeSplitDnsLookups.isEmpty()) {
+        finishSplitTunnelingPreparation(requestId, false);
+    }
+}
+
+void VpnConnection::finishSplitTunnelingPreparation(quint64 requestId, bool timedOut)
+{
+    if (!m_splitDnsPreparationActive || requestId != m_splitDnsRequestId) {
+        return;
+    }
+
+    const DockerContainer container = m_pendingSplitContainer;
+    const RouteMode routeMode = m_pendingSplitRouteMode;
+    const QMap<QString, QStringList> resolvedSites = m_resolvedSplitSites;
+    const qsizetype unresolvedCount = m_pendingSplitDomains.size() + m_activeSplitDnsLookups.size();
+    cancelSplitTunnelingPreparation();
+
+    if (!resolvedSites.isEmpty()) {
+        m_appSettingsRepository->replaceVpnSiteIps(routeMode, resolvedSites);
+    }
+
+    if (timedOut) {
+        qWarning() << "VpnConnection::finishSplitTunnelingPreparation: DNS preparation timed out;"
+                   << unresolvedCount << "domains will use their last stored addresses";
+    } else {
+        qDebug() << "VpnConnection::finishSplitTunnelingPreparation: resolved"
+                 << resolvedSites.size() << "domains";
+    }
+
+    startVpnConnection(container);
+}
+
+void VpnConnection::cancelSplitTunnelingPreparation()
+{
+    m_splitDnsTimeoutTimer.stop();
+    m_splitDnsPreparationActive = false;
+    const QSet<int> lookupIds = m_activeSplitDnsLookups;
+    m_activeSplitDnsLookups.clear();
+    for (const int lookupId : lookupIds) {
+        QHostInfo::abortHostLookup(lookupId);
+    }
+    m_pendingSplitDomains.clear();
+    m_resolvedSplitSites.clear();
+    m_pendingSplitContainer = DockerContainer::None;
+    m_pendingSplitRouteMode = RouteMode::VpnAllSites;
+}
+#endif
+
 void VpnConnection::createProtocolConnections()
 {
     connect(m_vpnProtocol.data(), &VpnProtocol::protocolError, this, &VpnConnection::vpnProtocolError);
@@ -385,8 +557,9 @@ void VpnConnection::createProtocolConnections()
 
 #ifdef AMNEZIA_DESKTOP
     IpcClient::withInterface([this](QSharedPointer<IpcInterfaceReplica> rep) {
-        connect(rep.data(), &IpcInterfaceReplica::networkChanged, this, &VpnConnection::reconnectToVpn, Qt::QueuedConnection);
-        connect(rep.data(), &IpcInterfaceReplica::wakeup, this, &VpnConnection::reconnectToVpn, Qt::QueuedConnection);
+        const auto connectionType = static_cast<Qt::ConnectionType>(Qt::QueuedConnection | Qt::UniqueConnection);
+        connect(rep.data(), &IpcInterfaceReplica::networkChanged, this, &VpnConnection::reconnectToVpn, connectionType);
+        connect(rep.data(), &IpcInterfaceReplica::wakeup, this, &VpnConnection::reconnectToVpn, connectionType);
     });
 #endif
 }
@@ -413,29 +586,38 @@ void VpnConnection::appendSplitTunnelingConfig()
 
     // this block is for old native configs and for old self-hosted configs
     auto protocolName = m_vpnConfiguration.value(configKey::vpnProto).toString();
-    if (protocolName == ProtocolUtils::protoToString(Proto::Awg) || protocolName == ProtocolUtils::protoToString(Proto::WireGuard)) {
+    if (protocolName == ProtocolUtils::protoToString(Proto::Awg)
+        || protocolName == ProtocolUtils::protoToString(Proto::WireGuard)) {
         allowSiteBasedSplitTunneling = false;
-        auto configData = m_vpnConfiguration.value(protocolName + "_config_data").toObject();
-        if (configData.value(configKey::allowedIps).isString()) {
-            QJsonArray allowedIpsJsonArray = QJsonArray::fromStringList(configData.value(configKey::allowedIps).toString().split(", "));
-            configData.insert(configKey::allowedIps, allowedIpsJsonArray);
-            m_vpnConfiguration.insert(protocolName + "_config_data", configData);
-        } else if (configData.value(configKey::allowedIps).isUndefined()) {
-            auto nativeConfig = configData.value(configKey::config).toString();
-            auto nativeConfigLines = nativeConfig.split("\n");
-            for (auto &line : nativeConfigLines) {
-                auto allowedIpsString = line.split("=", Qt::KeepEmptyParts);
-                if (allowedIpsString.size() >= 2 && allowedIpsString.first().trimmed() == QStringLiteral("AllowedIPs")) {
-                    QJsonArray allowedIpsJsonArray;
-                    const QString allowedIps = allowedIpsString.mid(1).join(QStringLiteral("=")).trimmed();
-                    for (const QString &allowedIp : allowedIps.split(",", Qt::SkipEmptyParts)) {
-                        allowedIpsJsonArray.append(allowedIp.trimmed());
-                    }
-                    configData.insert(configKey::allowedIps, allowedIpsJsonArray);
-                    m_vpnConfiguration.insert(protocolName + "_config_data", configData);
-                    break;
-                }
+        QJsonObject configData = m_vpnConfiguration.value(protocolName + "_config_data").toObject();
+        const QJsonValue allowedIpsValue = configData.value(configKey::allowedIps);
+        QStringList allowedIps;
+        if (allowedIpsValue.isArray()) {
+            const QJsonArray allowedIpsJsonArray = allowedIpsValue.toArray();
+            for (const QJsonValue &value : allowedIpsJsonArray) {
+                allowedIps.append(parseAllowedIps(value.toString()));
             }
+        } else if (allowedIpsValue.isString()) {
+            allowedIps = parseAllowedIps(allowedIpsValue.toString());
+        }
+        if (allowedIps.isEmpty()) {
+            const QStringList nativeConfigLines = configData.value(configKey::config).toString().split('\n');
+            for (const QString &line : nativeConfigLines) {
+                const qsizetype separatorIndex = line.indexOf('=');
+                if (separatorIndex < 0
+                    || line.left(separatorIndex).trimmed().compare(QStringLiteral("AllowedIPs"), Qt::CaseInsensitive)
+                            != 0) {
+                    continue;
+                }
+
+                allowedIps = parseAllowedIps(line.mid(separatorIndex + 1));
+                break;
+            }
+        }
+        allowedIps.removeDuplicates();
+        if (!allowedIps.isEmpty()) {
+            configData.insert(configKey::allowedIps, QJsonArray::fromStringList(allowedIps));
+            m_vpnConfiguration.insert(protocolName + "_config_data", configData);
         }
 
         if (configData.value(configKey::persistentKeepAlive).isUndefined()) {
@@ -453,10 +635,9 @@ void VpnConnection::appendSplitTunnelingConfig()
             }
         }
 
-        QJsonArray allowedIpsJsonArray = configData.value(configKey::allowedIps).toArray();
-        if (allowedIpsJsonArray.contains("0.0.0.0/0") && allowedIpsJsonArray.contains("::/0")) {
-            allowSiteBasedSplitTunneling = true;
-        }
+        // Desktop site routes currently contain IPv4 addresses, therefore an IPv4 default route is sufficient.
+        // Requiring an additional IPv6 default route disables valid IPv4-only WG/AWG configurations.
+        allowSiteBasedSplitTunneling = allowedIps.contains(QStringLiteral("0.0.0.0/0"));
     }
 
     amnezia::RouteMode routeMode = amnezia::RouteMode::VpnAllSites;
@@ -554,7 +735,8 @@ QString VpnConnection::bytesPerSecToText(quint64 bytes)
     return QString("%1 %2").arg(QString::number(mbps, 'f', 2)).arg(tr("Mbps")); // Mbit/s
 }
 
-void VpnConnection::reconnectToVpn() {
+void VpnConnection::reconnectToVpn()
+{
     if (m_vpnProtocol.isNull())
         return;
 
@@ -568,6 +750,19 @@ void VpnConnection::reconnectToVpn() {
 
     setConnectionState(Vpn::ConnectionState::Reconnecting);
 
+#ifdef AMNEZIA_DESKTOP
+    if (m_currentContainer != DockerContainer::None) {
+        ++m_splitDnsRequestId;
+        cancelSplitTunnelingPreparation();
+        if (prepareSplitTunnelingSites(m_currentContainer)) {
+            return;
+        }
+
+        startVpnConnection(m_currentContainer);
+        return;
+    }
+#endif
+
     m_vpnProtocol->stop();
     if (ErrorCode err = m_vpnProtocol->start(); err != ErrorCode::NoError) {
         setConnectionState(Vpn::ConnectionState::Error);
@@ -577,6 +772,11 @@ void VpnConnection::reconnectToVpn() {
 
 void VpnConnection::disconnectFromVpn()
 {
+#ifdef AMNEZIA_DESKTOP
+    ++m_splitDnsRequestId;
+    cancelSplitTunnelingPreparation();
+#endif
+
 #if defined(Q_OS_IOS) || defined(MACOS_NE)
     // iOS/macOS NE use IosController directly; m_vpnProtocol is not set there.
     IosController::Instance()->disconnectVpn();

--- a/client/vpnConnection.h
+++ b/client/vpnConnection.h
@@ -3,9 +3,12 @@
 
 #include <QObject>
 #include <QMetaObject>
+#include <QMap>
 #include <QString>
+#include <QStringList>
 #include <QScopedPointer>
 #include <QRemoteObjectNode>
+#include <QSet>
 #include <QTimer>
 
 #include "core/protocols/vpnProtocol.h"
@@ -31,6 +34,7 @@ class VpnConnection : public QObject
 
 public:
     explicit VpnConnection(SecureServersRepository* serversRepository, SecureAppSettingsRepository* appSettingsRepository, QObject* parent = nullptr);
+
     ~VpnConnection() override;
 
     static QString bytesPerSecToText(quint64 bytes);
@@ -49,8 +53,11 @@ public:
 
 public slots:
     void setRepositories(SecureServersRepository* serversRepository, SecureAppSettingsRepository* appSettingsRepository);
+
     void connectToVpn(const QString &serverId, DockerContainer container, const QJsonObject &vpnConfiguration);
+
     void reconnectToVpn();
+
     void disconnectFromVpn();
 
     void onKillSwitchModeChanged(bool enabled);
@@ -79,6 +86,7 @@ private:
     QJsonObject m_vpnConfiguration;
     QJsonObject m_routeMode;
     QString m_remoteAddress;
+    DockerContainer m_currentContainer = DockerContainer::None;
 
     // Only for iOS for now, check counters
     QTimer m_checkTimer;
@@ -96,6 +104,27 @@ private:
 
    void appendSplitTunnelingConfig();
    void appendKillSwitchConfig();
+
+   void startVpnConnection(DockerContainer container);
+
+#ifdef AMNEZIA_DESKTOP
+   bool prepareSplitTunnelingSites(DockerContainer container);
+
+   void startNextSplitDnsLookups(quint64 requestId);
+
+   void finishSplitTunnelingPreparation(quint64 requestId, bool timedOut);
+
+   void cancelSplitTunnelingPreparation();
+
+   QTimer m_splitDnsTimeoutTimer;
+   QStringList m_pendingSplitDomains;
+   QSet<int> m_activeSplitDnsLookups;
+   QMap<QString, QStringList> m_resolvedSplitSites;
+   DockerContainer m_pendingSplitContainer = DockerContainer::None;
+   RouteMode m_pendingSplitRouteMode = RouteMode::VpnAllSites;
+   quint64 m_splitDnsRequestId = 0;
+   bool m_splitDnsPreparationActive = false;
+#endif
 };
 
 #endif // VPNCONNECTION_H


### PR DESCRIPTION
## Summary

This PR makes domain-based split tunneling more reliable for WireGuard and AmneziaWG on Windows. It keeps all current IPv4 addresses for each hostname, refreshes them before connection and reconnection, applies exclusion routes as a batch, and makes Windows route reconciliation resilient to duplicate and failed route operations.

## Problem

I originally encountered two user-visible failures:

- an IPv4 CIDR exclusion such as `x.x.x.0/24` could be accepted and remain visible in settings without receiving a working Windows bypass route;
- domains and networks listed as exclusions could still be routed through the VPN tunnel, especially with IPv4-only WireGuard/AmneziaWG profiles.

Site exclusions could become incomplete or unstable for several independent reasons:

- a hostname could resolve to multiple IPv4 addresses, while stored and imported entries did not consistently retain the complete set;
- cached addresses could be stale when a WireGuard/AmneziaWG tunnel was started or reconnected;
- DNS resolution performed after tunnel activation could use a different route or resolver than the system and `hosts` configuration expected;
- IPv4-only WireGuard configurations were incorrectly treated as incompatible with site split tunneling unless both `0.0.0.0/0` and `::/0` were present;
- Windows exclusion routes were installed one by one while route-change notifications triggered repeated full reconciliations, which made large exclusion lists slow and prone to transient failures;
- route installation errors were not propagated consistently, so activation could continue with a partially applied exclusion list even though every entry remained visible in settings;
- repeated protocol setup could register duplicate reconnect handlers;

These issues could result in slow page loads, intermittent connections, or local/private hostnames timing out while the VPN was connected, even though the same destinations worked without the VPN.

## Changes

### Domain entries and persistence

- Normalize URLs and hostnames with `QUrl`, including IDN-to-ACE conversion and removal of a trailing dot.
- Validate IPv4 CIDRs strictly and reject malformed domain names and imported addresses.
- Store every unique IPv4 address associated with a hostname instead of a single address.
- Merge duplicate entries during JSON import.
- Export the full address list through `ips` while retaining the legacy `ip` field for backward compatibility.
- Continue reading legacy settings where a site contains one string instead of a string list.
- Associate asynchronous DNS results with the route mode in which the lookup was started, avoiding writes to a different list if the user changes the mode before the response arrives.

### DNS refresh before tunnel activation

- Resolve domain exclusions before starting WireGuard or AmneziaWG on desktop platforms.
- Use the system resolver, including local `hosts` mappings.
- Limit resolution to 16 concurrent lookups and a total preparation timeout of 10 seconds.
- Replace stored addresses only for domains that resolved successfully.
- Keep the last known addresses for unresolved domains so a temporary DNS failure does not erase a working configuration.
- Repeat the refresh on reconnect and cancel obsolete lookups on a new connection attempt, disconnect, or destruction.

### WireGuard and AmneziaWG configuration handling

- Parse `AllowedIPs` consistently from JSON arrays, strings, and native configuration text, regardless of comma spacing.
- Enable IPv4 site routes when `0.0.0.0/0` is present; `::/0` is no longer required for the currently IPv4-based site exclusion list.
- Use unique queued IPC subscriptions so repeated protocol creation does not multiply reconnect callbacks.

### Windows route handling

- Install exclusion routes as a batch and reuse one routing-table snapshot per address family.
- Apply reference-count updates only after the batch succeeds.
- Roll back newly added routes when activation or server switching fails.
- Propagate route errors instead of continuing with a partially configured exclusion list.
- Select and refresh the best physical interface and gateway for every exclusion route.
- Treat an already existing equivalent route as usable without claiming ownership of it.
- Skip duplicate and non-routable destinations.
- Debounce bursts of `NotifyRouteChange2` events and safely handle notifications without a route row.
- Avoid repeated attempts to clone the same conflicting captured route during one reconciliation pass.
- Clean up only routes owned by the monitor.
- For very large batches, temporarily pause `wcmSvc` route churn while applying the routes. This optimization is best-effort and falls back to normal batch installation if the required Windows APIs or privilege are unavailable.

## Related issues and overlapping pull requests

Related issues:

- [#2248](https://github.com/amnezia-vpn/amnezia-client/issues/2248) — slow and unstable Windows connection setup with large split-tunneling lists.
- [#2907](https://github.com/amnezia-vpn/amnezia-client/issues/2907) — site split tunneling not applied to imported AmneziaWG profiles.
- [#2939](https://github.com/amnezia-vpn/amnezia-client/issues/2939) — CIDR prefix handling for imported site entries.
- [#3020](https://github.com/amnezia-vpn/amnezia-client/issues/3020) — quadratic Windows route setup for large CIDR exclusion lists.

Overlapping pull requests:

- [#2825](https://github.com/amnezia-vpn/amnezia-client/pull/2825) — resolving multi-address hostnames before connection.
- [#3011](https://github.com/amnezia-vpn/amnezia-client/pull/3011) and [#3097](https://github.com/amnezia-vpn/amnezia-client/pull/3097) — IPv4-only WireGuard/AmneziaWG `AllowedIPs` handling.
- [#3018](https://github.com/amnezia-vpn/amnezia-client/pull/3018) — CIDR import regression coverage.
- [#3021](https://github.com/amnezia-vpn/amnezia-client/pull/3021) — batched Windows exclusion-route updates.

This PR keeps the split-tunneling changes together because the reproduced Windows failure crosses settings persistence, pre-connect DNS resolution, WireGuard/AmneziaWG configuration generation, and route application. Fixing only one layer did not restore reliable end-to-end bypass behavior in live testing.

## Backward compatibility

- Existing single-IP site settings remain readable.
- Exported JSON retains the legacy `ip` property and adds/updates the complete `ips` array.
- Split tunneling behavior is unchanged when site-based routing is disabled or the selected list contains no domain entries.
- DNS failures retain the previously stored addresses instead of clearing them.

## Verification

- Built the Windows x64 client, service, and IFW installer in Release mode against `dev` at [`94b51df2`](https://github.com/amnezia-vpn/amnezia-client/commit/94b51df24790bf52427afe82d81c87a95460bdfd) (`5.0.3.1`).
- Confirmed with `git range-diff` that the rebase preserves all three patch commits without changing their contents.

Live Windows checks were completed before this rebase with a real `vpn://` profile and the same patch:

- A large mixed exclusion list containing domains and IPv4 CIDRs.
- Public multi-address services and a private hostname resolved through the Windows `hosts` file.
- Excluded HTTPS sites and long-lived web connections remaining available while the VPN was connected.
- Disconnect/reconnect behavior with refreshed domain addresses.
