### PR TITLE
fix: read the full netlink route dump when detecting the default gateway

### DIFF
--- a/client/core/utils/networkUtilities.cpp
+++ b/client/core/utils/networkUtilities.cpp
@@ -23,6 +23,8 @@
     #include <sys/ioctl.h>
     #include <sys/socket.h>
     #include <unistd.h>
+    #include <climits>
+    #include <cstring>
 #endif
 #if defined(Q_OS_MAC) && !defined(Q_OS_IOS) && !defined(MACOS_NE)
     #include <sys/param.h>
@@ -291,124 +293,123 @@ QPair<QString, QNetworkInterface> NetworkUtilities::getGatewayAndIface()
     return { resGateway, QNetworkInterface::interfaceFromIndex(resIndex) };
 #endif
 #ifdef Q_OS_LINUX
+    // The routing table dump arrives as a sequence of netlink datagrams. Hosts with
+    // many interfaces (containers, VPNs, virtual bridges) easily produce a dump larger
+    // than any fixed-size buffer, so parse each datagram as it arrives instead of
+    // accumulating the whole dump first.
     constexpr int BUFFER_SIZE = 8192;
-    int     received_bytes = 0, msg_len = 0, route_attribute_len = 0;
-    int     sock = -1, msgseq = 0;
-    struct  nlmsghdr *nlh, *nlmsg;
-    struct  rtmsg *route_entry;
-    // This struct contain route attributes (route type)
-    struct  rtattr *route_attribute;
-    char    gateway_address[INET_ADDRSTRLEN], interface[IF_NAMESIZE];
-    char    msgbuf[100], buffer[BUFFER_SIZE];
-    char    *ptr = buffer;
-    struct timeval tv;
 
-    if ((sock = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE)) < 0) {
+    int sock = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
+    if (sock < 0) {
         perror("socket failed");
         return {};
     }
 
-    memset(msgbuf, 0, sizeof(msgbuf));
-    memset(gateway_address, 0, sizeof(gateway_address));
-    memset(interface, 0, sizeof(interface));
-    memset(buffer, 0, sizeof(buffer));
-
-    /* point the header and the msg structure pointers into the buffer */
-    nlmsg = (struct nlmsghdr *)msgbuf;
-
-    /* Fill in the nlmsg header*/
-    nlmsg->nlmsg_len = NLMSG_LENGTH(sizeof(struct rtmsg));
-    nlmsg->nlmsg_type = RTM_GETROUTE; // Get the routes from kernel routing table .
-    nlmsg->nlmsg_flags = NLM_F_DUMP | NLM_F_REQUEST; // The message is a request for dump.
-    nlmsg->nlmsg_seq = msgseq++; // Sequence of the message packet.
-    nlmsg->nlmsg_pid = getpid(); // PID of process sending the request.
-
     /* 1 Sec Timeout to avoid stall */
+    struct timeval tv = {};
     tv.tv_sec = 1;
-    setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (struct timeval *)&tv, sizeof(struct timeval));
-    /* send msg */
-    if (send(sock, nlmsg, nlmsg->nlmsg_len, 0) < 0) {
+    setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+    struct {
+        struct nlmsghdr nlh;
+        struct rtmsg rtm;
+    } request = {};
+    request.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(struct rtmsg));
+    request.nlh.nlmsg_type = RTM_GETROUTE;
+    request.nlh.nlmsg_flags = NLM_F_DUMP | NLM_F_REQUEST;
+    request.nlh.nlmsg_seq = 1;
+    request.rtm.rtm_family = AF_INET;
+
+    if (send(sock, &request, request.nlh.nlmsg_len, 0) < 0) {
         perror("send failed");
+        close(sock);
         return {};
     }
 
-    /* receive response */
-    do
-    {
-        received_bytes = recv(sock, ptr, sizeof(buffer) - msg_len, 0);
-        if (received_bytes < 0) {
-            perror("Error in recv");
-            return {};
-        }
+    char gateway_address[INET_ADDRSTRLEN] = {};
+    char interface[IF_NAMESIZE] = {};
+    unsigned int best_metric = UINT_MAX;
+    bool done = false;
+    char buffer[BUFFER_SIZE];
 
-        nlh = (struct nlmsghdr *) ptr;
-
-        /* Check if the header is valid */
-        if((NLMSG_OK(nlh, received_bytes) == 0) ||
-            (nlh->nlmsg_type == NLMSG_ERROR))
-        {
-            perror("Error in received packet");
-            return {};
-        }
-
-        /* If we received all data break */
-        if (nlh->nlmsg_type == NLMSG_DONE)
+    while (!done) {
+        ssize_t received_bytes = recv(sock, buffer, sizeof(buffer), 0);
+        if (received_bytes <= 0) {
+            if (received_bytes < 0) {
+                perror("Error in recv");
+            }
             break;
-        else {
-            ptr += received_bytes;
-            msg_len += received_bytes;
         }
 
-        /* Break if its not a multi part message */
-        if ((nlh->nlmsg_flags & NLM_F_MULTI) == 0)
-            break;
-    }
-    while ((nlh->nlmsg_seq != msgseq) || (nlh->nlmsg_pid != getpid()));
-
-    /* parse response */
-    int remaining = msg_len + received_bytes;
-    nlh = (struct nlmsghdr *) buffer;
-    for ( ; NLMSG_OK(nlh, remaining); nlh = NLMSG_NEXT(nlh, remaining))
-    {
-        /* Get the route data */
-        route_entry = (struct rtmsg *) NLMSG_DATA(nlh);
-
-        /* We are just interested in main routing table */
-        if (route_entry->rtm_table != RT_TABLE_MAIN)
-            continue;
-
-        /* Reset per-route to avoid cross-route state pollution */
-        memset(gateway_address, 0, sizeof(gateway_address));
-        memset(interface, 0, sizeof(interface));
-
-        route_attribute = (struct rtattr *) RTM_RTA(route_entry);
-        route_attribute_len = RTM_PAYLOAD(nlh);
-
-        /* Loop through all attributes */
-        for ( ; RTA_OK(route_attribute, route_attribute_len);
-             route_attribute = RTA_NEXT(route_attribute, route_attribute_len))
-        {
-            switch(route_attribute->rta_type) {
-            case RTA_OIF:
-                if_indextoname(*(int *)RTA_DATA(route_attribute), interface);
-                break;
-            case RTA_GATEWAY:
-                inet_ntop(AF_INET, RTA_DATA(route_attribute),
-                          gateway_address, sizeof(gateway_address));
-                break;
-            default:
+        int remaining = static_cast<int>(received_bytes);
+        struct nlmsghdr *nlh = reinterpret_cast<struct nlmsghdr *>(buffer);
+        for (; NLMSG_OK(nlh, remaining); nlh = NLMSG_NEXT(nlh, remaining)) {
+            if (nlh->nlmsg_type == NLMSG_DONE) {
+                done = true;
                 break;
             }
-        }
+            if (nlh->nlmsg_type == NLMSG_ERROR) {
+                perror("Error in received packet");
+                done = true;
+                break;
+            }
+            if (nlh->nlmsg_type != RTM_NEWROUTE) {
+                continue;
+            }
 
-        if ((*gateway_address) && (*interface)) {
-            qDebug() << "Gateway " << gateway_address << " for interface " << interface;
-            break;
+            const struct rtmsg *route_entry = static_cast<struct rtmsg *>(NLMSG_DATA(nlh));
+
+            /* We are just interested in the default route of the main routing table.
+             * Checking rtm_dst_len is essential: a VPN installs 0.0.0.0/1 and 128.0.0.0/1
+             * to override the default route, and those must not be mistaken for it. */
+            if (route_entry->rtm_table != RT_TABLE_MAIN || route_entry->rtm_dst_len != 0) {
+                continue;
+            }
+
+            char candidate_gateway[INET_ADDRSTRLEN] = {};
+            char candidate_interface[IF_NAMESIZE] = {};
+            unsigned int candidate_metric = 0;
+
+            struct rtattr *route_attribute = RTM_RTA(route_entry);
+            int route_attribute_len = RTM_PAYLOAD(nlh);
+
+            /* Loop through all attributes */
+            for (; RTA_OK(route_attribute, route_attribute_len);
+                 route_attribute = RTA_NEXT(route_attribute, route_attribute_len)) {
+                switch (route_attribute->rta_type) {
+                case RTA_OIF:
+                    if_indextoname(*static_cast<unsigned int *>(RTA_DATA(route_attribute)),
+                                   candidate_interface);
+                    break;
+                case RTA_GATEWAY:
+                    inet_ntop(AF_INET, RTA_DATA(route_attribute), candidate_gateway,
+                              sizeof(candidate_gateway));
+                    break;
+                case RTA_PRIORITY:
+                    candidate_metric = *static_cast<unsigned int *>(RTA_DATA(route_attribute));
+                    break;
+                default:
+                    break;
+                }
+            }
+
+            /* Multiple default routes may coexist; the kernel prefers the lowest metric. */
+            if ((*candidate_gateway) && (*candidate_interface) && candidate_metric < best_metric) {
+                best_metric = candidate_metric;
+                memcpy(gateway_address, candidate_gateway, sizeof(gateway_address));
+                memcpy(interface, candidate_interface, sizeof(interface));
+            }
         }
     }
-    if (!(*gateway_address) || !(*interface))
-        qDebug() << "getGatewayAndIface: no gateway found";
+
     close(sock);
+
+    if (!(*gateway_address) || !(*interface)) {
+        qDebug() << "getGatewayAndIface: no gateway found";
+        return {};
+    }
+
+    qDebug() << "Gateway " << gateway_address << " for interface " << interface;
     return { gateway_address, QNetworkInterface::interfaceFromName(interface) };
 #endif
 #if defined(Q_OS_MAC) && !defined(Q_OS_IOS) && !defined(MACOS_NE)


### PR DESCRIPTION
## Problem

On Linux, site-based split tunnelling silently stops working on hosts with many network interfaces. The exclusion list is still shown in the UI, but every route is skipped and all traffic goes through the tunnel. The only trace is in the service log:

```
LinuxRouteMonitor : Adding exclusion route for 84.252.149.0/24
LinuxRouteMonitor : No default gateway available, skipping exclusion route
Error in received packet: Numerical argument out of domain
```

Because nothing surfaces in the UI, this reads as a misconfiguration rather than a failure.

## Related reports

The failing log line appears in several open issues, where the consequence goes beyond split tunnelling: when the exclusion route to the VPN endpoint itself cannot be installed, endpoint traffic is routed into the tunnel, so the connection either passes no traffic or never completes a handshake.

Worth separating two different ways `getGatewayAndIface()` can come back empty, because this PR only addresses the first:

1. **A default route exists but is not found** - the dump overflows the buffer. That is the case measured here and what this patch fixes.
2. **No default route exists yet** - e.g. autoconnect racing network setup at boot. No parser can find what is not in the table; that needs a retry or a wait, not this change.

- #3090 - Ubuntu 24.04, 5.0.1.5 vs 4.8.21 on the same machine: `Error in received packet` and `No default gateway available` ten times each on 5.0.1.5, none on 4.8.21; endpoint routed into the tunnel, `sendmmsg: message too long`. Fits case 1; the route count on that host is not in the report yet.
- #2997 - second server reports `Connected` but passes no traffic, with `No default gateway available, skipping exclusion route` on a running system. Fits case 1.
- #3037 - autoconnect after reboot fails; reconnecting by hand then succeeds immediately. That points at case 2 rather than at this bug, since the route count does not change between the two attempts. Listing it because the log line is identical and the two causes are easy to confuse.
- #2048 - same family of symptoms; I could not tell which case applies from the report.

Verified only on my own host, so I am not marking any of these as fixed - maintainers can confirm which reports the change actually covers.

## Root cause

`NetworkUtilities::getGatewayAndIface()` accumulates the whole `RTM_GETROUTE` dump into a single 8 KiB buffer:

```c
received_bytes = recv(sock, ptr, sizeof(buffer) - msg_len, 0);
```

Two things make the dump large:

- `rtm_family` is never set (the request buffer is zeroed), so the kernel also returns IPv6 routes;
- container bridges, virtual machines and VPN interfaces each contribute routes.

Once `msg_len` reaches `sizeof(buffer)`, `recv()` is called with a zero-sized remainder, `NLMSG_OK()` fails and the function returns an empty pair. `LinuxRouteMonitor::rtmSendRoute()` then skips every `RTN_THROW` exclusion route.

Measured on an affected host (22 docker bridges, libvirt, tailscale, an active tunnel):

| | routes | dump size |
|---|---|---|
| Current request (`AF_UNSPEC`) | 118 | 10292 B |
| Buffer | | 8192 B |

The threshold is roughly 94 routes at ~87 bytes per entry. Below it everything works, which is why this does not show up on a typical desktop.

## Fix

- Parse each netlink datagram as it arrives instead of accumulating the whole dump, removing the dependency on any fixed dump size.
- Set `rtm_family = AF_INET`. The gateway is decoded with `inet_ntop(AF_INET, ...)`, so an IPv6 route reaching that code would have produced a bogus IPv4 address.
- Require `rtm_dst_len == 0` when selecting the route. The previous code accepted the first route carrying a gateway, which is not necessarily the default one. This matters for a VPN client in particular: `0.0.0.0/1` and `128.0.0.0/1` are installed precisely to shadow the default route.
- Prefer the lowest metric among several default routes, matching kernel behaviour.

Behaviour is unchanged on hosts where the dump already fitted into the buffer. Logging is left as it was, to keep the change focused.

## Relation to earlier work

This is not the first report of the problem, and the fix deliberately differs in approach.

- **#2862** (merged, shipped in 5.0.0.5) raised `BUFFER_SIZE` from 100 to 8192 and fixed the receive loop, which until then tested `NLM_F_MULTI` on the *request* header rather than the response and therefore exited after the first `recv()`. In 4.8.x the function effectively parsed only the first ~100 bytes of the dump - a single route message. That happened to be the default route whenever it comes first in the main table, which is the case at the moment the endpoint exclusion route is installed, before the tunnel's `0.0.0.0/1` routes exist. So 4.8.21 found the gateway by accident of dump ordering; #2862 made the loop read the whole dump and thereby exposed the overflow on hosts whose dump exceeds 8 KiB. This is why users report 4.8.21 working on a machine where 5.0.x does not (#3090).
- **#2287** (open since February, no review yet) diagnosed the same overflow back when the buffer was 100 bytes, and proposed 16384 plus an `AF_INET` filter. It also carries fixes outside the scope of this PR (socket fd leaks, `nlmsg_seq` validation, extra logging in the daemon) that remain worth taking on their own.

Both keep a fixed buffer, so the dump size stays a hard limit and the threshold merely moves. The host in this report already exceeds 8192 with a routine developer setup, and adding interfaces would eventually exceed 16384 too. Parsing datagrams as they arrive removes the limit rather than raising it, which is why this PR takes that route instead of picking a larger constant.

If maintainers prefer to land #2287 first, this change rebases onto it without conflict beyond the same function body.

## Testing

The patched block was extracted, compiled standalone with `-Wall -Wextra -Wpedantic` (no warnings) and run on the affected host:

```
candidate: 192.168.0.1 dev wlp9s0 metric 600
datagrams received: 2, candidates: 1
RESULT: gateway 192.168.0.1 via wlp9s0 (metric 600)
```

The same host returned no gateway before the change. With the gateway resolved, the exclusion routes are installed and site-based split tunnelling works as configured.

