### PR TITLE
fix(macOS): preserve app signature and scope launchd socket

### DIFF
--- a/deploy/data/macos/AmneziaVPN.plist
+++ b/deploy/data/macos/AmneziaVPN.plist
@@ -24,6 +24,8 @@
 	        <string>stream</string>
 	        <key>SockFamily</key>
 	        <string>IPv4</string>
+	        <key>SockNodeName</key>
+	        <string>127.0.0.1</string>
 	    </dict>
 	</dict>
 </dict>

--- a/deploy/data/macos/post_install.sh
+++ b/deploy/data/macos/post_install.sh
@@ -56,7 +56,7 @@ run_cmd osascript -e 'tell application "AmneziaVPN" to quit' || true
 
 PLIST_SOURCE="$APP_PATH/Contents/Resources/$PLIST_NAME"
 if [ -f "$PLIST_SOURCE" ]; then
-  run_cmd mv -f "$PLIST_SOURCE" "$LAUNCH_DAEMONS_PLIST_NAME"
+  run_cmd cp -f "$PLIST_SOURCE" "$LAUNCH_DAEMONS_PLIST_NAME"
 else
   log "ERROR: service plist not found at $PLIST_SOURCE"
 fi


### PR DESCRIPTION
## Summary

- preserve the signed `AmneziaVPN.plist` resource inside the installed app bundle
- bind launchd's compatibility/service socket to loopback instead of every IPv4 interface

## Problem

The macOS `post_install.sh` currently moves `Contents/Resources/AmneziaVPN.plist` to `/Library/LaunchDaemons`. Because that resource is part of the signed app bundle, the installed app no longer passes sealed-resource validation:

```text
$ codesign --verify --deep --strict --verbose=4 /Applications/AmneziaVPN.app
/Applications/AmneziaVPN.app: a sealed resource is missing or invalid
file missing: /Applications/AmneziaVPN.app/Contents/Resources/AmneziaVPN.plist
```

The LaunchDaemon plist also creates a passive TCP listener on every IPv4 interface:

```text
$ netstat -anv -p tcp | grep 5959
tcp4  0  0  *.5959  *.*  LISTEN  ...  launchd:1
```

The service's actual client IPC is implemented with `QLocalServer` at `/var/run/amneziavpn/daemon.socket` (falling back to `/tmp/amneziavpn.socket`), so the launchd TCP socket does not need LAN exposure.

Observed with release `5.0.1.5` on macOS 26.3.1 arm64. The same installer/plist behavior is still present on `dev`.

## Changes

1. Copy the plist into `/Library/LaunchDaemons` instead of moving it out of the signed bundle.
2. Set `SockNodeName` to `127.0.0.1` for the launchd socket.

This keeps the app bundle intact while retaining the existing LaunchDaemon installation and socket activation behavior.

## Validation

- `bash -n deploy/data/macos/post_install.sh`
- `plutil -lint deploy/data/macos/AmneziaVPN.plist`
- `git diff --check`

No changes were applied to the live installation while preparing this PR.
