### PR TITLE
Fix default MTU value for AmneziaWG

### DIFF
--- a/client/core/controllers/selfhosted/importController.cpp
+++ b/client/core/controllers/selfhosted/importController.cpp
@@ -748,8 +748,10 @@ void ImportController::processAmneziaConfig(QJsonObject &config) const
             }
 
             QJsonObject jsonConfig = QJsonDocument::fromJson(protocolConfig.toUtf8()).object();
-            jsonConfig[configKey::mtu] =
-                    ContainerUtils::isAwgContainer(dockerContainer) ? protocols::awg::defaultMtu : protocols::wireguard::defaultMtu;
+            if (jsonConfig.value(configKey::mtu).toString().isEmpty()) {
+                jsonConfig[configKey::mtu] =
+                        ContainerUtils::isAwgContainer(dockerContainer) ? protocols::awg::defaultMtu : protocols::wireguard::defaultMtu;
+            }
 
             containerConfig[configKey::lastConfig] = QString(QJsonDocument(jsonConfig).toJson());
 

--- a/client/core/utils/constants/protocolConstants.h
+++ b/client/core/utils/constants/protocolConstants.h
@@ -152,11 +152,7 @@ namespace amnezia
             constexpr char defaultPort[] = "51820";
             constexpr char defaultPersistentKeepAlive[] = "25";
 
-#if defined(Q_OS_ANDROID) || defined(Q_OS_IOS) || defined(MACOS_NE)
             constexpr char defaultMtu[] = "1280";
-#else
-            constexpr char defaultMtu[] = "1376";
-#endif
             constexpr char serverConfigPath[] = "/opt/amnezia/wireguard/wg0.conf";
             constexpr char serverPublicKeyPath[] = "/opt/amnezia/wireguard/wireguard_server_public_key.key";
             constexpr char serverPskKeyPath[] = "/opt/amnezia/wireguard/wireguard_psk.key";
@@ -172,11 +168,7 @@ namespace amnezia
         namespace awg
         {
             constexpr char defaultPort[] = "55424";
-#if defined(Q_OS_ANDROID) || defined(Q_OS_IOS) || defined(MACOS_NE)
             constexpr char defaultMtu[] = "1280";
-#else
-            constexpr char defaultMtu[] = "1376";
-#endif
 
             constexpr char serverConfigPath[] = "/opt/amnezia/awg/awg0.conf";
             constexpr char serverLegacyConfigPath[] = "/opt/amnezia/awg/wg0.conf";


### PR DESCRIPTION
Fix default MTU value for AmneziaWG
Было 1376 для windows/linux и 1280 для всего остального
теперь 1280 для всех, иначе теряются мелкие пакеты