### PR TITLE
feat: edit the SSH connection settings of a self hosted server

### DIFF
--- a/client/core/controllers/serversController.cpp
+++ b/client/core/controllers/serversController.cpp
@@ -83,6 +83,30 @@ bool ServersController::renameServer(const QString &serverId, const QString &nam
     }
 }
 
+bool ServersController::updateServerCredentials(const QString &serverId, const QString &userName, int port,
+                                                const QString &password)
+{
+    // Only a self hosted server the user administers keeps SSH credentials;
+    // every other kind is driven by a config and has nothing to update.
+    if (m_serversRepository->serverKind(serverId) != serverConfigUtils::ConfigType::SelfHostedAdmin) {
+        return false;
+    }
+
+    auto cfg = m_serversRepository->selfHostedAdminConfig(serverId);
+    if (!cfg.has_value() || userName.isEmpty() || port <= 0) {
+        return false;
+    }
+
+    cfg->userName = userName;
+    cfg->port = port;
+    if (!password.isEmpty()) {
+        cfg->password = password;
+    }
+
+    m_serversRepository->editServer(serverId, cfg->toJson(), serverConfigUtils::ConfigType::SelfHostedAdmin);
+    return true;
+}
+
 void ServersController::removeServer(const QString &serverId)
 {
     m_serversRepository->removeServer(serverId);

--- a/client/core/controllers/serversController.h
+++ b/client/core/controllers/serversController.h
@@ -37,6 +37,10 @@ public:
 
     // Server management
     bool renameServer(const QString &serverId, const QString &name);
+    // An empty password keeps the stored one, so the caller can change just the
+    // user name or the port without ever handling the secret.
+    bool updateServerCredentials(const QString &serverId, const QString &userName, int port,
+                                 const QString &password);
     void removeServer(const QString &serverId);
     void setDefaultServer(const QString &serverId);
 

--- a/client/ui/controllers/selfhosted/installUiController.cpp
+++ b/client/ui/controllers/selfhosted/installUiController.cpp
@@ -613,6 +613,28 @@ bool InstallUiController::checkSshConnection()
     return true;
 }
 
+bool InstallUiController::checkServerCredentials(const QString &serverId, const QString &userName, int port,
+                                                 const QString &password)
+{
+    ServerCredentials credentials = m_serversController->getServerCredentials(serverId);
+    if (credentials.hostName.isEmpty()) {
+        return false;
+    }
+
+    credentials.userName = userName;
+    credentials.port = port;
+    if (!password.isEmpty()) {
+        credentials.secretData = password;
+    }
+
+    if (!credentials.isValid()) {
+        return false;
+    }
+
+    m_processedServerCredentials = credentials;
+    return checkSshConnection();
+}
+
 void InstallUiController::setEncryptedPassphrase(QString passphrase)
 {
     m_privateKeyPassphrase = passphrase;

--- a/client/ui/controllers/selfhosted/installUiController.h
+++ b/client/ui/controllers/selfhosted/installUiController.h
@@ -84,6 +84,11 @@ public slots:
 
     bool checkSshConnection();
 
+    // Tries a stored server with a different user name, port or password before
+    // any of it is saved. An empty password reuses the stored one, so the port
+    // can be fixed without retyping the secret.
+    bool checkServerCredentials(const QString &serverId, const QString &userName, int port, const QString &password);
+
     void setEncryptedPassphrase(QString passphrase);
 
     void addEmptyServer();

--- a/client/ui/controllers/serversUiController.cpp
+++ b/client/ui/controllers/serversUiController.cpp
@@ -103,6 +103,46 @@ void ServersUiController::editServerName(const QString &serverId, const QString 
     updateModel();
 }
 
+bool ServersUiController::serverHasCredentials(const QString &serverId) const
+{
+    if (serverId.isEmpty()) {
+        return false;
+    }
+    return m_serversController->getServerCredentials(serverId).isValid();
+}
+
+QString ServersUiController::serverUserName(const QString &serverId) const
+{
+    if (serverId.isEmpty()) {
+        return {};
+    }
+    return m_serversController->getServerCredentials(serverId).userName;
+}
+
+int ServersUiController::serverSshPort(const QString &serverId) const
+{
+    if (serverId.isEmpty()) {
+        return 0;
+    }
+    return m_serversController->getServerCredentials(serverId).port;
+}
+
+void ServersUiController::editServerCredentials(const QString &serverId, const QString &userName, int port,
+                                                const QString &password)
+{
+    if (serverId.isEmpty()) {
+        return;
+    }
+
+    if (!m_serversController->updateServerCredentials(serverId, userName, port, password)) {
+        emit errorOccurred(tr("This server has no stored credentials to update."));
+        return;
+    }
+
+    updateModel();
+    emit finished(tr("Credentials updated"));
+}
+
 void ServersUiController::setDefaultServer(const QString &serverId)
 {
     if (serverId.isEmpty()) {

--- a/client/ui/controllers/serversUiController.h
+++ b/client/ui/controllers/serversUiController.h
@@ -53,6 +53,13 @@ public slots:
 
     void editServerName(const QString &serverId, const QString &name);
 
+    // SSH credentials of a self hosted server. The stored password is never
+    // handed back to QML, it can only be replaced.
+    bool serverHasCredentials(const QString &serverId) const;
+    QString serverUserName(const QString &serverId) const;
+    int serverSshPort(const QString &serverId) const;
+    void editServerCredentials(const QString &serverId, const QString &userName, int port, const QString &password);
+
     void setDefaultServer(const QString &serverId);
     void setDefaultServerAtIndex(int index);
 

--- a/client/ui/qml/Pages2/PageSettingsServerCredentials.qml
+++ b/client/ui/qml/Pages2/PageSettingsServerCredentials.qml
@@ -1,0 +1,168 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import PageEnum 1.0
+import Style 1.0
+
+import "./"
+import "../Controls2"
+import "../Config"
+import "../Controls2/TextTypes"
+import "../Components"
+
+PageType {
+    id: root
+
+    readonly property string serverId: ServersUiController.processedServerId
+
+    BackButtonType {
+        id: backButton
+
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.topMargin: 20 + PageController.safeAreaTopMargin
+
+        onFocusChanged: {
+            if (this.activeFocus) {
+                listView.positionViewAtBeginning()
+            }
+        }
+    }
+
+    ListViewType {
+        id: listView
+
+        anchors.top: backButton.bottom
+        anchors.bottom: parent.bottom
+        anchors.right: parent.right
+        anchors.left: parent.left
+
+        header: ColumnLayout {
+            width: listView.width
+            spacing: 16
+
+            BaseHeaderType {
+                Layout.fillWidth: true
+                Layout.leftMargin: 16
+                Layout.rightMargin: 16
+
+                headerText: qsTr("SSH connection")
+                descriptionText: qsTr("Used to manage the server: installing protocols and services, rebooting and clearing it. The VPN connection itself does not use them.")
+            }
+        }
+
+        model: 1 // fake model to force the ListView to be created without a model
+
+        delegate: ColumnLayout {
+            width: listView.width
+            spacing: 16
+
+            LabelWithButtonType {
+                Layout.fillWidth: true
+
+                text: qsTr("Server address")
+                descriptionText: ServersUiController.serverHostName(root.serverId)
+                descriptionOnTop: true
+            }
+
+            DividerType {}
+
+            TextFieldWithHeaderType {
+                id: userNameField
+
+                Layout.fillWidth: true
+                Layout.leftMargin: 16
+                Layout.rightMargin: 16
+
+                headerText: qsTr("User name")
+                textField.text: ServersUiController.serverUserName(root.serverId)
+            }
+
+            TextFieldWithHeaderType {
+                id: portField
+
+                Layout.fillWidth: true
+                Layout.leftMargin: 16
+                Layout.rightMargin: 16
+
+                headerText: qsTr("SSH port")
+                textField.text: ServersUiController.serverSshPort(root.serverId)
+                textField.validator: IntValidator { bottom: 1; top: 65535 }
+            }
+
+            TextFieldWithHeaderType {
+                id: passwordField
+
+                property bool hidePassword: true
+
+                Layout.fillWidth: true
+                Layout.leftMargin: 16
+                Layout.rightMargin: 16
+
+                headerText: qsTr("New password or private key")
+                // The stored secret is never shown, it can only be replaced
+                textField.placeholderText: qsTr("Leave empty to keep the current one")
+
+                textField.echoMode: hidePassword ? TextInput.Password : TextInput.Normal
+                buttonImageSource: textField.text !== "" ? (hidePassword ? "qrc:/images/controls/eye.svg" : "qrc:/images/controls/eye-off.svg")
+                                                         : ""
+
+                clickedFunc: function() {
+                    hidePassword = !hidePassword
+                }
+            }
+
+            WarningType {
+                Layout.fillWidth: true
+                Layout.leftMargin: 16
+                Layout.rightMargin: 16
+
+                textString: qsTr("The address cannot be changed here: it is also the address your VPN configs point at, so a server that moved has to be added again. Everything else is tried against the server before it is saved, and nothing is stored if it does not work.")
+                iconPath: "qrc:/images/controls/alert-circle.svg"
+            }
+
+            BasicButtonType {
+                id: saveButton
+
+                Layout.fillWidth: true
+                Layout.margins: 16
+
+                text: qsTr("Save")
+
+                clickedFunc: function() {
+                    var userName = userNameField.textField.text.replace(/^\s+|\s+$/g, '')
+                    var port = parseInt(portField.textField.text)
+                    var password = passwordField.textField.text.replace(/^\s+|\s+$/g, '')
+
+                    userNameField.errorText = ""
+                    portField.errorText = ""
+
+                    if (userName === "") {
+                        userNameField.errorText = qsTr("User name cannot be empty")
+                        return
+                    }
+                    if (isNaN(port) || port < 1 || port > 65535) {
+                        portField.errorText = qsTr("Port must be between 1 and 65535")
+                        return
+                    }
+
+                    // Try them against the server first, the same check the setup
+                    // wizard runs. On failure the controller reports the error and
+                    // we stay on the page with the values still filled in.
+                    PageController.showBusyIndicator(true)
+                    var isConnectionOpened = InstallController.checkServerCredentials(root.serverId, userName, port, password)
+                    PageController.showBusyIndicator(false)
+                    if (!isConnectionOpened) {
+                        return
+                    }
+
+                    ServersUiController.editServerCredentials(root.serverId, userName, port, password)
+                    passwordField.textField.text = ""
+                    PageController.closePage()
+                }
+            }
+        }
+    }
+}

--- a/client/ui/qml/Pages2/PageSettingsServerData.qml
+++ b/client/ui/qml/Pages2/PageSettingsServerData.qml
@@ -84,12 +84,26 @@ PageType {
     }
 
     property list<QtObject> serverActions: [
+        credentials,
         check,
         reboot,
         remove,
         clear,
         reset,
     ]
+
+    QtObject {
+        id: credentials
+
+        property bool isVisible: root.isServerWithWriteAccess
+                                 && ServersUiController.serverHasCredentials(ServersUiController.processedServerId)
+        readonly property string title: qsTr("SSH connection")
+        readonly property string description: qsTr("User name, port and password the application uses to manage this server")
+        readonly property var tColor: AmneziaStyle.color.paleGray
+        readonly property var clickedHandler: function() {
+            PageController.goToPage(PageEnum.PageSettingsServerCredentials)
+        }
+    }
 
     QtObject {
         id: check

--- a/client/ui/qml/qml.qrc
+++ b/client/ui/qml/qml.qrc
@@ -107,6 +107,7 @@
         <file>Pages2/PageSettingsKillSwitchExceptions.qml</file>
         <file>Pages2/PageSettingsLogging.qml</file>
         <file>Pages2/PageSettingsServerData.qml</file>
+        <file>Pages2/PageSettingsServerCredentials.qml</file>
         <file>Pages2/PageSettingsServerInfo.qml</file>
         <file>Pages2/PageSettingsServerProtocol.qml</file>
         <file>Pages2/PageSettingsServerProtocols.qml</file>

--- a/client/ui/utils/pageEnum.h
+++ b/client/ui/utils/pageEnum.h
@@ -88,6 +88,7 @@ namespace PageLoader
         PageProtocolXrayXPaddingBytesSettings,
 
         PageSettingsLanguage,
+        PageSettingsServerCredentials,
     };
     Q_ENUM_NS(PageEnum)
 


### PR DESCRIPTION
Once a server is added there is no way to change the SSH user name, port or password the application uses to manage it. If any of them changes on the server, installing protocols and services, rebooting and clearing it stop working, and the only way out is to remove the server and add it again.

This adds an "SSH connection" entry to the server management tab, for self hosted servers only. User name and port are editable; the stored secret is never handed to QML and can only be replaced, and leaving that field empty keeps the current one, so the port can be fixed without retyping it.

Everything is tried against the server before it is saved, through the same InstallController::checkSshConnection the setup wizard runs. If it fails nothing is stored and the page stays open with the values filled in.

The address is shown but not editable: it is also baked into the generated protocol configs, so changing it here would leave management and the VPN pointing at different hosts. A server that moved still has to be added again.

I have no Qt toolchain on this machine, so this is checked by reading the code and with qmllint. The screenshots are the real QML rendered in a bare Qt Quick window.

| Management tab | The page |
| --- | --- |
| ![management tab](https://raw.githubusercontent.com/WkdXeqtr/amnezia-client/pr-screens-tv-focus/screens/ssh_menu.png) | ![ssh connection page](https://raw.githubusercontent.com/WkdXeqtr/amnezia-client/pr-screens-tv-focus/screens/ssh_page.png) |
