### PR TITLE
Add local JSON CLI control interface

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -286,6 +286,22 @@ install(SCRIPT ${QT_DEPLOY_SCRIPT}
     COMPONENT AmneziaVPN
 )
 
+option(AMNEZIA_BUILD_CLI_CONTROL_TESTS "Build CLI control protocol tests" OFF)
+if(AMNEZIA_BUILD_CLI_CONTROL_TESTS)
+    include(CTest)
+    qt_add_executable(cli-control-protocol-test
+        tests/cliControlProtocolTest.cpp
+        core/utils/cliControlProtocol.cpp
+        core/utils/cliControlProtocol.h
+    )
+    target_include_directories(cli-control-protocol-test PRIVATE ${CMAKE_CURRENT_LIST_DIR})
+    target_link_libraries(cli-control-protocol-test PRIVATE Qt6::Core)
+    if(APPLE)
+        set_target_properties(cli-control-protocol-test PROPERTIES OSX_ARCHITECTURES "${CMAKE_HOST_SYSTEM_PROCESSOR}")
+    endif()
+    add_test(NAME cli-control-protocol COMMAND cli-control-protocol-test)
+endif()
+
 if (APPLE AND NOT IOS AND NOT MACOS_NE)
     list(APPEND OVPN_SCRIPTS "${CMAKE_SOURCE_DIR}/deploy/data/macos/update-resolv-conf.sh")
     set_target_properties(${PROJECT} PROPERTIES

--- a/client/amneziaApplication.cpp
+++ b/client/amneziaApplication.cpp
@@ -5,11 +5,14 @@
 #include <QLocalServer>
 #include <QLocalSocket>
 #include <QMimeData>
+#include <QJsonDocument>
+#include <QJsonParseError>
 #include <QQuickItem>
 #include <QQuickStyle>
 #include <QResource>
 #include <QStandardPaths>
 #include <QTextDocument>
+#include <QTextStream>
 #include <QTimer>
 #include <QTranslator>
 #include <QEvent>
@@ -41,8 +44,12 @@ bool AmneziaApplication::m_forceQuit = false;
 AmneziaApplication::AmneziaApplication(int &argc, char *argv[]) : AMNEZIA_BASE_CLASS(argc, argv),
       m_optAutostart({QStringLiteral("a"), QStringLiteral("autostart")}, QStringLiteral("System autostart")),
       m_optCleanup  ({QStringLiteral("c"), QStringLiteral("cleanup")}, QStringLiteral("Cleanup logs")),
-      m_optConnect  ({QStringLiteral("connect")}, QStringLiteral("Connect to server by index on startup"), QStringLiteral("index")),
-      m_optImport   ({QStringLiteral("import")}, QStringLiteral("Import configuration from data string"), QStringLiteral("data"))
+      m_optConnect  ({QStringLiteral("connect")}, QStringLiteral("Connect to server by stable ID (a legacy zero-based index is also accepted)"), QStringLiteral("server")),
+      m_optImport   ({QStringLiteral("import")}, QStringLiteral("Import configuration from data string"), QStringLiteral("data")),
+      m_optStatus   ({QStringLiteral("status")}, QStringLiteral("Print connection status as JSON")),
+      m_optListServers({QStringLiteral("list-servers")}, QStringLiteral("Print configured servers as JSON")),
+      m_optDisconnect({QStringLiteral("disconnect")}, QStringLiteral("Disconnect the active VPN connection")),
+      m_optToggle   ({QStringLiteral("toggle")}, QStringLiteral("Toggle the default VPN connection"))
 {
     setDesktopFileName(QStringLiteral(APPLICATION_NAME));
     setQuitOnLastWindowClosed(false);
@@ -207,17 +214,6 @@ void AmneziaApplication::init()
     });
 #endif
 
-    if (m_parser.isSet(m_optConnect)) {
-        bool ok = false;
-        int idx = m_parser.value(m_optConnect).toInt(&ok);
-        if (ok) {
-            QTimer::singleShot(0, this, [this, idx]() {
-                if (m_coreController) {
-                    m_coreController->openConnectionByIndex(idx);
-                }
-            });
-        }
-    }
 }
 
 void AmneziaApplication::registerTypes()
@@ -268,6 +264,10 @@ bool AmneziaApplication::parseCommands()
     m_parser.addOption(m_optCleanup);
     m_parser.addOption(m_optConnect);
     m_parser.addOption(m_optImport);
+    m_parser.addOption(m_optStatus);
+    m_parser.addOption(m_optListServers);
+    m_parser.addOption(m_optDisconnect);
+    m_parser.addOption(m_optToggle);
     
     m_parser.process(*this);
 
@@ -281,20 +281,151 @@ bool AmneziaApplication::parseCommands()
 }
 
 #if !defined(Q_OS_ANDROID) && !defined(Q_OS_IOS) && !defined(MACOS_NE)
-void AmneziaApplication::startLocalServer() {
+std::optional<int> AmneziaApplication::forwardToRunningInstance()
+{
+    QLocalSocket socket;
+    socket.connectToServer(QStringLiteral(APP_INSTANCE_NAME));
+    if (!socket.waitForConnected(500)) {
+        return std::nullopt;
+    }
+
+    const CliControl::Request request = CliControl::requestFromArguments(arguments());
+    socket.write(CliControl::toJsonLine(CliControl::requestToJson(request)));
+    if (!socket.waitForBytesWritten(1000) || !socket.waitForReadyRead(3000)) {
+        writeCliResponse(QJsonObject {
+            { QStringLiteral("version"), 1 },
+            { QStringLiteral("ok"), false },
+            { QStringLiteral("command"), CliControl::commandName(request.command) },
+            { QStringLiteral("error"), QStringLiteral("control_response_timeout") }
+        });
+        return 2;
+    }
+
+    QByteArray responseData = socket.readAll();
+    while (!responseData.contains('\n') && socket.waitForReadyRead(100)) {
+        responseData.append(socket.readAll());
+    }
+    QJsonParseError parseError;
+    const QJsonObject response = QJsonDocument::fromJson(responseData.trimmed(), &parseError).object();
+    if (parseError.error != QJsonParseError::NoError || response.isEmpty()) {
+        writeCliResponse(QJsonObject {
+            { QStringLiteral("version"), 1 },
+            { QStringLiteral("ok"), false },
+            { QStringLiteral("command"), CliControl::commandName(request.command) },
+            { QStringLiteral("error"), QStringLiteral("invalid_control_response") }
+        });
+        return 2;
+    }
+    if (request.isControlCommand()) {
+        writeCliResponse(response);
+    }
+    return response.value(QStringLiteral("ok")).toBool() ? 0 : 2;
+}
+
+std::optional<int> AmneziaApplication::handleControlCommandWithoutRunningInstance()
+{
+    const CliControl::Request request = CliControl::requestFromArguments(arguments());
+    if (!request.isControlCommand()) {
+        return std::nullopt;
+    }
+    if (!request.isValid()) {
+        writeCliResponse(QJsonObject {
+            { QStringLiteral("version"), 1 },
+            { QStringLiteral("ok"), false },
+            { QStringLiteral("command"), CliControl::commandName(request.command) },
+            { QStringLiteral("error"), request.error }
+        });
+        return 2;
+    }
+    if (request.command == CliControl::Command::Connect || request.command == CliControl::Command::Toggle) {
+        return std::nullopt;
+    }
+
+    const bool isStatus = request.command == CliControl::Command::Status;
+    const bool isDisconnect = request.command == CliControl::Command::Disconnect;
+    writeCliResponse(QJsonObject {
+        { QStringLiteral("version"), 1 },
+        { QStringLiteral("ok"), isStatus || isDisconnect },
+        { QStringLiteral("command"), CliControl::commandName(request.command) },
+        { QStringLiteral("state"), QStringLiteral("stopped") },
+        { QStringLiteral("serverId"), QString() },
+        { QStringLiteral("error"), (isStatus || isDisconnect) ? QString() : QStringLiteral("client_not_running") }
+    });
+    return (isStatus || isDisconnect) ? 0 : 3;
+}
+
+void AmneziaApplication::executeStartupControlCommand()
+{
+    const CliControl::Request request = CliControl::requestFromArguments(arguments());
+    if (request.isControlCommand() && m_coreController) {
+        writeCliResponse(m_coreController->handleCliControlRequest(request));
+    }
+}
+
+void AmneziaApplication::writeCliResponse(const QJsonObject &response) const
+{
+    QTextStream output(stdout);
+    output << QString::fromUtf8(QJsonDocument(response).toJson(QJsonDocument::Compact)) << Qt::endl;
+    output.flush();
+}
+
+void AmneziaApplication::processControlConnection(QLocalSocket *socket)
+{
+    if (!socket || socket->property("cliControlProcessed").toBool() || !socket->canReadLine()) {
+        return;
+    }
+    socket->setProperty("cliControlProcessed", true);
+
+    const QByteArray requestData = socket->readLine().trimmed();
+    QJsonParseError parseError;
+    const QJsonObject requestJson = QJsonDocument::fromJson(requestData, &parseError).object();
+    QJsonObject response;
+    if (parseError.error != QJsonParseError::NoError || requestJson.isEmpty()) {
+        response = QJsonObject {
+            { QStringLiteral("version"), 1 },
+            { QStringLiteral("ok"), false },
+            { QStringLiteral("error"), QStringLiteral("invalid_json") }
+        };
+    } else if (!m_coreController) {
+        response = QJsonObject {
+            { QStringLiteral("version"), 1 },
+            { QStringLiteral("ok"), false },
+            { QStringLiteral("error"), QStringLiteral("not_ready") }
+        };
+    } else {
+        response = m_coreController->handleCliControlRequest(CliControl::requestFromJson(requestJson));
+    }
+
+    socket->write(CliControl::toJsonLine(response));
+    socket->flush();
+    socket->waitForBytesWritten(1000);
+    socket->disconnectFromServer();
+    socket->deleteLater();
+}
+
+bool AmneziaApplication::startLocalServer() {
     const QString serverName(APP_INSTANCE_NAME);
     QLocalServer::removeServer(serverName);
 
-    QLocalServer *server = new QLocalServer(this);
-    server->listen(serverName);
+    m_localServer = new QLocalServer(this);
+    m_localServer->setSocketOptions(QLocalServer::UserAccessOption);
+    if (!m_localServer->listen(serverName)) {
+        qCritical() << "Unable to start application control server:" << m_localServer->errorString();
+        return false;
+    }
 
-    QObject::connect(server, &QLocalServer::newConnection, this, [server, this]() {
-        if (server) {
-            QLocalSocket *clientConnection = server->nextPendingConnection();
-            clientConnection->deleteLater();
+    QObject::connect(m_localServer, &QLocalServer::newConnection, this, [this]() {
+        while (m_localServer && m_localServer->hasPendingConnections()) {
+            QLocalSocket *socket = m_localServer->nextPendingConnection();
+            QObject::connect(socket, &QLocalSocket::readyRead, this, [this, socket]() {
+                processControlConnection(socket);
+            });
+            if (socket->bytesAvailable() > 0) {
+                processControlConnection(socket);
+            }
         }
-        emit m_coreController->pageController()->raiseMainWindow(); //TODO
     });
+    return true;
 }
 #endif
 

--- a/client/amneziaApplication.h
+++ b/client/amneziaApplication.h
@@ -6,6 +6,7 @@
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
 #include <QThread>
+#include <optional>
 #if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)
   #include <QGuiApplication>
 #else
@@ -14,6 +15,7 @@
 #include <QClipboard>
 
 #include "core/controllers/coreController.h"
+#include "core/utils/cliControlProtocol.h"
 #include "secureQSettings.h"
 #include "ui/controllers/marketplaceUpdateController.h"
 #include "vpnConnection.h"
@@ -21,6 +23,9 @@
 #include "ui/models/protocolProps.h"
 
 #define amnApp (static_cast<AmneziaApplication *>(QCoreApplication::instance()))
+
+class QLocalServer;
+class QLocalSocket;
 
 #if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)
   #define AMNEZIA_BASE_CLASS QGuiApplication
@@ -41,7 +46,10 @@ public:
     bool parseCommands();
 
 #if !defined(Q_OS_ANDROID) && !defined(Q_OS_IOS) && !defined(MACOS_NE)
-    void startLocalServer();
+    bool startLocalServer();
+    std::optional<int> forwardToRunningInstance();
+    std::optional<int> handleControlCommandWithoutRunningInstance();
+    void executeStartupControlCommand();
 #endif
 
     QQmlApplicationEngine *qmlEngine() const;
@@ -68,6 +76,16 @@ private:
     QCommandLineOption m_optCleanup;
     QCommandLineOption m_optConnect;
     QCommandLineOption m_optImport;
+    QCommandLineOption m_optStatus;
+    QCommandLineOption m_optListServers;
+    QCommandLineOption m_optDisconnect;
+    QCommandLineOption m_optToggle;
+
+#if !defined(Q_OS_ANDROID) && !defined(Q_OS_IOS) && !defined(MACOS_NE)
+    QLocalServer *m_localServer = nullptr;
+    void processControlConnection(QLocalSocket *socket);
+    void writeCliResponse(const QJsonObject &response) const;
+#endif
 
     QSharedPointer<VpnConnection> m_vpnConnection;
     QThread m_vpnConnectionThread;

--- a/client/cmake/sources.cmake
+++ b/client/cmake/sources.cmake
@@ -2,6 +2,7 @@ set(CLIENT_ROOT_DIR ${CMAKE_CURRENT_LIST_DIR}/..)
 
 set(HEADERS ${HEADERS}
     ${CLIENT_ROOT_DIR}/core/utils/migrations.h
+    ${CLIENT_ROOT_DIR}/core/utils/cliControlProtocol.h
     ${CLIENT_ROOT_DIR}/../ipc/ipc.h
     ${CLIENT_ROOT_DIR}/amneziaApplication.h
     ${CLIENT_ROOT_DIR}/core/utils/errorCodes.h
@@ -96,6 +97,7 @@ endif()
 
 set(SOURCES ${SOURCES}
     ${CLIENT_ROOT_DIR}/core/utils/migrations.cpp
+    ${CLIENT_ROOT_DIR}/core/utils/cliControlProtocol.cpp
     ${CLIENT_ROOT_DIR}/amneziaApplication.cpp
     ${CLIENT_ROOT_DIR}/core/utils/errorStrings.cpp
     ${CLIENT_ROOT_DIR}/core/utils/containers/containerUtils.cpp

--- a/client/core/controllers/connectionController.cpp
+++ b/client/core/controllers/connectionController.cpp
@@ -42,6 +42,11 @@ bool ConnectionController::isConnected() const
     return m_vpnConnection && m_vpnConnection->connectionState() == Vpn::ConnectionState::Connected;
 }
 
+Vpn::ConnectionState ConnectionController::connectionState() const
+{
+    return m_vpnConnection ? m_vpnConnection->connectionState() : Vpn::ConnectionState::Unknown;
+}
+
 void ConnectionController::setConnectionState(Vpn::ConnectionState state)
 {
     emit connectionStateChanged(state);

--- a/client/core/controllers/connectionController.h
+++ b/client/core/controllers/connectionController.h
@@ -49,6 +49,7 @@ public:
     ErrorCode lastConnectionError() const;
 
     bool isConnected() const;
+    Vpn::ConnectionState connectionState() const;
     void setConnectionState(Vpn::ConnectionState state);
 
     QJsonObject createConnectionConfiguration(const QPair<QString, QString> &dns,

--- a/client/core/controllers/coreController.cpp
+++ b/client/core/controllers/coreController.cpp
@@ -1,6 +1,7 @@
 #include "coreController.h"
 
 #include <QDirIterator>
+#include <QJsonArray>
 #include <QTranslator>
 #include <QTimer>
 
@@ -16,6 +17,39 @@
     #include "core/utils/installedAppsImageProvider.h"
     #include "platforms/android/android_controller.h"
 #endif
+
+namespace {
+
+QString cliConnectionStateName(Vpn::ConnectionState state)
+{
+    switch (state) {
+    case Vpn::ConnectionState::Unknown: return QStringLiteral("unknown");
+    case Vpn::ConnectionState::Disconnected: return QStringLiteral("disconnected");
+    case Vpn::ConnectionState::Preparing: return QStringLiteral("preparing");
+    case Vpn::ConnectionState::Connecting: return QStringLiteral("connecting");
+    case Vpn::ConnectionState::Connected: return QStringLiteral("connected");
+    case Vpn::ConnectionState::Disconnecting: return QStringLiteral("disconnecting");
+    case Vpn::ConnectionState::Reconnecting: return QStringLiteral("reconnecting");
+    case Vpn::ConnectionState::Error: return QStringLiteral("error");
+    }
+    return QStringLiteral("unknown");
+}
+
+QJsonObject cliError(const CliControl::Request &request, const QString &error, int errorCode = 0)
+{
+    QJsonObject result {
+        { QStringLiteral("version"), 1 },
+        { QStringLiteral("ok"), false },
+        { QStringLiteral("command"), CliControl::commandName(request.command) },
+        { QStringLiteral("error"), error }
+    };
+    if (errorCode != 0) {
+        result.insert(QStringLiteral("errorCode"), errorCode);
+    }
+    return result;
+}
+
+} // namespace
 
 #if defined(Q_OS_IOS)
     #include "platforms/ios/ios_controller.h"
@@ -358,6 +392,102 @@ void CoreController::openConnectionByIndex(int serverIndex)
         m_serversController->setDefaultServer(serverId);
     }
     m_connectionUiController->toggleConnection();
+}
+
+QJsonObject CoreController::handleCliControlRequest(const CliControl::Request &request)
+{
+    if (!request.isValid()) {
+        return cliError(request, request.error.isEmpty() ? QStringLiteral("invalid_request") : request.error);
+    }
+    if (!m_serversController || !m_connectionController) {
+        return cliError(request, QStringLiteral("not_ready"));
+    }
+
+    const auto currentState = [this]() { return m_connectionController->connectionState(); };
+    const auto status = [this, &currentState](const CliControl::Request &statusRequest) {
+        return QJsonObject {
+            { QStringLiteral("version"), 1 },
+            { QStringLiteral("ok"), true },
+            { QStringLiteral("command"), CliControl::commandName(statusRequest.command) },
+            { QStringLiteral("state"), cliConnectionStateName(currentState()) },
+            { QStringLiteral("serverId"), m_serversController->getDefaultServerId() }
+        };
+    };
+    const auto resolveServerId = [this](const QString &value) {
+        if (m_serversController->indexOfServerId(value) >= 0) {
+            return value;
+        }
+        bool isIndex = false;
+        const int index = value.toInt(&isIndex);
+        return isIndex ? m_serversController->getServerId(index) : QString();
+    };
+    const auto connectToServer = [this, &status, &resolveServerId](const CliControl::Request &connectRequest) {
+        const QString serverId = resolveServerId(connectRequest.serverId);
+        if (serverId.isEmpty()) {
+            return cliError(connectRequest, QStringLiteral("server_not_found"));
+        }
+        const ErrorCode supported = m_connectionController->isConnectionSupported(serverId);
+        if (supported != ErrorCode::NoError) {
+            return cliError(connectRequest, QStringLiteral("connection_not_supported"), static_cast<int>(supported));
+        }
+        m_serversController->setDefaultServer(serverId);
+        const ErrorCode opened = m_connectionController->openConnection(serverId);
+        if (opened != ErrorCode::NoError) {
+            return cliError(connectRequest, QStringLiteral("connect_failed"), static_cast<int>(opened));
+        }
+        QJsonObject result = status(connectRequest);
+        result.insert(QStringLiteral("state"), QStringLiteral("connecting"));
+        result.insert(QStringLiteral("serverId"), serverId);
+        return result;
+    };
+
+    switch (request.command) {
+    case CliControl::Command::Raise:
+        if (m_pageController) emit m_pageController->raiseMainWindow();
+        return status(request);
+    case CliControl::Command::Status:
+        return status(request);
+    case CliControl::Command::ListServers: {
+        QJsonArray servers;
+        const QString defaultServerId = m_serversController->getDefaultServerId();
+        for (int index = 0; index < m_serversController->getServersCount(); ++index) {
+            const QString serverId = m_serversController->getServerId(index);
+            servers.append(QJsonObject {
+                { QStringLiteral("id"), serverId },
+                { QStringLiteral("name"), m_serversController->notificationDisplayName(serverId) },
+                { QStringLiteral("default"), serverId == defaultServerId }
+            });
+        }
+        QJsonObject result = status(request);
+        result.insert(QStringLiteral("servers"), servers);
+        return result;
+    }
+    case CliControl::Command::Connect:
+        return connectToServer(request);
+    case CliControl::Command::Disconnect: {
+        if (currentState() == Vpn::ConnectionState::Disconnected) return status(request);
+        m_connectionController->closeConnection();
+        QJsonObject result = status(request);
+        result.insert(QStringLiteral("state"), QStringLiteral("disconnecting"));
+        return result;
+    }
+    case CliControl::Command::Toggle: {
+        const Vpn::ConnectionState state = currentState();
+        if (state == Vpn::ConnectionState::Connected || state == Vpn::ConnectionState::Connecting
+            || state == Vpn::ConnectionState::Preparing || state == Vpn::ConnectionState::Reconnecting) {
+            m_connectionController->closeConnection();
+            QJsonObject result = status(request);
+            result.insert(QStringLiteral("state"), QStringLiteral("disconnecting"));
+            return result;
+        }
+        CliControl::Request connectRequest = request;
+        connectRequest.serverId = request.serverId.isEmpty() ? m_serversController->getDefaultServerId() : request.serverId;
+        return connectToServer(connectRequest);
+    }
+    case CliControl::Command::Invalid:
+        return cliError(request, QStringLiteral("invalid_request"));
+    }
+    return cliError(request, QStringLiteral("invalid_request"));
 }
 
 void CoreController::importConfigFromData(const QString &data)

--- a/client/core/controllers/coreController.cpp
+++ b/client/core/controllers/coreController.cpp
@@ -399,7 +399,7 @@ QJsonObject CoreController::handleCliControlRequest(const CliControl::Request &r
     if (!request.isValid()) {
         return cliError(request, request.error.isEmpty() ? QStringLiteral("invalid_request") : request.error);
     }
-    if (!m_serversController || !m_connectionController) {
+    if (!m_serversController || !m_connectionController || !m_connectionUiController) {
         return cliError(request, QStringLiteral("not_ready"));
     }
 
@@ -431,12 +431,9 @@ QJsonObject CoreController::handleCliControlRequest(const CliControl::Request &r
             return cliError(connectRequest, QStringLiteral("connection_not_supported"), static_cast<int>(supported));
         }
         m_serversController->setDefaultServer(serverId);
-        const ErrorCode opened = m_connectionController->openConnection(serverId);
-        if (opened != ErrorCode::NoError) {
-            return cliError(connectRequest, QStringLiteral("connect_failed"), static_cast<int>(opened));
-        }
+        m_connectionUiController->toggleConnection();
         QJsonObject result = status(connectRequest);
-        result.insert(QStringLiteral("state"), QStringLiteral("connecting"));
+        result.insert(QStringLiteral("state"), QStringLiteral("preparing"));
         result.insert(QStringLiteral("serverId"), serverId);
         return result;
     };
@@ -466,7 +463,7 @@ QJsonObject CoreController::handleCliControlRequest(const CliControl::Request &r
         return connectToServer(request);
     case CliControl::Command::Disconnect: {
         if (currentState() == Vpn::ConnectionState::Disconnected) return status(request);
-        m_connectionController->closeConnection();
+        m_connectionUiController->closeConnection();
         QJsonObject result = status(request);
         result.insert(QStringLiteral("state"), QStringLiteral("disconnecting"));
         return result;
@@ -475,7 +472,7 @@ QJsonObject CoreController::handleCliControlRequest(const CliControl::Request &r
         const Vpn::ConnectionState state = currentState();
         if (state == Vpn::ConnectionState::Connected || state == Vpn::ConnectionState::Connecting
             || state == Vpn::ConnectionState::Preparing || state == Vpn::ConnectionState::Reconnecting) {
-            m_connectionController->closeConnection();
+            m_connectionUiController->closeConnection();
             QJsonObject result = status(request);
             result.insert(QStringLiteral("state"), QStringLiteral("disconnecting"));
             return result;

--- a/client/core/controllers/coreController.h
+++ b/client/core/controllers/coreController.h
@@ -2,6 +2,7 @@
 #define CORECONTROLLER_H
 
 #include <QObject>
+#include <QJsonObject>
 #include <QQmlContext>
 #include <QThread>
 
@@ -43,6 +44,7 @@
 #include "core/controllers/settingsController.h"
 #include "core/controllers/connectionController.h"
 #include "core/controllers/updateController.h"
+#include "core/utils/cliControlProtocol.h"
 
 #include "core/repositories/secureServersRepository.h"
 #include "core/repositories/secureAppSettingsRepository.h"
@@ -98,6 +100,7 @@ public:
     void setQmlRoot();
 
     void openConnectionByIndex(int serverIndex);
+    QJsonObject handleCliControlRequest(const CliControl::Request &request);
     void importConfigFromData(const QString &data);
     void updateTranslator(const QLocale &locale);
 

--- a/client/core/utils/cliControlProtocol.cpp
+++ b/client/core/utils/cliControlProtocol.cpp
@@ -1,0 +1,114 @@
+#include "cliControlProtocol.h"
+
+#include <QJsonDocument>
+
+namespace CliControl
+{
+
+    QString commandName(Command command)
+    {
+        switch (command) {
+        case Command::Raise: return QStringLiteral("raise");
+        case Command::Status: return QStringLiteral("status");
+        case Command::ListServers: return QStringLiteral("list");
+        case Command::Connect: return QStringLiteral("connect");
+        case Command::Disconnect: return QStringLiteral("disconnect");
+        case Command::Toggle: return QStringLiteral("toggle");
+        case Command::Invalid: return QStringLiteral("invalid");
+        }
+        return QStringLiteral("invalid");
+    }
+
+    namespace
+    {
+
+        Command commandFromName(const QString &name)
+        {
+            if (name == QStringLiteral("raise"))
+                return Command::Raise;
+            if (name == QStringLiteral("status"))
+                return Command::Status;
+            if (name == QStringLiteral("list"))
+                return Command::ListServers;
+            if (name == QStringLiteral("connect"))
+                return Command::Connect;
+            if (name == QStringLiteral("disconnect"))
+                return Command::Disconnect;
+            if (name == QStringLiteral("toggle"))
+                return Command::Toggle;
+            return Command::Invalid;
+        }
+
+        void selectCommand(Request &request, Command command)
+        {
+            if (request.command != Command::Raise) {
+                request.command = Command::Invalid;
+                request.error = QStringLiteral("multiple_control_commands");
+                return;
+            }
+            request.command = command;
+        }
+
+    } // namespace
+
+    Request requestFromArguments(const QStringList &arguments)
+    {
+        Request request;
+        for (int i = 1; i < arguments.size(); ++i) {
+            const QString &argument = arguments.at(i);
+            if (argument == QStringLiteral("--status")) {
+                selectCommand(request, Command::Status);
+            } else if (argument == QStringLiteral("--list-servers")) {
+                selectCommand(request, Command::ListServers);
+            } else if (argument == QStringLiteral("--disconnect")) {
+                selectCommand(request, Command::Disconnect);
+            } else if (argument == QStringLiteral("--toggle")) {
+                selectCommand(request, Command::Toggle);
+            } else if (argument == QStringLiteral("--connect")) {
+                selectCommand(request, Command::Connect);
+                if (request.command == Command::Invalid) {
+                    continue;
+                }
+                if (i + 1 >= arguments.size() || arguments.at(i + 1).startsWith(QStringLiteral("--"))) {
+                    request.command = Command::Invalid;
+                    request.error = QStringLiteral("missing_server_id");
+                    continue;
+                }
+                request.serverId = arguments.at(++i);
+            }
+        }
+        return request;
+    }
+
+    Request requestFromJson(const QJsonObject &json)
+    {
+        Request request;
+        request.command = commandFromName(json.value(QStringLiteral("command")).toString());
+        request.serverId = json.value(QStringLiteral("serverId")).toString();
+        if (request.command == Command::Invalid) {
+            request.error = QStringLiteral("unknown_command");
+        } else if (request.command == Command::Connect && request.serverId.isEmpty()) {
+            request.command = Command::Invalid;
+            request.error = QStringLiteral("missing_server_id");
+        }
+        return request;
+    }
+
+    QJsonObject requestToJson(const Request &request)
+    {
+        QJsonObject json { { QStringLiteral("command"), commandName(request.command) } };
+        if (!request.serverId.isEmpty()) {
+            json.insert(QStringLiteral("serverId"), request.serverId);
+        }
+        if (!request.error.isEmpty()) {
+            json.insert(QStringLiteral("error"), request.error);
+        }
+        return json;
+    }
+
+    QByteArray toJsonLine(const QJsonObject &json)
+    {
+        return QJsonDocument(json).toJson(QJsonDocument::Compact) + '\n';
+    }
+
+} // namespace CliControl

--- a/client/core/utils/cliControlProtocol.h
+++ b/client/core/utils/cliControlProtocol.h
@@ -1,0 +1,45 @@
+#ifndef CLI_CONTROL_PROTOCOL_H
+#define CLI_CONTROL_PROTOCOL_H
+
+#include <QJsonObject>
+#include <QString>
+#include <QStringList>
+
+namespace CliControl
+{
+
+    enum class Command {
+        Raise,
+        Status,
+        ListServers,
+        Connect,
+        Disconnect,
+        Toggle,
+        Invalid
+    };
+
+    struct Request
+    {
+        Command command = Command::Raise;
+        QString serverId;
+        QString error;
+
+        bool isControlCommand() const
+        {
+            return command != Command::Raise;
+        }
+        bool isValid() const
+        {
+            return command != Command::Invalid;
+        }
+    };
+
+    QString commandName(Command command);
+    Request requestFromArguments(const QStringList &arguments);
+    Request requestFromJson(const QJsonObject &json);
+    QJsonObject requestToJson(const Request &request);
+    QByteArray toJsonLine(const QJsonObject &json);
+
+} // namespace CliControl
+
+#endif // CLI_CONTROL_PROTOCOL_H

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -23,19 +23,6 @@ void anchorOpenSSL() {
     #include "platforms/ios/QtAppDelegate-C-Interface.h"
 #endif
 
-#if !defined(Q_OS_ANDROID) && !defined(Q_OS_IOS) && !defined(MACOS_NE)
-bool isAnotherInstanceRunning()
-{
-    QLocalSocket socket;
-    socket.connectToServer(APP_INSTANCE_NAME);
-    if (socket.waitForConnected(500)) {
-        qWarning() << APPLICATION_NAME << "is already running";
-        return true;
-    }
-    return false;
-}
-#endif
-
 int main(int argc, char *argv[])
 {
     Migrations migrationsManager;
@@ -52,6 +39,10 @@ int main(int argc, char *argv[])
 #endif
 
     AmneziaApplication app(argc, argv);
+    app.setApplicationName(APPLICATION_NAME);
+    app.setOrganizationName(ORGANIZATION_NAME);
+    app.setApplicationDisplayName(APPLICATION_NAME);
+
     OsSignalHandler::setup();
 
     anchorOpenSSL();
@@ -61,12 +52,21 @@ int main(int argc, char *argv[])
         ssh_finalize();
     });
 
-#if !defined(Q_OS_ANDROID) && !defined(Q_OS_IOS) && !defined(MACOS_NE)
-    if (isAnotherInstanceRunning()) {
-        QTimer::singleShot(1000, &app, [&]() { app.quit(); });
-        return app.exec();
+    const bool doExec = app.parseCommands();
+    if (!doExec) {
+        return 0;
     }
-    app.startLocalServer();
+
+#if !defined(Q_OS_ANDROID) && !defined(Q_OS_IOS) && !defined(MACOS_NE)
+    if (const auto forwarded = app.forwardToRunningInstance()) {
+        return *forwarded;
+    }
+    if (const auto handled = app.handleControlCommandWithoutRunningInstance()) {
+        return *handled;
+    }
+    if (!app.startLocalServer()) {
+        return 2;
+    }
 #endif
 
 // Allow to raise app window if secondary instance launched
@@ -75,22 +75,15 @@ int main(int argc, char *argv[])
 #endif
 
     app.registerTypes();
-
-    app.setApplicationName(APPLICATION_NAME);
-    app.setOrganizationName(ORGANIZATION_NAME);
-    app.setApplicationDisplayName(APPLICATION_NAME);
-
     app.loadFonts();
+    app.init();
 
-    bool doExec = app.parseCommands();
+#if !defined(Q_OS_ANDROID) && !defined(Q_OS_IOS) && !defined(MACOS_NE)
+    app.executeStartupControlCommand();
+#endif
 
-    if (doExec) {
-        app.init();
+    qInfo().noquote() << QString("Started %1 version %2 %3").arg(APPLICATION_NAME, APP_VERSION, GIT_COMMIT_HASH);
+    qInfo().noquote() << QString("%1 (%2)").arg(QSysInfo::prettyProductName(), QSysInfo::currentCpuArchitecture());
 
-        qInfo().noquote() << QString("Started %1 version %2 %3").arg(APPLICATION_NAME, APP_VERSION, GIT_COMMIT_HASH);
-        qInfo().noquote() << QString("%1 (%2)").arg(QSysInfo::prettyProductName(), QSysInfo::currentCpuArchitecture());
-
-        return app.exec();
-    }
-    return 0;
+    return app.exec();
 }

--- a/client/mozilla/localsocketcontroller.cpp
+++ b/client/mozilla/localsocketcontroller.cpp
@@ -123,6 +123,13 @@ void LocalSocketController::daemonConnected() {
 }
 
 void LocalSocketController::activate(const QJsonObject &rawConfig) {
+  if (m_daemonState != eReady) {
+    logger.debug() << "Queue activation until daemon initialization completes";
+    m_pendingActivation = rawConfig;
+    m_activationPending = true;
+    return;
+  }
+
   QString protocolName = rawConfig.value("protocol").toString();
 
   int splitTunnelType = rawConfig.value("splitTunnelType").toInt();
@@ -267,6 +274,9 @@ void LocalSocketController::activate(const QJsonObject &rawConfig) {
 void LocalSocketController::deactivate() {
   logger.debug() << "Deactivating";
 
+  m_pendingActivation = {};
+  m_activationPending = false;
+
   if (m_daemonState != eReady) {
     logger.debug() << "No disconnect, controller is not ready";
     emit disconnected();
@@ -400,6 +410,12 @@ void LocalSocketController::parseCommand(const QByteArray& command) {
     }
 
     emit initialized(true, connected.toBool(), datetime);
+    if (m_activationPending) {
+      const QJsonObject pendingActivation = m_pendingActivation;
+      m_pendingActivation = {};
+      m_activationPending = false;
+      activate(pendingActivation);
+    }
     return;
   }
 

--- a/client/mozilla/localsocketcontroller.h
+++ b/client/mozilla/localsocketcontroller.h
@@ -6,6 +6,7 @@
 #define LOCALSOCKETCONTROLLER_H
 
 #include <QHostAddress>
+#include <QJsonObject>
 #include <QLocalSocket>
 #include <QTimer>
 #include <functional>
@@ -58,6 +59,9 @@ class LocalSocketController final : public ControllerImpl {
   QLocalSocket* m_socket = nullptr;
 
   QByteArray m_buffer;
+
+  QJsonObject m_pendingActivation;
+  bool m_activationPending = false;
 
   QString m_deviceIpv4;
   std::function<void(const QString&)> m_logCallback = nullptr;

--- a/client/tests/cliControlProtocolTest.cpp
+++ b/client/tests/cliControlProtocolTest.cpp
@@ -1,0 +1,68 @@
+#include <QCoreApplication>
+#include <QJsonDocument>
+
+#include "core/utils/cliControlProtocol.h"
+
+namespace
+{
+
+    bool require(bool condition, const char *message)
+    {
+        if (!condition) {
+            qCritical("%s", message);
+        }
+        return condition;
+    }
+
+} // namespace
+
+int main(int argc, char *argv[])
+{
+    QCoreApplication app(argc, argv);
+
+    const auto connect = CliControl::requestFromArguments(
+            { QStringLiteral("AmneziaVPN"), QStringLiteral("--connect"), QStringLiteral("stable-server-id") });
+    if (!require(connect.command == CliControl::Command::Connect, "connect command was not parsed")
+        || !require(connect.serverId == QStringLiteral("stable-server-id"), "server ID was not preserved")) {
+        return 1;
+    }
+
+    const auto status = CliControl::requestFromArguments({ QStringLiteral("AmneziaVPN"), QStringLiteral("--status") });
+    if (!require(status.command == CliControl::Command::Status, "status command was not parsed")) {
+        return 1;
+    }
+
+    const QList<QPair<QString, CliControl::Command>> commands {
+        { QStringLiteral("--list-servers"), CliControl::Command::ListServers },
+        { QStringLiteral("--disconnect"), CliControl::Command::Disconnect },
+        { QStringLiteral("--toggle"), CliControl::Command::Toggle }
+    };
+    for (const auto &[argument, expected] : commands) {
+        const auto parsed = CliControl::requestFromArguments({ QStringLiteral("AmneziaVPN"), argument });
+        if (!require(parsed.command == expected, "control command was not parsed")) {
+            return 1;
+        }
+    }
+
+    const auto missingId = CliControl::requestFromArguments(
+            { QStringLiteral("AmneziaVPN"), QStringLiteral("--connect") });
+    if (!require(!missingId.isValid() && missingId.error == QStringLiteral("missing_server_id"),
+                 "connect without a server ID was accepted")) {
+        return 1;
+    }
+
+    const auto conflict = CliControl::requestFromArguments(
+            { QStringLiteral("AmneziaVPN"), QStringLiteral("--status"), QStringLiteral("--toggle") });
+    if (!require(!conflict.isValid(), "conflicting commands were accepted")) {
+        return 1;
+    }
+
+    const auto roundTrip = CliControl::requestFromJson(
+            QJsonDocument::fromJson(CliControl::toJsonLine(CliControl::requestToJson(connect))).object());
+    if (!require(roundTrip.command == connect.command && roundTrip.serverId == connect.serverId,
+                 "JSON request round-trip failed")) {
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

- add a versioned JSON command-line interface for `status`, `list-servers`, `connect`, `disconnect`, and `toggle`;
- forward commands from a secondary invocation to the already running GUI over the existing per-user local application socket;
- route connection changes through the existing connection UI workflow and preserve an activation requested while the daemon socket is still initializing;
- add a focused protocol parser/serialization test, enabled with `AMNEZIA_BUILD_CLI_CONTROL_TESTS`.

Example commands:

```text
AmneziaVPN --status
AmneziaVPN --list-servers
AmneziaVPN --connect <stable-server-id>
AmneziaVPN --disconnect
AmneziaVPN --toggle
```

Every response is one JSON line with `version: 1` and `ok`. The server list exposes only stable IDs, display names, and the default marker.

## Motivation and consumer

The interface allows desktop integrations to control the existing AmneziaVPN process instead of automating the GUI or starting a second client instance.

The first consumer is the open-source [Amnezia Stream Deck plugin](https://github.com/witqq/amnezia-stream-deck). An installable macOS/Windows preview was published before this PR: [v0.1.0-preview.1](https://github.com/witqq/amnezia-stream-deck/releases/tag/v0.1.0-preview.1).

## Local security model

- no TCP listener or remote-control service is added;
- `QLocalServer::UserAccessOption` restricts the control socket to the current OS user;
- requests are handled inside the existing GUI process and reuse its server and connection controllers;
- responses do not include server configurations, credentials, private keys, or connection secrets.

## Verification

- macOS arm64: full `AmneziaVPN` target built; `cli-control-protocol` passed 1/1;
- Windows x64 with Qt 6.10.1/MSVC 2022: full `AmneziaVPN` target built; `cli-control-protocol` passed 1/1;
- Stream Deck consumer: 7/7 unit tests passed on macOS and Windows;
- Stream Deck protocol E2E passed on both platforms with a non-networking CLI fixture, covering registration, status rendering, Connect/Toggle responses, and rejected server IDs without changing a real VPN connection.
