### PR TITLE
Fix: IPv4-only full-tunnel AWG/WireGuard configs silently disable site-based split tunneling

### DIFF
--- a/client/vpnConnection.cpp
+++ b/client/vpnConnection.cpp
@@ -454,7 +454,14 @@ void VpnConnection::appendSplitTunnelingConfig()
         }
 
         QJsonArray allowedIpsJsonArray = configData.value(configKey::allowedIps).toArray();
-        if (allowedIpsJsonArray.contains("0.0.0.0/0") && allowedIpsJsonArray.contains("::/0")) {
+        if (allowedIpsJsonArray.contains("0.0.0.0/0")) {
+            // Site-based split tunneling only ever collects IPv4 addresses
+            // (see IpSplitTunnelingController::onHostResolved), so requiring
+            // ::/0 as well as 0.0.0.0/0 here silently disabled the whole
+            // feature for any IPv4-only full-tunnel AWG/WireGuard config
+            // (e.g. AllowedIPs = 0.0.0.0/0 with no IPv6 route at all) even
+            // though nothing about that config makes IPv4 site exclusion
+            // unsafe.
             allowSiteBasedSplitTunneling = true;
         }
     }


### PR DESCRIPTION
## Что не так

`VpnConnection::appendSplitTunnelingConfig()` требует, чтобы `AllowedIPs` содержал одновременно `0.0.0.0/0` **и** `::/0`, прежде чем разрешить сайт-based split tunneling для AWG/WireGuard-подключений:

```cpp
if (allowedIpsJsonArray.contains("0.0.0.0/0") && allowedIpsJsonArray.contains("::/0")) {
    allowSiteBasedSplitTunneling = true;
}
```

Любой полностью-IPv4-туннель без единого IPv6-маршрута (частый случай для self-hosted серверов без настроенного IPv6) никогда не проходит это условие. В итоге `allowSiteBasedSplitTunneling` остаётся `false`, `sitesJsonArray` остаётся пустым, и `routeMode` тихо откатывается на `VpnAllSites` — вся функция «Sites» (раздельное туннелирование по сайтам) молча отключается, хотя она включена и настроена в приложении. Пользователь не получает никакого предупреждения об этом.

## Почему это баг, а не защита

Сама функция split-tunneling по сайтам работает только с IPv4-адресами — `IpSplitTunnelingController::onHostResolved` собирает исключительно `QAbstractSocket::IPv4Protocol`-адреса:

```cpp
for (const QHostAddress &addr : addresses) {
    if (addr.protocol() == QAbstractSocket::NetworkLayerProtocol::IPv4Protocol) {
        allIpv4.append(addr.toString());
    }
}
```

Поэтому требование наличия `::/0` для включения этой (по факту IPv4-only) функции не имеет технического обоснования — оно просто отсекает валидный, часто встречающийся сценарий (IPv4-only self-hosted туннель).

## Как обнаружено

Диагностировано на реальном self-hosted AmneziaWG сервере: сайт был добавлен в список split-tunneling («в обход VPN»), DNS для него корректно резолвился через сам VPN-туннель (подтверждено tcpdump на сервере), но в таблице маршрутизации Windows-клиента не оказалось ни одного исключающего маршрута для реальных IP этого сайта — то есть соединение всё равно шло через VPN. Трассировка кода привела к этому условию.

## Исправление

```diff
-if (allowedIpsJsonArray.contains("0.0.0.0/0") && allowedIpsJsonArray.contains("::/0")) {
+if (allowedIpsJsonArray.contains("0.0.0.0/0")) {
     allowSiteBasedSplitTunneling = true;
 }
```

Патч из 1 условия, поведение для конфигов с IPv6 не меняется (там оно и раньше проходило по `0.0.0.0/0`).