### PR TITLE
fix(windows): sanitize process ancestry before driver registration

### DIFF
--- a/client/platforms/windows/daemon/windowssplittunnel.cpp
+++ b/client/platforms/windows/daemon/windowssplittunnel.cpp
@@ -149,6 +149,16 @@ ProcessInfo getProcessInfo(HANDLE process, const PROCESSENTRY32W& processMeta) {
   return pi;
 }
 
+bool retainParentRelationship(const ProcessInfo& parent,
+                              const ProcessInfo& child) {
+  const auto value = [](const FILETIME& time) {
+    return (static_cast<std::uint64_t>(time.dwHighDateTime) << 32) |
+           time.dwLowDateTime;
+  };
+  return value(parent.CreationTime) != 0 && value(child.CreationTime) != 0 &&
+         value(parent.CreationTime) < value(child.CreationTime);
+}
+
 QString normalizeExecutablePath(const QString& path) {
   QString normalized = path.trimmed();
   if (normalized.startsWith("file:", Qt::CaseInsensitive)) {
@@ -541,11 +551,12 @@ std::vector<uint8_t> WindowsSplitTunnel::generateProcessBlob() {
   }
   auto cleanup = qScopeGuard([&] { CloseHandle(snapshot_handle); });
   // Load the First Entry, later iterate over all
-  PROCESSENTRY32W currentProcess;
+  PROCESSENTRY32W currentProcess = {};
   currentProcess.dwSize = sizeof(PROCESSENTRY32W);
 
-  if (FALSE == (Process32First(snapshot_handle, &currentProcess))) {
+  if (FALSE == Process32FirstW(snapshot_handle, &currentProcess)) {
     WindowsUtils::windowsLog("Cant read first entry");
+    return {};
   }
 
   QMap<DWORD, ProcessInfo> processes;
@@ -561,7 +572,15 @@ std::vector<uint8_t> WindowsSplitTunnel::generateProcessBlob() {
     processes.insert(info.ProcessId, info);
     CloseHandle(process_handle);
 
-  } while (FALSE != (Process32NextW(snapshot_handle, &currentProcess)));
+  } while (FALSE != Process32NextW(snapshot_handle, &currentProcess));
+
+  for (auto process = processes.begin(); process != processes.end(); ++process) {
+    const DWORD parentId = process->ParentProcessId;
+    const auto parent = processes.constFind(parentId);
+    const bool keepParent = parent != processes.constEnd() &&
+                            retainParentRelationship(*parent, process.value());
+    process->ParentProcessId = keepParent ? parentId : 0;
+  }
 
   auto process_list = processes.values();
   if (process_list.isEmpty()) {


### PR DESCRIPTION
## Problem

The Windows client builds a process-parent map from a live Toolhelp snapshot and sends it to the split-tunnel driver by PID. Between process enumeration and registration, a PID can be recycled; an unreadable or stale entry can therefore point to an unrelated process, including itself or another node in a cycle.

The driver uses these relationships while applying inherited split state. A cyclic or stale parent link can make the kernel-side ancestry walk non-terminating, leaving DeviceIoControl(IOCTL_SET_CONFIGURATION) blocked and the AmneziaVPN service unresponsive. This is consistent with the intermittent WindowsSplitTunnel::excludeApps hangs and high CPU reported in amnezia-vpn/amnezia-client#1996.

This is a strongly supported root-cause hypothesis, not a claim that the original report included runtime proof of a cycle.

## Fix

- Zero-initialize PROCESSENTRY32W before Toolhelp calls.
- Use Process32FirstW and abort registration if the snapshot cannot be read.
- Keep a parent link only when the parent is present in the same snapshot and its creation time is strictly older than the child.
- Clear invalid parent PIDs before sending the process graph to the driver.

This prevents stale PID reuse and malformed ancestry from entering the kernel graph. The companion driver PR adds cycle detection as defense in depth and keeps cyclic processes in the safe non-split state.

The change is intentionally limited to process snapshot construction; it does not alter split-tunnel policy semantics for valid process trees.

## Validation

The patch was reviewed against the existing Toolhelp snapshot and IOCTL contract. Invalid snapshot reads and recycled-PID relationships are rejected before IOCTL_SET_CONFIGURATION is called.

Related issue: amnezia-vpn/amnezia-client#1996
Companion driver PR: https://github.com/mullvad/win-split-tunnel/pull/56