### PR TITLE
fix(windows): refresh split tunnel addresses and support all address modes

### DIFF
--- a/client/platforms/windows/daemon/windowsdaemon.cpp
+++ b/client/platforms/windows/daemon/windowsdaemon.cpp
@@ -22,7 +22,6 @@
 #include "logger.h"
 #include "platforms/windows/daemon/windowsfirewall.h"
 #include "platforms/windows/daemon/windowssplittunnel.h"
-#include "platforms/windows/daemon/windowssplittunnelcontracts.h"
 #include "windowsfirewall.h"
 
 #include "core/utils/networkUtilities.h"
@@ -54,9 +53,15 @@ WindowsDaemon::~WindowsDaemon() {
 void WindowsDaemon::prepareActivation(const InterfaceConfig& config, int inetAdapterIndex) {
   // Before creating the interface we need to check which adapter
   // routes to the server endpoint
+  m_serverEndpoint = QHostAddress(config.m_serverIpv4AddrIn);
+  if (m_serverEndpoint.isNull()) {
+    m_serverEndpoint = QHostAddress(config.m_serverIpv6AddrIn);
+  }
   if (inetAdapterIndex == 0) {
-      auto serveraddr = QHostAddress(config.m_serverIpv4AddrIn);
-      m_inetAdapterIndex = NetworkUtilities::AdapterIndexTo(serveraddr);
+      m_inetAdapterIndex =
+          m_serverEndpoint.protocol() == QAbstractSocket::IPv4Protocol
+              ? NetworkUtilities::AdapterIndexTo(m_serverEndpoint)
+              : -1;
   } else {
       m_inetAdapterIndex = inetAdapterIndex;
   }
@@ -72,7 +77,8 @@ void WindowsDaemon::activateSplitTunnel(const InterfaceConfig& config, int vpnAd
     }
 
   if (config.m_vpnDisabledApps.length() > 0) {
-      if (!m_splitTunnelManager->start(m_inetAdapterIndex, vpnAdapterIndex)) {
+      if (!m_splitTunnelManager->start(m_serverEndpoint, m_inetAdapterIndex,
+                                       vpnAdapterIndex)) {
           logger.error() << "Failed to start split tunnel";
           emit backendFailure(DaemonError::ERROR_SPLIT_TUNNEL_START_FAILURE);
           return;
@@ -82,7 +88,7 @@ void WindowsDaemon::activateSplitTunnel(const InterfaceConfig& config, int vpnAd
           emit backendFailure(DaemonError::ERROR_SPLIT_TUNNEL_EXCLUDE_FAILURE);
           return;
       }
-      if (!m_splitTunnelManager->isRunning()) {
+      if (!m_splitTunnelManager->isOperational()) {
           logger.error() << "Split tunnel did not reach running state";
           emit backendFailure(DaemonError::ERROR_SPLIT_TUNNEL_START_FAILURE);
       }
@@ -112,7 +118,7 @@ bool WindowsDaemon::run(Op op, const InterfaceConfig& config) {
     prepareActivation(config);
   }
   if (config.m_vpnDisabledApps.length() > 0) {
-    if (!m_splitTunnelManager->start(m_inetAdapterIndex)) {
+    if (!m_splitTunnelManager->start(m_serverEndpoint, m_inetAdapterIndex)) {
       logger.error() << "Split tunnel start failed";
       emit backendFailure(DaemonError::ERROR_SPLIT_TUNNEL_START_FAILURE);
       return false;
@@ -123,7 +129,7 @@ bool WindowsDaemon::run(Op op, const InterfaceConfig& config) {
       return false;
     };
     // Now the driver should be running (State == 4)
-    if (!m_splitTunnelManager->isRunning()) {
+    if (!m_splitTunnelManager->isOperational()) {
       logger.error() << "Split tunnel did not reach running state";
       emit backendFailure(DaemonError::ERROR_SPLIT_TUNNEL_START_FAILURE);
       return false;

--- a/client/platforms/windows/daemon/windowsdaemon.cpp
+++ b/client/platforms/windows/daemon/windowsdaemon.cpp
@@ -22,6 +22,7 @@
 #include "logger.h"
 #include "platforms/windows/daemon/windowsfirewall.h"
 #include "platforms/windows/daemon/windowssplittunnel.h"
+#include "platforms/windows/daemon/windowssplittunnelcontracts.h"
 #include "windowsfirewall.h"
 
 #include "core/utils/networkUtilities.h"
@@ -106,6 +107,9 @@ bool WindowsDaemon::run(Op op, const InterfaceConfig& config) {
   if (op == Down) {
     m_splitTunnelManager->stop();
     return true;
+  }
+  if (op == Switch) {
+    prepareActivation(config);
   }
   if (config.m_vpnDisabledApps.length() > 0) {
     if (!m_splitTunnelManager->start(m_inetAdapterIndex)) {

--- a/client/platforms/windows/daemon/windowsdaemon.h
+++ b/client/platforms/windows/daemon/windowsdaemon.h
@@ -7,6 +7,8 @@
 
 #include <qpointer.h>
 
+#include <QHostAddress>
+
 #include "daemon/daemon.h"
 #include "dnsutilswindows.h"
 #include "windowsfirewall.h"
@@ -41,6 +43,7 @@ class WindowsDaemon final : public Daemon {
   };
 
   int m_inetAdapterIndex = -1;
+  QHostAddress m_serverEndpoint;
 
   std::unique_ptr<WireguardUtilsWindows> m_wgutils;
   DnsUtilsWindows* m_dnsutils = nullptr;

--- a/client/platforms/windows/daemon/windowssplittunnel.cpp
+++ b/client/platforms/windows/daemon/windowssplittunnel.cpp
@@ -22,6 +22,7 @@
 
 #include <QCoreApplication>
 #include <QFileInfo>
+#include <QMetaObject>
 #include <QNetworkInterface>
 #include <QScopeGuard>
 #include <QUrl>
@@ -127,6 +128,7 @@ constexpr static const auto MV_SERVICE_NAME = L"MullvadVPN";
 
 namespace {
 Logger logger("WindowsSplitTunnel");
+constexpr int AddressRefreshRetryIntervalMs = 1000;
 
 ProcessInfo getProcessInfo(HANDLE process, const PROCESSENTRY32W& processMeta) {
   ProcessInfo pi;
@@ -162,6 +164,11 @@ QString normalizeExecutablePath(const QString& path) {
 }
 
 }  // namespace
+
+struct WindowsSplitTunnel::NotificationContext {
+  SRWLOCK lock = SRWLOCK_INIT;
+  WindowsSplitTunnel* target = nullptr;
+};
 
 std::unique_ptr<WindowsSplitTunnel> WindowsSplitTunnel::create(
     WindowsFirewall* fw) {
@@ -279,13 +286,32 @@ bool WindowsSplitTunnel::initDriver(HANDLE driverIO) {
   return true;
 }
 
-WindowsSplitTunnel::WindowsSplitTunnel(HANDLE driverIO) : m_driver(driverIO) {
+WindowsSplitTunnel::WindowsSplitTunnel(HANDLE driverIO)
+    : QObject(nullptr), m_driver(driverIO), m_addressRefreshTimer(this) {
   logger.debug() << "Connected to the Driver";
+
+  m_addressRefreshTimer.setSingleShot(true);
+  m_addressRefreshTimer.setInterval(250);
+  connect(&m_addressRefreshTimer, &QTimer::timeout, this, [this]() {
+    const bool refreshSucceeded =
+        !m_addressMonitoringActive || registerIPConfiguration(false);
+    if (!refreshSucceeded) {
+      logger.error() << "Failed to refresh split-tunnel network addresses";
+      if (m_addressMonitoringActive && m_addressRefreshRetryAttempts < 3) {
+        ++m_addressRefreshRetryAttempts;
+        m_addressRefreshTimer.start(AddressRefreshRetryIntervalMs);
+      }
+      return;
+    }
+    m_addressRefreshRetryAttempts = 0;
+  });
 
   Q_ASSERT(getState() == STATE_INITIALIZED);
 }
 
 WindowsSplitTunnel::~WindowsSplitTunnel() {
+  m_addressMonitoringActive = false;
+  stopAddressMonitoring();
   CloseHandle(m_driver);
   uninstallDriver();
 }
@@ -325,6 +351,15 @@ bool WindowsSplitTunnel::start(int inetAdapterIndex, int vpnAdapterIndex) {
   logger.debug() << "Starting SplitTunnel";
   DWORD bytesReturned;
 
+  m_addressMonitoringActive = false;
+  stopAddressMonitoring();
+  m_inetAdapterIndex = inetAdapterIndex;
+  m_vpnAdapterIndex = vpnAdapterIndex;
+  auto failedStart = qScopeGuard([this]() {
+    m_addressMonitoringActive = false;
+    stopAddressMonitoring();
+  });
+
   if (getState() == STATE_STARTED) {
     logger.debug() << "Driver needs Init Call";
     DWORD bytesReturned;
@@ -334,6 +369,7 @@ bool WindowsSplitTunnel::start(int inetAdapterIndex, int vpnAdapterIndex) {
       logger.error() << "Driver init failed. Error:" << GetLastError();
       return false;
     }
+    m_lastIPConfiguration.clear();
   }
 
   // Process Info (what is running already)
@@ -361,24 +397,23 @@ bool WindowsSplitTunnel::start(int inetAdapterIndex, int vpnAdapterIndex) {
   }
   logger.debug() << "Driver is  ready || new State:" << stateString();
 
-  auto config = generateIPConfiguration(inetAdapterIndex, vpnAdapterIndex);
-  if (config.empty()) {
-    logger.error() << "Network configuration blob is empty. Internet adapter:"
-                   << inetAdapterIndex << "VPN adapter:" << vpnAdapterIndex;
+  if (!startAddressMonitoring()) {
     return false;
   }
-  auto ok = DeviceIoControl(m_driver, IOCTL_REGISTER_IP_ADDRESSES, &config[0],
-                            (DWORD)config.size(), nullptr, 0, &bytesReturned,
-                            nullptr);
-  if (!ok) {
-    logger.error() << "Failed to set Network Config. Error:" << GetLastError();
+  if (!registerIPConfiguration(true)) {
+    logger.error() << "Failed to register initial split-tunnel addresses";
     return false;
   }
-  logger.debug() << "New Network Config Applied || new State:" << stateString();
+  m_addressMonitoringActive = true;
+  failedStart.dismiss();
   return true;
 }
 
 void WindowsSplitTunnel::stop() {
+  m_addressMonitoringActive = false;
+  stopAddressMonitoring();
+  m_lastIPConfiguration.clear();
+
   DWORD bytesReturned;
   auto ok = DeviceIoControl(m_driver, IOCTL_CLEAR_CONFIGURATION, nullptr, 0,
                             nullptr, 0, &bytesReturned, nullptr);
@@ -530,6 +565,144 @@ bool WindowsSplitTunnel::getAddress(int adapterIndex, IN_ADDR* out_ipv4,
     logger.debug() << "Ipv6 Conversation error" << WSAGetLastError();
   }
   return true;
+}
+
+bool WindowsSplitTunnel::registerIPConfiguration(bool force) {
+  auto config =
+      generateIPConfiguration(m_inetAdapterIndex, m_vpnAdapterIndex);
+  if (config.empty()) {
+    logger.error() << "Network configuration blob is empty. Internet adapter:"
+                   << m_inetAdapterIndex << "VPN adapter:"
+                   << m_vpnAdapterIndex;
+    return false;
+  }
+  if (!force && config == m_lastIPConfiguration) {
+    return true;
+  }
+
+  DWORD bytesReturned = 0;
+  const auto ok = DeviceIoControl(
+      m_driver, IOCTL_REGISTER_IP_ADDRESSES, config.data(),
+      static_cast<DWORD>(config.size()), nullptr, 0, &bytesReturned, nullptr);
+  if (!ok) {
+    logger.error() << "Failed to set Network Config. Error:" << GetLastError();
+    return false;
+  }
+  m_lastIPConfiguration = std::move(config);
+  logger.debug() << "New Network Config Applied || new State:" << stateString();
+  return true;
+}
+
+bool WindowsSplitTunnel::startAddressMonitoring() {
+  if (m_notificationContext != nullptr) {
+    return true;
+  }
+
+  auto context = std::make_unique<NotificationContext>();
+  context->target = this;
+  m_notificationContext = context.release();
+
+  DWORD result = NotifyRouteChange2(AF_UNSPEC, routeChangeCallback,
+                                    m_notificationContext, FALSE,
+                                    &m_routeChangeHandle);
+  if (result == NO_ERROR) {
+    result = NotifyUnicastIpAddressChange(
+        AF_UNSPEC, addressChangeCallback, m_notificationContext, FALSE,
+        &m_addressChangeHandle);
+  }
+  if (result == NO_ERROR) {
+    result = NotifyIpInterfaceChange(AF_UNSPEC, interfaceChangeCallback,
+                                     m_notificationContext, FALSE,
+                                     &m_interfaceChangeHandle);
+  }
+  if (result != NO_ERROR) {
+    logger.error() << "Failed to monitor network address changes:" << result;
+    stopAddressMonitoring();
+    return false;
+  }
+  return true;
+}
+
+void WindowsSplitTunnel::stopAddressMonitoring() {
+  m_addressRefreshTimer.stop();
+  m_addressRefreshRetryAttempts = 0;
+
+  NotificationContext* context = m_notificationContext;
+  if (context != nullptr) {
+    AcquireSRWLockExclusive(&context->lock);
+    context->target = nullptr;
+    ReleaseSRWLockExclusive(&context->lock);
+  }
+
+  bool allCancelled = true;
+  auto cancel = [&allCancelled](HANDLE& handle) {
+    if (handle == nullptr) {
+      return;
+    }
+    const DWORD result = CancelMibChangeNotify2(handle);
+    if (result != NO_ERROR) {
+      logger.error() << "Failed to cancel network change notification:"
+                     << result;
+      allCancelled = false;
+    }
+    handle = nullptr;
+  };
+  cancel(m_interfaceChangeHandle);
+  cancel(m_addressChangeHandle);
+  cancel(m_routeChangeHandle);
+
+  m_notificationContext = nullptr;
+  if (allCancelled) {
+    delete context;
+  } else if (context != nullptr) {
+    logger.error()
+        << "Retaining disabled network callback context after cancel failure";
+  }
+}
+
+void WindowsSplitTunnel::scheduleAddressRefresh() {
+  QMetaObject::invokeMethod(
+      this,
+      [this]() {
+        m_addressRefreshRetryAttempts = 0;
+        if (m_addressMonitoringActive && !m_addressRefreshTimer.isActive()) {
+          m_addressRefreshTimer.start();
+        }
+      },
+      Qt::QueuedConnection);
+}
+
+void WindowsSplitTunnel::dispatchAddressRefresh(PVOID context) {
+  auto notification = static_cast<NotificationContext*>(context);
+  if (notification == nullptr) {
+    return;
+  }
+  AcquireSRWLockShared(&notification->lock);
+  if (notification->target != nullptr) {
+    notification->target->scheduleAddressRefresh();
+  }
+  ReleaseSRWLockShared(&notification->lock);
+}
+
+void CALLBACK WindowsSplitTunnel::routeChangeCallback(
+    PVOID context, PMIB_IPFORWARD_ROW2 row, MIB_NOTIFICATION_TYPE type) {
+  Q_UNUSED(row);
+  Q_UNUSED(type);
+  dispatchAddressRefresh(context);
+}
+
+void CALLBACK WindowsSplitTunnel::addressChangeCallback(
+    PVOID context, PMIB_UNICASTIPADDRESS_ROW row, MIB_NOTIFICATION_TYPE type) {
+  Q_UNUSED(row);
+  Q_UNUSED(type);
+  dispatchAddressRefresh(context);
+}
+
+void CALLBACK WindowsSplitTunnel::interfaceChangeCallback(
+    PVOID context, PMIB_IPINTERFACE_ROW row, MIB_NOTIFICATION_TYPE type) {
+  Q_UNUSED(row);
+  Q_UNUSED(type);
+  dispatchAddressRefresh(context);
 }
 
 std::vector<uint8_t> WindowsSplitTunnel::generateProcessBlob() {

--- a/client/platforms/windows/daemon/windowssplittunnel.cpp
+++ b/client/platforms/windows/daemon/windowssplittunnel.cpp
@@ -6,6 +6,10 @@
 
 #include <qassert.h>
 
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <limits>
 #include <memory>
 
 #include "../windowscommons.h"
@@ -23,7 +27,6 @@
 #include <QCoreApplication>
 #include <QFileInfo>
 #include <QMetaObject>
-#include <QNetworkInterface>
 #include <QScopeGuard>
 #include <QUrl>
 
@@ -129,6 +132,77 @@ constexpr static const auto MV_SERVICE_NAME = L"MullvadVPN";
 namespace {
 Logger logger("WindowsSplitTunnel");
 constexpr int AddressRefreshRetryIntervalMs = 1000;
+
+enum class DadState { Other, Tentative, Deprecated, Preferred };
+
+struct AddressAvailability {
+  bool internetIpv4;
+  bool tunnelIpv4;
+  bool internetIpv6;
+  bool tunnelIpv6;
+};
+
+constexpr int dadAddressScore(DadState state) {
+  return state == DadState::Preferred    ? 2
+         : state == DadState::Deprecated ? 1
+                                         : 0;
+}
+
+constexpr bool hasInternetAddress(const AddressAvailability& addresses) {
+  return addresses.internetIpv4 || addresses.internetIpv6;
+}
+
+constexpr bool hasTunnelAddress(const AddressAvailability& addresses) {
+  return addresses.tunnelIpv4 || addresses.tunnelIpv6;
+}
+
+constexpr int splittingMode(const AddressAvailability& addresses) {
+  if (addresses.internetIpv4 && addresses.tunnelIpv4 &&
+      addresses.internetIpv6 && addresses.tunnelIpv6) {
+    return 1;
+  }
+  if (addresses.internetIpv4 && addresses.tunnelIpv4 &&
+      !addresses.internetIpv6 && !addresses.tunnelIpv6) {
+    return 2;
+  }
+  if (addresses.internetIpv4 && addresses.tunnelIpv4 &&
+      addresses.internetIpv6 && !addresses.tunnelIpv6) {
+    return 3;
+  }
+  if (addresses.internetIpv4 && addresses.tunnelIpv4 &&
+      !addresses.internetIpv6 && addresses.tunnelIpv6) {
+    return 4;
+  }
+  if (!addresses.internetIpv4 && !addresses.tunnelIpv4 &&
+      addresses.internetIpv6 && addresses.tunnelIpv6) {
+    return 5;
+  }
+  if (addresses.internetIpv4 && !addresses.tunnelIpv4 &&
+      addresses.internetIpv6 && addresses.tunnelIpv6) {
+    return 6;
+  }
+  if (!addresses.internetIpv4 && addresses.tunnelIpv4 &&
+      addresses.internetIpv6 && addresses.tunnelIpv6) {
+    return 7;
+  }
+  if (!addresses.internetIpv4 && addresses.tunnelIpv4 &&
+      addresses.internetIpv6 && !addresses.tunnelIpv6) {
+    return 8;
+  }
+  if (addresses.internetIpv4 && !addresses.tunnelIpv4 &&
+      !addresses.internetIpv6 && addresses.tunnelIpv6) {
+    return 9;
+  }
+  return 0;
+}
+
+constexpr bool operationalWhileDadSettles(bool driverRunning,
+                                          bool driverReady,
+                                          bool monitoringActive,
+                                          bool stabilizationPending) {
+  return driverRunning ||
+         (driverReady && monitoringActive && stabilizationPending);
+}
 
 ProcessInfo getProcessInfo(HANDLE process, const PROCESSENTRY32W& processMeta) {
   ProcessInfo pi;
@@ -294,7 +368,8 @@ WindowsSplitTunnel::WindowsSplitTunnel(HANDLE driverIO)
   m_addressRefreshTimer.setInterval(250);
   connect(&m_addressRefreshTimer, &QTimer::timeout, this, [this]() {
     const bool refreshSucceeded =
-        !m_addressMonitoringActive || registerIPConfiguration(false);
+        !m_addressMonitoringActive ||
+        registerIPConfiguration(false, false);
     if (!refreshSucceeded) {
       logger.error() << "Failed to refresh split-tunnel network addresses";
       if (m_addressMonitoringActive && m_addressRefreshRetryAttempts < 3) {
@@ -304,6 +379,9 @@ WindowsSplitTunnel::WindowsSplitTunnel(HANDLE driverIO)
       return;
     }
     m_addressRefreshRetryAttempts = 0;
+    if (m_addressMonitoringActive && m_addressStabilizationPending) {
+      m_addressRefreshTimer.start();
+    }
   });
 
   Q_ASSERT(getState() == STATE_INITIALIZED);
@@ -345,7 +423,8 @@ bool WindowsSplitTunnel::excludeApps(const QStringList& appPaths) {
   return true;
 }
 
-bool WindowsSplitTunnel::start(int inetAdapterIndex, int vpnAdapterIndex) {
+bool WindowsSplitTunnel::start(const QHostAddress& endpoint,
+                               int inetAdapterIndex, int vpnAdapterIndex) {
   // To Start we need to send 2 things:
   // Network info (what is vpn what is network)
   logger.debug() << "Starting SplitTunnel";
@@ -353,8 +432,10 @@ bool WindowsSplitTunnel::start(int inetAdapterIndex, int vpnAdapterIndex) {
 
   m_addressMonitoringActive = false;
   stopAddressMonitoring();
-  m_inetAdapterIndex = inetAdapterIndex;
-  m_vpnAdapterIndex = vpnAdapterIndex;
+  m_endpoint = endpoint;
+  if (!updateAdapterLuids(inetAdapterIndex, vpnAdapterIndex)) {
+    return false;
+  }
   auto failedStart = qScopeGuard([this]() {
     m_addressMonitoringActive = false;
     stopAddressMonitoring();
@@ -400,11 +481,14 @@ bool WindowsSplitTunnel::start(int inetAdapterIndex, int vpnAdapterIndex) {
   if (!startAddressMonitoring()) {
     return false;
   }
-  if (!registerIPConfiguration(true)) {
+  if (!registerIPConfiguration(true, true)) {
     logger.error() << "Failed to register initial split-tunnel addresses";
     return false;
   }
   m_addressMonitoringActive = true;
+  if (m_addressStabilizationPending) {
+    m_addressRefreshTimer.start();
+  }
   failedStart.dismiss();
   return true;
 }
@@ -514,67 +598,162 @@ std::vector<uint8_t> WindowsSplitTunnel::generateAppConfiguration(
   return outBuffer;
 }
 
-std::vector<std::byte> WindowsSplitTunnel::generateIPConfiguration(
-    int inetAdapterIndex, int vpnAdapterIndex) {
-  std::vector<std::byte> out(sizeof(IP_ADDRESSES_CONFIG));
-
-  auto config = reinterpret_cast<IP_ADDRESSES_CONFIG*>(&out[0]);
-
+bool WindowsSplitTunnel::updateAdapterLuids(int inetAdapterIndex,
+                                            int vpnAdapterIndex) {
   if (vpnAdapterIndex == 0) {
     vpnAdapterIndex = WindowsCommons::VPNAdapterIndex();
   }
-  // Always the VPN
-  if (!getAddress(vpnAdapterIndex, &config->TunnelIpv4,
-                  &config->TunnelIpv6)) {
-    return {};
-  }
-  // 2nd best route is usually the internet adapter
-  if (!getAddress(inetAdapterIndex, &config->InternetIpv4,
-                  &config->InternetIpv6)) {
-    return {};
-  };
-  return out;
-}
-bool WindowsSplitTunnel::getAddress(int adapterIndex, IN_ADDR* out_ipv4,
-                                    IN6_ADDR* out_ipv6) {
-  QNetworkInterface target =
-      QNetworkInterface::interfaceFromIndex(adapterIndex);
-  logger.debug() << "Getting adapter info for:" << target.humanReadableName();
-
-  auto get = [&target](QAbstractSocket::NetworkLayerProtocol protocol) {
-    for (auto address : target.addressEntries()) {
-      if (address.ip().protocol() != protocol) {
-        continue;
-      }
-      return address.ip().toString().toStdWString();
-    }
-    return std::wstring{};
-  };
-  auto ipv4 = get(QAbstractSocket::IPv4Protocol);
-  auto ipv6 = get(QAbstractSocket::IPv6Protocol);
-
-  if (InetPtonW(AF_INET, ipv4.c_str(), out_ipv4) != 1) {
-    logger.debug() << "Ipv4 Conversation error" << WSAGetLastError();
+  if (vpnAdapterIndex <= 0 ||
+      ConvertInterfaceIndexToLuid(vpnAdapterIndex, &m_vpnAdapterLuid) !=
+          NO_ERROR) {
+    logger.error() << "Failed to resolve VPN adapter LUID:" << vpnAdapterIndex;
+    m_vpnAdapterLuid.Value = 0;
     return false;
   }
-  if (ipv6.empty()) {
-    std::memset(out_ipv6, 0x00, sizeof(IN6_ADDR));
-    return true;
-  }
-  if (InetPtonW(AF_INET6, ipv6.c_str(), out_ipv6) != 1) {
-    logger.debug() << "Ipv6 Conversation error" << WSAGetLastError();
+
+  m_internetHintLuid.Value = 0;
+  if (inetAdapterIndex > 0 &&
+      ConvertInterfaceIndexToLuid(inetAdapterIndex, &m_internetHintLuid) !=
+          NO_ERROR) {
+    logger.warning() << "Failed to resolve internet adapter LUID:"
+                     << inetAdapterIndex;
+    m_internetHintLuid.Value = 0;
   }
   return true;
 }
 
-bool WindowsSplitTunnel::registerIPConfiguration(bool force) {
-  auto config =
-      generateIPConfiguration(m_inetAdapterIndex, m_vpnAdapterIndex);
+namespace {
+
+bool isEmpty(const IN_ADDR& address) {
+  return address.S_un.S_addr == INADDR_ANY;
+}
+
+bool isEmpty(const IN6_ADDR& address) {
+  return IN6_IS_ADDR_UNSPECIFIED(&address);
+}
+
+bool isUsable(const IN_ADDR& address) {
+  const std::uint32_t hostAddress = ntohl(address.S_un.S_addr);
+  const std::uint8_t firstOctet =
+      static_cast<std::uint8_t>(hostAddress >> 24);
+  return hostAddress != INADDR_ANY && firstOctet != 127 && firstOctet < 224 &&
+         (hostAddress & 0xffff0000u) != 0xa9fe0000u;
+}
+
+bool isUsable(const IN6_ADDR& address) {
+  return !IN6_IS_ADDR_UNSPECIFIED(&address) &&
+         !IN6_IS_ADDR_LOOPBACK(&address) && !IN6_IS_ADDR_LINKLOCAL(&address) &&
+         !IN6_IS_ADDR_MULTICAST(&address);
+}
+
+AddressAvailability availability(
+    const IP_ADDRESSES_CONFIG& addresses) {
+  return {
+      !isEmpty(addresses.InternetIpv4),
+      !isEmpty(addresses.TunnelIpv4),
+      !isEmpty(addresses.InternetIpv6),
+      !isEmpty(addresses.TunnelIpv6),
+  };
+}
+
+}  // namespace
+
+std::vector<std::byte> WindowsSplitTunnel::generateIPConfiguration() {
+  std::vector<std::byte> out(sizeof(IP_ADDRESSES_CONFIG));
+  auto config = reinterpret_cast<IP_ADDRESSES_CONFIG*>(out.data());
+  m_addressStabilizationPending = false;
+  m_addressCollectionIncomplete = false;
+
+  if (!getAddresses(m_vpnAdapterLuid, &config->TunnelIpv4,
+                    &config->TunnelIpv6)) {
+    logger.error() << "Failed to collect VPN interface addresses";
+    return {};
+  }
+
+  NET_LUID preferredAdapter = m_internetHintLuid;
+  const auto endpointRoute = getEndpointRoute();
+  if (endpointRoute) {
+    preferredAdapter = endpointRoute->adapter;
+    m_internetHintLuid = endpointRoute->adapter;
+  }
+
+  if (m_endpoint.protocol() == QAbstractSocket::IPv4Protocol &&
+      endpointRoute) {
+    if (endpointRoute->source.si_family == AF_INET &&
+        isUsable(endpointRoute->source.Ipv4.sin_addr)) {
+      config->InternetIpv4 = endpointRoute->source.Ipv4.sin_addr;
+    } else if (!getAddresses(endpointRoute->adapter, &config->InternetIpv4,
+                             nullptr)) {
+      logger.error() << "Failed to collect fallback internet IPv4 address";
+      return {};
+    }
+  } else if (auto adapter = getBestDefaultRoute(AF_INET, preferredAdapter)) {
+    if (!getAddresses(*adapter, &config->InternetIpv4, nullptr)) {
+      logger.error() << "Failed to collect internet IPv4 address";
+      return {};
+    }
+  }
+
+  if (m_endpoint.protocol() == QAbstractSocket::IPv6Protocol &&
+      endpointRoute) {
+    if (endpointRoute->source.si_family == AF_INET6 &&
+        isUsable(endpointRoute->source.Ipv6.sin6_addr)) {
+      config->InternetIpv6 = endpointRoute->source.Ipv6.sin6_addr;
+    } else if (!getAddresses(endpointRoute->adapter, nullptr,
+                             &config->InternetIpv6)) {
+      logger.error() << "Failed to collect fallback internet IPv6 address";
+      return {};
+    }
+  } else if (auto adapter = getBestDefaultRoute(AF_INET6, preferredAdapter)) {
+    if (!getAddresses(*adapter, nullptr, &config->InternetIpv6)) {
+      logger.error() << "Failed to collect internet IPv6 address";
+      return {};
+    }
+  }
+
+  if (m_addressCollectionIncomplete) {
+    return {};
+  }
+
+  auto addressState = availability(*config);
+  if (!hasInternetAddress(addressState)) {
+    std::memset(config, 0, sizeof(*config));
+    addressState = availability(*config);
+  }
+
+  const int mode = splittingMode(addressState);
+  if (hasTunnelAddress(addressState) && mode == 0) {
+    logger.error() << "Unsupported split-tunnel address combination";
+    return {};
+  }
+  logger.debug() << "Split-tunnel address availability: internet v4"
+                 << addressState.internetIpv4 << "tunnel v4"
+                 << addressState.tunnelIpv4 << "internet v6"
+                 << addressState.internetIpv6 << "tunnel v6"
+                 << addressState.tunnelIpv6 << "mode" << mode;
+  return out;
+}
+
+bool WindowsSplitTunnel::registerIPConfiguration(bool force,
+                                                 bool requireActiveMode) {
+  auto config = generateIPConfiguration();
   if (config.empty()) {
-    logger.error() << "Network configuration blob is empty. Internet adapter:"
-                   << m_inetAdapterIndex << "VPN adapter:"
-                   << m_vpnAdapterIndex;
     return false;
+  }
+
+  const auto* addresses =
+      reinterpret_cast<const IP_ADDRESSES_CONFIG*>(config.data());
+  const auto addressState = availability(*addresses);
+  const bool activeMode =
+      hasInternetAddress(addressState) &&
+      hasTunnelAddress(addressState) &&
+      splittingMode(addressState) != 0;
+  if (requireActiveMode && !activeMode && !m_addressStabilizationPending) {
+    logger.error() << "No usable tunnel/internet address pair";
+    return false;
+  }
+  if (!activeMode && m_addressStabilizationPending) {
+    std::memset(config.data(), 0, config.size());
   }
   if (!force && config == m_lastIPConfiguration) {
     return true;
@@ -591,6 +770,160 @@ bool WindowsSplitTunnel::registerIPConfiguration(bool force) {
   m_lastIPConfiguration = std::move(config);
   logger.debug() << "New Network Config Applied || new State:" << stateString();
   return true;
+}
+
+bool WindowsSplitTunnel::getAddresses(const NET_LUID& adapter,
+                                      IN_ADDR* outIpv4, IN6_ADDR* outIpv6) {
+  if (outIpv4 != nullptr) {
+    std::memset(outIpv4, 0, sizeof(*outIpv4));
+  }
+  if (outIpv6 != nullptr) {
+    std::memset(outIpv6, 0, sizeof(*outIpv6));
+  }
+  if (adapter.Value == 0) {
+    return true;
+  }
+
+  PMIB_UNICASTIPADDRESS_TABLE table = nullptr;
+  const DWORD result = GetUnicastIpAddressTable(AF_UNSPEC, &table);
+  if (result == ERROR_NOT_FOUND) {
+    return true;
+  }
+  if (result != NO_ERROR) {
+    logger.error() << "Failed to retrieve unicast address table:" << result;
+    m_addressCollectionIncomplete = true;
+    return false;
+  }
+  auto guard = qScopeGuard([&] { FreeMibTable(table); });
+
+  int ipv4Score = 0;
+  int ipv6Score = 0;
+  bool ipv4Tentative = false;
+  bool ipv6Tentative = false;
+  for (ULONG i = 0; i < table->NumEntries; ++i) {
+    const MIB_UNICASTIPADDRESS_ROW& row = table->Table[i];
+    if (row.InterfaceLuid.Value != adapter.Value || row.SkipAsSource) {
+      continue;
+    }
+
+    DadState dadState =
+        DadState::Other;
+    if (row.DadState == IpDadStatePreferred) {
+      dadState = DadState::Preferred;
+    } else if (row.DadState == IpDadStateDeprecated) {
+      dadState = DadState::Deprecated;
+    } else if (row.DadState == IpDadStateTentative) {
+      dadState = DadState::Tentative;
+      const bool requestedUsableIpv4 =
+          outIpv4 != nullptr && row.Address.si_family == AF_INET &&
+          isUsable(row.Address.Ipv4.sin_addr);
+      const bool requestedUsableIpv6 =
+          outIpv6 != nullptr && row.Address.si_family == AF_INET6 &&
+          isUsable(row.Address.Ipv6.sin6_addr);
+      ipv4Tentative = ipv4Tentative || requestedUsableIpv4;
+      ipv6Tentative = ipv6Tentative || requestedUsableIpv6;
+    }
+    const int score = dadAddressScore(dadState);
+    if (score == 0) {
+      continue;
+    }
+    if (outIpv4 != nullptr && row.Address.si_family == AF_INET &&
+        score > ipv4Score && isUsable(row.Address.Ipv4.sin_addr)) {
+      *outIpv4 = row.Address.Ipv4.sin_addr;
+      ipv4Score = score;
+    }
+    if (outIpv6 != nullptr && row.Address.si_family == AF_INET6 &&
+        score > ipv6Score && isUsable(row.Address.Ipv6.sin6_addr)) {
+      *outIpv6 = row.Address.Ipv6.sin6_addr;
+      ipv6Score = score;
+    }
+  }
+  m_addressStabilizationPending =
+      m_addressStabilizationPending ||
+      (ipv4Tentative && ipv4Score == 0) ||
+      (ipv6Tentative && ipv6Score == 0);
+  return true;
+}
+
+std::optional<NET_LUID> WindowsSplitTunnel::getBestDefaultRoute(
+    ADDRESS_FAMILY family, const NET_LUID& preferredAdapter) {
+  PMIB_IPFORWARD_TABLE2 table = nullptr;
+  const DWORD result = GetIpForwardTable2(family, &table);
+  if (result == ERROR_NOT_FOUND || result == ERROR_NOT_SUPPORTED) {
+    return std::nullopt;
+  }
+  if (result != NO_ERROR) {
+    logger.error() << "Failed to retrieve route table for family" << family
+                   << ":" << result;
+    m_addressCollectionIncomplete = true;
+    return std::nullopt;
+  }
+  auto guard = qScopeGuard([&] { FreeMibTable(table); });
+
+  std::optional<NET_LUID> bestAdapter;
+  std::uint64_t bestMetric = (std::numeric_limits<std::uint64_t>::max)();
+  bool bestIsPreferred = false;
+  for (ULONG i = 0; i < table->NumEntries; ++i) {
+    const MIB_IPFORWARD_ROW2& route = table->Table[i];
+    if (route.DestinationPrefix.PrefixLength != 0 || route.Loopback ||
+        route.ValidLifetime == 0 ||
+        route.InterfaceLuid.Value == m_vpnAdapterLuid.Value) {
+      continue;
+    }
+
+    MIB_IPINTERFACE_ROW interfaceRow = {};
+    InitializeIpInterfaceEntry(&interfaceRow);
+    interfaceRow.Family = family;
+    interfaceRow.InterfaceLuid = route.InterfaceLuid;
+    if (GetIpInterfaceEntry(&interfaceRow) != NO_ERROR ||
+        !interfaceRow.Connected) {
+      continue;
+    }
+
+    const std::uint64_t metric = static_cast<std::uint64_t>(route.Metric) +
+                                 static_cast<std::uint64_t>(interfaceRow.Metric);
+    const bool isPreferred =
+        route.InterfaceLuid.Value == preferredAdapter.Value;
+    if (metric > bestMetric ||
+        (metric == bestMetric && (bestIsPreferred || !isPreferred))) {
+      continue;
+    }
+    bestAdapter = route.InterfaceLuid;
+    bestMetric = metric;
+    bestIsPreferred = isPreferred;
+  }
+  return bestAdapter;
+}
+
+std::optional<WindowsSplitTunnel::EndpointRoute>
+WindowsSplitTunnel::getEndpointRoute() {
+  SOCKADDR_INET destination = {};
+  if (m_endpoint.protocol() == QAbstractSocket::IPv4Protocol) {
+    destination.Ipv4.sin_family = AF_INET;
+    destination.Ipv4.sin_addr.S_un.S_addr = htonl(m_endpoint.toIPv4Address());
+  } else if (m_endpoint.protocol() == QAbstractSocket::IPv6Protocol) {
+    destination.Ipv6.sin6_family = AF_INET6;
+    const Q_IPV6ADDR address = m_endpoint.toIPv6Address();
+    std::memcpy(&destination.Ipv6.sin6_addr, address.c, sizeof(address.c));
+  } else {
+    return std::nullopt;
+  }
+
+  MIB_IPFORWARD_ROW2 route = {};
+  SOCKADDR_INET source = {};
+  const DWORD result =
+      GetBestRoute2(nullptr, 0, nullptr, &destination, 0, &route, &source);
+  if (result != NO_ERROR) {
+    logger.warning() << "Failed to resolve current route to VPN endpoint:"
+                     << result;
+    m_addressCollectionIncomplete = true;
+    return std::nullopt;
+  }
+  if (route.InterfaceLuid.Value == m_vpnAdapterLuid.Value) {
+    logger.warning() << "VPN endpoint route points into the VPN interface";
+    return std::nullopt;
+  }
+  return EndpointRoute{route.InterfaceLuid, source};
 }
 
 bool WindowsSplitTunnel::startAddressMonitoring() {
@@ -931,7 +1264,12 @@ bool WindowsSplitTunnel::detectConflict() {
   return err == ERROR_SERVICE_DOES_NOT_EXIST;
 }
 
-bool WindowsSplitTunnel::isRunning() { return getState() == STATE_RUNNING; }
+bool WindowsSplitTunnel::isOperational() {
+  const auto state = getState();
+  return operationalWhileDadSettles(
+      state == STATE_RUNNING, state == STATE_READY, m_addressMonitoringActive,
+      m_addressStabilizationPending);
+}
 QString WindowsSplitTunnel::stateString() {
   switch (getState()) {
     case STATE_UNKNOWN:

--- a/client/platforms/windows/daemon/windowssplittunnel.h
+++ b/client/platforms/windows/daemon/windowssplittunnel.h
@@ -5,12 +5,14 @@
 #ifndef WINDOWSSPLITTUNNEL_H
 #define WINDOWSSPLITTUNNEL_H
 
+#include <QHostAddress>
 #include <QObject>
 #include <QString>
 #include <QStringList>
 #include <QTimer>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <vector>
 
 // Note: the ws2tcpip.h import must come before the others.
@@ -53,12 +55,13 @@ class WindowsSplitTunnel final : public QObject {
   bool excludeApps(const QStringList& appPaths);
 
   // Fetches and Pushed needed info to move to engaged mode
-  bool start(int inetAdapterIndex, int vpnAdapterIndex = 0);
+  bool start(const QHostAddress& endpoint, int inetAdapterIndex,
+             int vpnAdapterIndex = 0);
   // Deletes Rules and puts the driver into passive mode
   void stop();
 
-  // Returns true if the split-tunnel driver is now up and running.
-  bool isRunning();
+  // Returns true if split tunneling is running or safely waiting for IPv6 DAD.
+  bool isOperational();
 
   static bool detectConflict();
 
@@ -89,10 +92,11 @@ class WindowsSplitTunnel final : public QObject {
   // Generates a Configuration for Each APP
   std::vector<uint8_t> generateAppConfiguration(const QStringList& appPaths);
   // Generates a Configuration which IP's are VPN and which network
-  std::vector<std::byte> generateIPConfiguration(int inetAdapterIndex, int vpnAdapterIndex = 0);
+  std::vector<std::byte> generateIPConfiguration();
   std::vector<uint8_t> generateProcessBlob();
 
-  bool registerIPConfiguration(bool force);
+  bool updateAdapterLuids(int inetAdapterIndex, int vpnAdapterIndex);
+  bool registerIPConfiguration(bool force, bool requireActiveMode = false);
   bool startAddressMonitoring();
   void stopAddressMonitoring();
   void scheduleAddressRefresh();
@@ -107,8 +111,15 @@ class WindowsSplitTunnel final : public QObject {
                                                PMIB_IPINTERFACE_ROW row,
                                                MIB_NOTIFICATION_TYPE type);
 
-  [[nodiscard]] bool getAddress(int adapterIndex, IN_ADDR* out_ipv4,
-                                IN6_ADDR* out_ipv6);
+  [[nodiscard]] bool getAddresses(const NET_LUID& adapter, IN_ADDR* outIpv4,
+                                  IN6_ADDR* outIpv6);
+  [[nodiscard]] std::optional<NET_LUID> getBestDefaultRoute(
+      ADDRESS_FAMILY family, const NET_LUID& preferredAdapter);
+  struct EndpointRoute {
+    NET_LUID adapter;
+    SOCKADDR_INET source;
+  };
+  [[nodiscard]] std::optional<EndpointRoute> getEndpointRoute();
   // Collects info about an Opened Process
 
   // Converts a path to a Dos Path:
@@ -122,9 +133,12 @@ class WindowsSplitTunnel final : public QObject {
   HANDLE m_addressChangeHandle = nullptr;
   HANDLE m_interfaceChangeHandle = nullptr;
   bool m_addressMonitoringActive = false;
-  int m_inetAdapterIndex = 0;
-  int m_vpnAdapterIndex = 0;
+  bool m_addressStabilizationPending = false;
+  bool m_addressCollectionIncomplete = false;
   std::uint32_t m_addressRefreshRetryAttempts = 0;
+  QHostAddress m_endpoint;
+  NET_LUID m_internetHintLuid = {};
+  NET_LUID m_vpnAdapterLuid = {};
   std::vector<std::byte> m_lastIPConfiguration;
 };
 

--- a/client/platforms/windows/daemon/windowssplittunnel.h
+++ b/client/platforms/windows/daemon/windowssplittunnel.h
@@ -8,7 +8,10 @@
 #include <QObject>
 #include <QString>
 #include <QStringList>
+#include <QTimer>
+#include <cstdint>
 #include <memory>
+#include <vector>
 
 // Note: the ws2tcpip.h import must come before the others.
 // clang-format off
@@ -16,12 +19,13 @@
 // clang-format on
 #include <Ws2ipdef.h>
 #include <ioapiset.h>
+#include <iphlpapi.h>
 #include <tlhelp32.h>
 #include <windows.h>
 
 class WindowsFirewall;
 
-class WindowsSplitTunnel final {
+class WindowsSplitTunnel final : public QObject {
  public:
   /**
    * @brief Installs and Initializes the Split Tunnel Driver.
@@ -88,6 +92,21 @@ class WindowsSplitTunnel final {
   std::vector<std::byte> generateIPConfiguration(int inetAdapterIndex, int vpnAdapterIndex = 0);
   std::vector<uint8_t> generateProcessBlob();
 
+  bool registerIPConfiguration(bool force);
+  bool startAddressMonitoring();
+  void stopAddressMonitoring();
+  void scheduleAddressRefresh();
+  static void dispatchAddressRefresh(PVOID context);
+  static void CALLBACK routeChangeCallback(PVOID context,
+                                           PMIB_IPFORWARD_ROW2 row,
+                                           MIB_NOTIFICATION_TYPE type);
+  static void CALLBACK addressChangeCallback(PVOID context,
+                                             PMIB_UNICASTIPADDRESS_ROW row,
+                                             MIB_NOTIFICATION_TYPE type);
+  static void CALLBACK interfaceChangeCallback(PVOID context,
+                                               PMIB_IPINTERFACE_ROW row,
+                                               MIB_NOTIFICATION_TYPE type);
+
   [[nodiscard]] bool getAddress(int adapterIndex, IN_ADDR* out_ipv4,
                                 IN6_ADDR* out_ipv6);
   // Collects info about an Opened Process
@@ -95,6 +114,18 @@ class WindowsSplitTunnel final {
   // Converts a path to a Dos Path:
   // e.g C:/a.exe -> /harddisk0/a.exe
   QString convertPath(const QString& path);
+
+  struct NotificationContext;
+  QTimer m_addressRefreshTimer;
+  NotificationContext* m_notificationContext = nullptr;
+  HANDLE m_routeChangeHandle = nullptr;
+  HANDLE m_addressChangeHandle = nullptr;
+  HANDLE m_interfaceChangeHandle = nullptr;
+  bool m_addressMonitoringActive = false;
+  int m_inetAdapterIndex = 0;
+  int m_vpnAdapterIndex = 0;
+  std::uint32_t m_addressRefreshRetryAttempts = 0;
+  std::vector<std::byte> m_lastIPConfiguration;
 };
 
 #endif  // WINDOWSSPLITTUNNEL_H


### PR DESCRIPTION
## Problem
Split tunnel addresses are registered only at start. On route / interface / address changes (Wi-Fi switch, VPN reconnect, address renewal) the registered addresses go stale and split tunneling breaks until reconnect. Additionally the client computes only a subset of the driver's splitting modes, so legitimate IPv4/IPv6 availability combinations misconfigure the driver.

## Fix
- Subscribe to NotifyRouteChange2 / NotifyIpInterfaceChange / NotifyUnicastIpAddressChange; debounce 250 ms; retry up to 3 times; wait for address stabilization before re-registering.
- Recompute availability (internet/tunnel x v4/v6) and select the matching driver splitting mode (1-9); pick the physical adapter from the server endpoint passed into start().
- Replace isRunning() with isOperational() for accurate state checks.

## Validation
- Network switch / adapter toggling / ipconfig renew during an active tunnel: split apps keep working.
- All 9 modes covered by compile-time static_asserts.
- Together with the companion driver PR: Java apps (ex. Minecraft) work in MODE_4.

## Related issue
mullvad/mullvadvpn-app#2972
## Companion driver PR
mullvad/win-split-tunnel#57 (MODE_4 IPv6 TCP bind fix)