### PR TITLE
fix(import): preserve MTU from vpn:// configurations

### DIFF
--- a/client/core/controllers/selfhosted/importController.cpp
+++ b/client/core/controllers/selfhosted/importController.cpp
@@ -748,8 +748,11 @@ void ImportController::processAmneziaConfig(QJsonObject &config) const
             }
 
             QJsonObject jsonConfig = QJsonDocument::fromJson(protocolConfig.toUtf8()).object();
-            jsonConfig[configKey::mtu] =
-                    ContainerUtils::isAwgContainer(dockerContainer) ? protocols::awg::defaultMtu : protocols::wireguard::defaultMtu;
+            if (jsonConfig.value(configKey::mtu).toString().trimmed().isEmpty()) {
+                jsonConfig[configKey::mtu] = ContainerUtils::isAwgContainer(dockerContainer)
+                        ? protocols::awg::defaultMtu
+                        : protocols::wireguard::defaultMtu;
+            }
 
             containerConfig[configKey::lastConfig] = QString(QJsonDocument(jsonConfig).toJson());
 
@@ -759,4 +762,3 @@ void ImportController::processAmneziaConfig(QJsonObject &config) const
         }
     }
 }
-


### PR DESCRIPTION
## Summary

Preserve an explicitly configured non-empty MTU when importing an Amnezia `vpn://` configuration. The WireGuard or AmneziaWG protocol default is now applied only when the imported MTU is missing or empty.

## Problem

`ImportController::processAmneziaConfig()` unconditionally replaced the MTU contained in imported WireGuard and AmneziaWG configurations with the protocol default. As a result, profiles that intentionally specified a custom MTU silently changed during import.

## Changes

- Keep a non-empty imported MTU unchanged.
- Treat whitespace-only MTU values as empty.
- Preserve the existing WireGuard/AmneziaWG default fallback for missing or empty values.

## Backward compatibility

Profiles without an MTU continue to receive the same protocol default. The change only affects profiles that already provide an explicit value.

## Verification

- Built the Windows x64 client and service in Release mode against `dev` at [`94b51df2`](https://github.com/amnezia-vpn/amnezia-client/commit/94b51df24790bf52427afe82d81c87a95460bdfd) (`5.0.3.1`) with this change included.
- Confirmed with `git range-diff` that the rebase preserves the patch without changing its contents.
- Before this rebase, imported a real `vpn://` profile on Windows and verified that its non-default MTU survives import. The MTU-handling implementation is unchanged.

## Related pull requests

- This is complementary to #3065, which changes the AmneziaWG default MTU value. This PR only changes when the default is applied.
