### PR TITLE
fix(windows): eliminate route-change storms with large split-tunnel e…

### DIFF
--- a/client/daemon/daemon.cpp
+++ b/client/daemon/daemon.cpp
@@ -132,9 +132,7 @@ bool Daemon::activate(const InterfaceConfig& config) {
   }
 
   // Configure routing for excluded addresses.
-  for (const QString& i : config.m_excludedAddresses) {
-    addExclusionRoute(IPAddress(i));
-  }
+  addExclusionRouteList(config.m_excludedAddresses);
 
   // Add the peer to this interface.
   if (!wgutils()->updatePeer(config)) {
@@ -219,6 +217,43 @@ bool Daemon::addExclusionRoute(const IPAddress& prefix) {
   }
   m_excludedAddrSet[prefix] = 1;
   return true;
+}
+
+// Batched variant for large split-tunneling lists: hand the whole batch to
+// the platform layer at once so it can amortize per-prefix costs.
+bool Daemon::addExclusionRouteList(const QStringList& addresses) {
+  logger.debug() << "Exclusion batch: parsing" << addresses.count()
+                 << "addresses";
+  QList<IPAddress> batch;
+  // QHash rather than QMap: IPAddress has no operator<, but provides
+  // qHash and operator==.
+  QHash<IPAddress, int> pending;
+  for (const QString& i : addresses) {
+    IPAddress prefix(i);
+    if (m_excludedAddrSet.contains(prefix)) {
+      m_excludedAddrSet[prefix]++;
+      continue;
+    }
+    auto it = pending.find(prefix);
+    if (it != pending.end()) {
+      it.value()++;
+      continue;
+    }
+    pending[prefix] = 1;
+    batch.append(prefix);
+  }
+  if (batch.isEmpty()) {
+    logger.debug() << "Exclusion batch: nothing new to add";
+    return true;
+  }
+  logger.debug() << "Exclusion batch: handing" << batch.count()
+                 << "prefixes to the platform layer";
+  bool ok = wgutils()->addExclusionRouteList(batch);
+  logger.debug() << "Exclusion batch: platform layer returned" << ok;
+  for (auto it = pending.constBegin(); it != pending.constEnd(); ++it) {
+    m_excludedAddrSet[it.key()] = it.value();
+  }
+  return ok;
 }
 
 bool Daemon::delExclusionRoute(const IPAddress& prefix) {
@@ -504,12 +539,12 @@ bool Daemon::deactivate(bool emitSignals) {
     wgutils()->deletePeer(config);
   }
 
-  // Cleanup routing for excluded addresses.
-  for (auto iterator = m_excludedAddrSet.constBegin();
-       iterator != m_excludedAddrSet.constEnd(); ++iterator) {
-    wgutils()->deleteExclusionRoute(iterator.key());
+  // Cleanup routing for excluded addresses (batched: per-prefix teardown
+  // rescans the routing table on every delete).
+  if (!m_excludedAddrSet.isEmpty()) {
+    wgutils()->deleteExclusionRouteList(m_excludedAddrSet.keys());
+    m_excludedAddrSet.clear();
   }
-  m_excludedAddrSet.clear();
 
   m_connections.clear();
   // Delete the interface
@@ -546,9 +581,7 @@ bool Daemon::switchServer(const InterfaceConfig& config) {
       m_connections.value(config.m_hopType).m_config;
 
   // Configure routing for new excluded addresses.
-  for (const QString& i : config.m_excludedAddresses) {
-    addExclusionRoute(IPAddress(i));
-  }
+  addExclusionRouteList(config.m_excludedAddresses);
 
   // Activate the new peer and its routes.
   if (!wgutils()->updatePeer(config)) {

--- a/client/daemon/daemon.h
+++ b/client/daemon/daemon.h
@@ -58,6 +58,7 @@ class Daemon : public QObject {
  private:
   bool maybeUpdateResolvers(const InterfaceConfig& config);
   bool addExclusionRoute(const IPAddress& address);
+  bool addExclusionRouteList(const QStringList& addresses);
   bool delExclusionRoute(const IPAddress& address);
 
  protected:

--- a/client/daemon/wireguardutils.h
+++ b/client/daemon/wireguardutils.h
@@ -45,7 +45,25 @@ class WireguardUtils : public QObject {
   virtual bool deleteRoutePrefix(const IPAddress& prefix) = 0;
   
   virtual bool addExclusionRoute(const IPAddress& prefix) = 0;
+  // Batched variant; platforms can override it to amortize expensive
+  // per-prefix work (e.g. routing table snapshots) over the whole list.
+  virtual bool addExclusionRouteList(const QList<IPAddress>& prefixes) {
+    bool ok = true;
+    for (const IPAddress& prefix : prefixes) {
+      ok &= addExclusionRoute(prefix);
+    }
+    return ok;
+  }
   virtual bool deleteExclusionRoute(const IPAddress& prefix) = 0;
+  // Batched variant; platforms can override it to amortize expensive
+  // per-prefix work over the whole list.
+  virtual bool deleteExclusionRouteList(const QList<IPAddress>& prefixes) {
+    bool ok = true;
+    for (const IPAddress& prefix : prefixes) {
+      ok &= deleteExclusionRoute(prefix);
+    }
+    return ok;
+  }
 
   virtual bool excludeLocalNetworks(const QList<IPAddress>& addresses) = 0;
 };

--- a/client/platforms/windows/daemon/windowsroutemonitor.cpp
+++ b/client/platforms/windows/daemon/windowsroutemonitor.cpp
@@ -63,6 +63,30 @@ WindowsRouteMonitor::WindowsRouteMonitor(quint64 luid, QObject* parent)
   MZ_COUNT_CTOR(WindowsRouteMonitor);
   logger.debug() << "WindowsRouteMonitor created.";
 
+  // Purge orphans from a previous run: if the daemon died without
+  // removing its exclusion routes, they stay in the table and blackhole
+  // matching traffic (including the handshake to the VPN server itself)
+  // until reboot. The NETMGMT + EXCLUSION_ROUTE_METRIC pair is produced
+  // only by this code, so the cleanup cannot touch foreign routes.
+  PMIB_IPFORWARD_TABLE2 table;
+  if (GetIpForwardTable2(AF_UNSPEC, &table) == NO_ERROR) {
+    ULONG stale = 0;
+    for (ULONG i = 0; i < table->NumEntries; i++) {
+      MIB_IPFORWARD_ROW2* row = &table->Table[i];
+      if ((row->Protocol == MIB_IPPROTO_NETMGMT) &&
+          (row->Metric == EXCLUSION_ROUTE_METRIC)) {
+        if (DeleteIpForwardEntry2(row) == NO_ERROR) {
+          stale++;
+        }
+      }
+    }
+    FreeMibTable(table);
+    if (stale) {
+      logger.warning() << "Removed" << stale
+                       << "stale exclusion route(s) from a previous run";
+    }
+  }
+
   NotifyRouteChange2(AF_INET, routeChangeCallback, this, FALSE, &m_routeHandle);
 }
 
@@ -366,69 +390,148 @@ void WindowsRouteMonitor::updateCapturedRoutes(int family, void* ptable) {
 }
 
 bool WindowsRouteMonitor::addExclusionRoute(const IPAddress& prefix) {
-  logger.debug() << "Adding exclusion route for" << prefix.toString();
+  return addExclusionRouteList(QList<IPAddress>{prefix});
+}
 
-  // Silently ignore non-routeable addresses.
-  QHostAddress addr = prefix.address();
-  if (addr.isLoopback() || addr.isBroadcast() || addr.isLinkLocal() ||
-      addr.isMulticast()) {
+// Batched variant: the routing table snapshot, interface metrics and captured
+// route refresh are done once per address family instead of once per prefix.
+// The per-prefix variant used to refetch and rescan the whole system routing
+// table for every entry, which is O(n^2) and takes many minutes for large
+// split-tunneling lists (~8-9k prefixes).
+bool WindowsRouteMonitor::addExclusionRouteList(const QList<IPAddress>& prefixes) {
+  logger.debug() << "Adding" << prefixes.count() << "exclusion route(s)";
+
+  // Mute our own echo: while we are bulk-editing routes ourselves, every
+  // change wakes routeChanged() with a full table rescan (the callback
+  // filter cannot drop these notifications - their rows carry unreliable
+  // fields). The unsubscribe/resubscribe pair is the same calls the
+  // constructor and destructor already use.
+  if (m_routeHandle != INVALID_HANDLE_VALUE) {
+    CancelMibChangeNotify2(m_routeHandle);
+    m_routeHandle = INVALID_HANDLE_VALUE;
+  }
+
+  PMIB_IPFORWARD_TABLE2 tables[2] = {nullptr, nullptr};  // [0]=IPv4, [1]=IPv6
+  bool ok = true;
+
+  for (const IPAddress& prefix : prefixes) {
+    // Silently ignore non-routeable addresses.
+    QHostAddress addr = prefix.address();
+    if (addr.isLoopback() || addr.isBroadcast() || addr.isLinkLocal() ||
+        addr.isMulticast()) {
+      continue;
+    }
+
+    if (m_exclusionRoutes.contains(prefix)) {
+      logger.warning() << "Exclusion route already exists";
+      ok = false;
+      continue;
+    }
+
+    int family;
+    int slot;
+    if (addr.protocol() == QAbstractSocket::IPv6Protocol) {
+      family = AF_INET6;
+      slot = 1;
+    } else {
+      family = AF_INET;
+      slot = 0;
+    }
+
+    // Fetch the routing table snapshot once per address family.
+    if (tables[slot] == nullptr) {
+      DWORD result = GetIpForwardTable2(family, &tables[slot]);
+      if (result != NO_ERROR) {
+        logger.error() << "Failed to fetch routing table:" << result;
+        ok = false;
+        continue;
+      }
+      updateInterfaceMetrics(family);
+      updateCapturedRoutes(family, tables[slot]);
+    }
+
+    // Allocate and initialize the MIB routing table row.
+    MIB_IPFORWARD_ROW2* data = new MIB_IPFORWARD_ROW2;
+    InitializeIpForwardEntry(data);
+    if (addr.protocol() == QAbstractSocket::IPv6Protocol) {
+      Q_IPV6ADDR buf = addr.toIPv6Address();
+
+      memcpy(&data->DestinationPrefix.Prefix.Ipv6.sin6_addr, &buf, sizeof(buf));
+      data->DestinationPrefix.Prefix.Ipv6.sin6_family = AF_INET6;
+      data->DestinationPrefix.PrefixLength = prefix.prefixLength();
+    } else {
+      quint32 buf = addr.toIPv4Address();
+
+      data->DestinationPrefix.Prefix.Ipv4.sin_addr.s_addr = htonl(buf);
+      data->DestinationPrefix.Prefix.Ipv4.sin_family = AF_INET;
+      data->DestinationPrefix.PrefixLength = prefix.prefixLength();
+    }
+    data->NextHop.si_family = data->DestinationPrefix.Prefix.si_family;
+
+    // Set the rest of the flags for a static route.
+    data->ValidLifetime = 0xffffffff;
+    data->PreferredLifetime = 0xffffffff;
+    data->Metric = EXCLUSION_ROUTE_METRIC;
+    data->Protocol = MIB_IPPROTO_NETMGMT;
+    data->Loopback = false;
+    data->AutoconfigureAddress = false;
+    data->Publish = false;
+    data->Immortal = false;
+    data->Age = 0;
+
+    updateExclusionRoute(data, tables[slot]);
+
+    m_exclusionRoutes[prefix] = data;
+  }
+
+  for (PMIB_IPFORWARD_TABLE2 table : tables) {
+    if (table != nullptr) {
+      FreeMibTable(table);
+    }
+  }
+
+  // A single manual rescan covers everything that may have changed while
+  // we were deaf (including a real network change mid-install);
+  // routeChanged() restores the subscription when it finishes.
+  routeChanged();
+  logger.debug() << "Exclusion batch done, ok =" << ok;
+  return ok;
+}
+
+bool WindowsRouteMonitor::deleteExclusionRouteList(
+    const QList<IPAddress>& prefixes) {
+  // An empty list is a no-op, matching zero iterations of the
+  // single-prefix path: the GUI sends a second deactivate after the
+  // tunnel is already torn down, and touching the subscription or
+  // triggering a rescan in that state is unsafe.
+  if (prefixes.isEmpty()) {
     return true;
   }
+  logger.debug() << "Deleting" << prefixes.count() << "exclusion route(s)";
 
-  if (m_exclusionRoutes.contains(prefix)) {
-    logger.warning() << "Exclusion route already exists";
-    return false;
+  if (m_routeHandle != INVALID_HANDLE_VALUE) {
+    CancelMibChangeNotify2(m_routeHandle);
+    m_routeHandle = INVALID_HANDLE_VALUE;
   }
 
-  // Allocate and initialize the MIB routing table row.
-  MIB_IPFORWARD_ROW2* data = new MIB_IPFORWARD_ROW2;
-  InitializeIpForwardEntry(data);
-  if (prefix.address().protocol() == QAbstractSocket::IPv6Protocol) {
-    Q_IPV6ADDR buf = prefix.address().toIPv6Address();
-
-    memcpy(&data->DestinationPrefix.Prefix.Ipv6.sin6_addr, &buf, sizeof(buf));
-    data->DestinationPrefix.Prefix.Ipv6.sin6_family = AF_INET6;
-    data->DestinationPrefix.PrefixLength = prefix.prefixLength();
-  } else {
-    quint32 buf = prefix.address().toIPv4Address();
-
-    data->DestinationPrefix.Prefix.Ipv4.sin_addr.s_addr = htonl(buf);
-    data->DestinationPrefix.Prefix.Ipv4.sin_family = AF_INET;
-    data->DestinationPrefix.PrefixLength = prefix.prefixLength();
-  }
-  data->NextHop.si_family = data->DestinationPrefix.Prefix.si_family;
-
-  // Set the rest of the flags for a static route.
-  data->ValidLifetime = 0xffffffff;
-  data->PreferredLifetime = 0xffffffff;
-  data->Metric = EXCLUSION_ROUTE_METRIC;
-  data->Protocol = MIB_IPPROTO_NETMGMT;
-  data->Loopback = false;
-  data->AutoconfigureAddress = false;
-  data->Publish = false;
-  data->Immortal = false;
-  data->Age = 0;
-
-  PMIB_IPFORWARD_TABLE2 table;
-  int family;
-  if (prefix.address().protocol() == QAbstractSocket::IPv6Protocol) {
-    family = AF_INET6;
-  } else {
-    family = AF_INET;
-  }
-
-  DWORD result = GetIpForwardTable2(family, &table);
-  if (result != NO_ERROR) {
-    logger.error() << "Failed to fetch routing table:" << result;
+  for (const IPAddress& prefix : prefixes) {
+    MIB_IPFORWARD_ROW2* data = m_exclusionRoutes.take(prefix);
+    if (data == nullptr) {
+      continue;
+    }
+    DWORD result = DeleteIpForwardEntry2(data);
+    if ((result != ERROR_NOT_FOUND) && (result != NO_ERROR)) {
+      logger.error() << "Failed to delete route to" << prefix.toString()
+                     << "result:" << result;
+    }
     delete data;
-    return false;
   }
-  updateInterfaceMetrics(family);
-  updateCapturedRoutes(family, table);
-  updateExclusionRoute(data, table);
-  FreeMibTable(table);
 
-  m_exclusionRoutes[prefix] = data;
+  // Captured routes are refreshed once for the whole list rather than
+  // per prefix (the single-prefix deleteExclusionRoute refetches the full
+  // table on every removal); routeChanged() restores the subscription.
+  routeChanged();
+  logger.debug() << "Exclusion delete batch done";
   return true;
 }
 
@@ -483,10 +586,21 @@ void WindowsRouteMonitor::setDetaultRouteCapture(bool enable) {
 void WindowsRouteMonitor::routeChanged() {
   logger.debug() << "Routes changed";
 
+  // The rescan itself rewrites routes (captured clones, flapping
+  // next-hops) - without muting, each of its own edits wakes the next
+  // rescan, which with a large exclusion list becomes an endless loop
+  // for the lifetime of the connection.
+  if (m_routeHandle != INVALID_HANDLE_VALUE) {
+    CancelMibChangeNotify2(m_routeHandle);
+    m_routeHandle = INVALID_HANDLE_VALUE;
+  }
+
   PMIB_IPFORWARD_TABLE2 table;
   DWORD result = GetIpForwardTable2(AF_UNSPEC, &table);
   if (result != NO_ERROR) {
     logger.error() << "Failed to fetch routing table:" << result;
+    NotifyRouteChange2(AF_INET, routeChangeCallback, this, FALSE,
+                       &m_routeHandle);
     return;
   }
 
@@ -497,4 +611,6 @@ void WindowsRouteMonitor::routeChanged() {
   }
 
   FreeMibTable(table);
+  NotifyRouteChange2(AF_INET, routeChangeCallback, this, FALSE,
+                     &m_routeHandle);
 }

--- a/client/platforms/windows/daemon/windowsroutemonitor.h
+++ b/client/platforms/windows/daemon/windowsroutemonitor.h
@@ -27,7 +27,9 @@ class WindowsRouteMonitor final : public QObject {
   void setDetaultRouteCapture(bool enable);
 
   bool addExclusionRoute(const IPAddress& prefix);
+  bool addExclusionRouteList(const QList<IPAddress>& prefixes);
   bool deleteExclusionRoute(const IPAddress& prefix);
+  bool deleteExclusionRouteList(const QList<IPAddress>& prefixes);
   void flushExclusionRoutes() { return flushRouteTable(m_exclusionRoutes); };
 
   quint64 getLuid() const { return m_luid; }

--- a/client/platforms/windows/daemon/wireguardutilswindows.cpp
+++ b/client/platforms/windows/daemon/wireguardutilswindows.cpp
@@ -312,8 +312,18 @@ bool WireguardUtilsWindows::addExclusionRoute(const IPAddress& prefix) {
   return m_routeMonitor->addExclusionRoute(prefix);
 }
 
+bool WireguardUtilsWindows::addExclusionRouteList(
+    const QList<IPAddress>& prefixes) {
+  return m_routeMonitor->addExclusionRouteList(prefixes);
+}
+
 bool WireguardUtilsWindows::deleteExclusionRoute(const IPAddress& prefix) {
   return m_routeMonitor->deleteExclusionRoute(prefix);
+}
+
+bool WireguardUtilsWindows::deleteExclusionRouteList(
+    const QList<IPAddress>& prefixes) {
+  return m_routeMonitor->deleteExclusionRouteList(prefixes);
 }
 
 bool WireguardUtilsWindows::excludeLocalNetworks(

--- a/client/platforms/windows/daemon/wireguardutilswindows.h
+++ b/client/platforms/windows/daemon/wireguardutilswindows.h
@@ -42,7 +42,9 @@ class WireguardUtilsWindows final : public WireguardUtils {
   bool deleteRoutePrefix(const IPAddress& prefix) override;
 
   bool addExclusionRoute(const IPAddress& prefix) override;
+  bool addExclusionRouteList(const QList<IPAddress>& prefixes) override;
   bool deleteExclusionRoute(const IPAddress& prefix) override;
+  bool deleteExclusionRouteList(const QList<IPAddress>& prefixes) override;
 
   bool WireguardUtilsWindows::excludeLocalNetworks(const QList<IPAddress>& addresses) override;
 


### PR DESCRIPTION
…xclusion lists

Importing a large IP exclusion list (~8.6k prefixes) made the Windows client unusable: connecting stalled for many minutes, disconnecting hung, and after a forced kill the client could not reconnect until reboot.

Three related defects in WindowsRouteMonitor:

1. Quadratic route installation. Every added exclusion route refetched the full routing table and interface metrics. Measured on stock: 500 prefixes = 1.4s, 1000 = 6.4s, 2000 = 33.4s (the kernel itself installs 500 routes in 146ms). Fix: batched add/delete entry points that snapshot the table once per address family; the teardown loop additionally refetched the table per deleted prefix.

2. Self-sustaining rescan storm. The monitor subscribes to NotifyRouteChange2, but its own rescan rewrites routes (captured clones, flapping next-hops), waking itself: with a large list the monitor rescanned ~4 times/second for the whole session, starving the IPC queue (deactivate took minutes to be processed). The callback filter cannot drop these notifications because the notification rows carry unreliable Protocol/Metric fields. Fix: unsubscribe for the duration of bulk operations and of the rescan itself, then run exactly one manual rescan; real network changes still trigger it via the restored subscription.

3. Orphaned exclusion routes. After a hard service kill the routes stayed in the system table pointing at the dead tunnel's next-hop, blackholing matching traffic (including the VPN server handshake) until reboot. Fix: purge NETMGMT+EXCLUSION_ROUTE_METRIC rows at monitor creation - that pair is only ever produced by this code.

Result with an 8658-prefix list: connect in 4-7s (route installation 0.85s), idle monitor after connect, teardown in seconds, reboot no longer needed after a crash.