### PR TITLE
fix: prevent G-Sync and ShadowPlay from reacting to the client window on Windows

### DIFF
--- a/client/main.cpp
+++ b/client/main.cpp
@@ -51,6 +51,17 @@ int main(int argc, char *argv[])
     qputenv("ANDROID_OPENSSL_SUFFIX", "_3");
 #endif
 
+#ifdef Q_OS_WIN
+    // Qt's D3D11 RHI creates a flip-model swapchain (DXGI_SWAP_EFFECT_FLIP_DISCARD) by default.
+    // NVIDIA treats flip presentation as fullscreen-like, so G-Sync in windowed mode and
+    // ShadowPlay react to the client window. Fall back to the blit-model swapchain, which DWM
+    // composites as an ordinary window. Rendering and QtQuick effects are unaffected.
+    // Only set it when the user has not overridden it from the outside.
+    if (!qEnvironmentVariableIsSet("QT_D3D_NO_FLIP")) {
+        qputenv("QT_D3D_NO_FLIP", "1");
+    }
+#endif
+
     AmneziaApplication app(argc, argv);
     OsSignalHandler::setup();
 


### PR DESCRIPTION
## Problem

On Windows the client window triggers NVIDIA features that should only apply to games:
G-Sync engages in windowed mode while AmneziaVPN is focused, and ShadowPlay treats the
window as a capturable application.

The cause is not D3D as such. Qt's D3D11 RHI creates a flip-model swapchain
(`DXGI_SWAP_EFFECT_FLIP_DISCARD`) by default, and NVIDIA detects flip presentation as
fullscreen-like. A regular blit-model swapchain is composited by DWM as an ordinary
window and is not detected this way.

## Fix

Set `QT_D3D_NO_FLIP=1` before the application is constructed, so Qt takes the legacy
blit-model path (`qrhid3d11.cpp`, `useLegacySwapchainModel`). Windows only, and only when
the variable is not already set from the outside, so it stays overridable.

Rendering is not touched: the D3D11 backend, the QtQuick effects (`DropShadow`,
`FastBlur`, `ColorOverlay`, `OpacityMask`) and the scene graph all behave as before.
The one documented side effect is that Qt cannot use `FRAME_LATENCY_WAITABLE_OBJECT`
in the blit model, so max frame latency drops from 2 to 0.

## How to verify

Run the client with `QSG_INFO=1` and look at the `qt.rhi.general` line.

Before:

```
FLIP_* swapchain supported = true, ALLOW_TEARING supported = true,
use legacy (non-FLIP) model = false, max frame latency = 2
```

After:

```
FLIP_* swapchain supported = true, ALLOW_TEARING supported = true,
use legacy (non-FLIP) model = true, max frame latency = 0
Disabling FRAME_LATENCY_WAITABLE_OBJECT usage
```

Tested on Windows 11 with a GeForce RTX 4080 (driver 616.56): the backend stays D3D11,
the UI and all effects render unchanged, and G-Sync/ShadowPlay no longer react to the
window.

Note: this does not address #2594 (high GPU usage), which is a separate issue about the
scene being redrawn continuously.

Closes #2462
Closes #1884
