### PR TITLE
Fix closing to tray from the Windows taskbar

### DIFF
--- a/client/core/utils/osSignalHandler.cpp
+++ b/client/core/utils/osSignalHandler.cpp
@@ -1,10 +1,7 @@
 #include "osSignalHandler.h"
 
 #include <QCoreApplication>
-#include <QMetaObject>
 #include <QSocketNotifier>
-
-#include "../amneziaApplication.h"
 
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
     #include <pthread.h>
@@ -17,43 +14,10 @@
     #include <unistd.h>
 #endif
 
-#ifdef Q_OS_WIN
-    #include <QAbstractNativeEventFilter>
-
-    #include <windows.h>
-#endif
-
 namespace
 {
 
     static bool initialized = false;
-
-#ifdef Q_OS_WIN
-    class WindowsCloseFilter : public QAbstractNativeEventFilter
-    {
-    public:
-        bool nativeEventFilter(const QByteArray &eventType, void *message, qintptr *result) override
-        {
-            MSG *msg = static_cast<MSG *>(message);
-
-            switch (msg->message) {
-            case WM_CLOSE: {
-                const HWND active = GetActiveWindow();
-                const HWND self = msg->hwnd;
-                if (active != self) {
-                    AmneziaApplication *app = qobject_cast<AmneziaApplication *>(QCoreApplication::instance());
-                    if (app) {
-                        QMetaObject::invokeMethod(app, "forceQuit", Qt::QueuedConnection);
-                    }
-                }
-            }
-            }
-            return false;
-        };
-    };
-
-    static WindowsCloseFilter *windowsFilter = nullptr;
-#endif
 
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
     static int signalFd = -1;
@@ -159,14 +123,6 @@ namespace
             signalPipe[1] = -1;
         }
 #endif
-
-#ifdef Q_OS_WIN
-        if (windowsFilter) {
-            QCoreApplication::instance()->removeNativeEventFilter(windowsFilter);
-            delete windowsFilter;
-            windowsFilter = nullptr;
-        }
-#endif
     }
 }
 
@@ -183,11 +139,6 @@ void OsSignalHandler::setup()
 
 #if (defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)) || defined(Q_OS_MACOS)
     setupUnixSignalHandler();
-#endif
-
-#ifdef Q_OS_WIN
-    windowsFilter = new WindowsCloseFilter();
-    QCoreApplication::instance()->installNativeEventFilter(windowsFilter);
 #endif
 
     QObject::connect(QCoreApplication::instance(), &QCoreApplication::aboutToQuit, [] { cleanupUnixSignalHandler(); });


### PR DESCRIPTION
## Summary

Fix a Windows bug where **closing AmneziaVPN from the taskbar terminates the client instead of keeping it running in the system tray**.

## Bug

The two ways of closing the same window produce different results:

- **Title-bar X:** hides the window and keeps the client running in the tray.
- **Taskbar thumbnail X:** can terminate the entire client process.

To reproduce:

1. Launch AmneziaVPN and minimize its window.
2. Hover over its taskbar icon to display the window thumbnail.
3. Click the X on the thumbnail.

**Expected:** The application remains running and accessible from the system tray.

**Actual:** The client process exits and the tray icon disappears.

## Cause

The regression was introduced in [[PR #2020](https://github.com/amnezia-vpn/amnezia-client/pull/2020)](https://github.com/amnezia-vpn/amnezia-client/pull/2020).

`WindowsCloseFilter` calls `forceQuit()` for `WM_CLOSE` whenever `GetActiveWindow()` differs from the target window. Closing a minimized window through the taskbar can satisfy this condition, causing a normal window-close action to terminate the application.

## Changes

Remove `WindowsCloseFilter`, its registration and cleanup, and the associated unused includes. Window closing now follows Amnezia’s existing Qt close-event handling, which hides the window and keeps the client running.

## Why the filter is unnecessary

- Qt already delivers window-close events to Amnezia’s close-to-tray handler.
- Qt’s session manager handles `WM_QUERYENDSESSION` and `WM_ENDSESSION` for Windows session shutdown and cancellation.
- The WiX configuration already specifies `TerminateProcess="1"` in `util:CloseApplication`. The installer can terminate a client that is still running, using `1` as its exit code, independently of this filter.