### PR TITLE
feat: add French (fr_FR) localization

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -92,6 +92,7 @@ else()
         ${CMAKE_CURRENT_LIST_DIR}/translations/${CLIENT_TS_PREFIX}_hi_IN.ts
         ${CMAKE_CURRENT_LIST_DIR}/translations/${CLIENT_TS_PREFIX}_es_ES.ts
         ${CMAKE_CURRENT_LIST_DIR}/translations/${CLIENT_TS_PREFIX}_ko_KR.ts
+        ${CMAKE_CURRENT_LIST_DIR}/translations/${CLIENT_TS_PREFIX}_fr_FR.ts
     )
 endif()
 

--- a/client/translations/amneziavpn_fr_FR.ts
+++ b/client/translations/amneziavpn_fr_FR.ts
@@ -1,0 +1,6872 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr_FR" sourcelanguage="en_US">
+<context>
+    <name>AllowedDnsUiController</name>
+    <message>
+        <location filename="../ui/controllers/allowedDnsUiController.cpp" line="33"/>
+        <source>The address does not look like a valid IP address</source>
+        <translation>L'adresse ne semble pas être une adresse IP valide</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/allowedDnsUiController.cpp" line="38"/>
+        <source>New DNS server added: %1</source>
+        <translation>Nouveau serveur DNS ajouté : %1</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/allowedDnsUiController.cpp" line="40"/>
+        <source>DNS server already exists: %1</source>
+        <translation>Le serveur DNS existe déjà : %1</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/allowedDnsUiController.cpp" line="49"/>
+        <source>DNS server removed: %1</source>
+        <translation>Serveur DNS supprimé : %1</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/allowedDnsUiController.cpp" line="56"/>
+        <source>Can&apos;t open file: %1</source>
+        <translation>Impossible d'ouvrir le fichier : %1</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/allowedDnsUiController.cpp" line="62"/>
+        <source>Failed to parse JSON data from file: %1</source>
+        <translation>Échec de l'analyse des données JSON du fichier : %1</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/allowedDnsUiController.cpp" line="67"/>
+        <source>The JSON data is not an array in file: %1</source>
+        <translation>Les données JSON ne sont pas un tableau dans le fichier : %1</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/allowedDnsUiController.cpp" line="86"/>
+        <source>Import completed</source>
+        <translation>Importation terminée</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/allowedDnsUiController.cpp" line="107"/>
+        <source>Export completed</source>
+        <translation>Exportation terminée</translation>
+    </message>
+</context>
+<context>
+    <name>ApiAccountInfoModel</name>
+    <message>
+        <location filename="../ui/models/api/apiAccountInfoModel.cpp" line="33"/>
+        <location filename="../ui/models/api/apiAccountInfoModel.cpp" line="38"/>
+        <source>Active</source>
+        <translation>Actif</translation>
+    </message>
+    <message>
+        <location filename="../ui/models/api/apiAccountInfoModel.cpp" line="37"/>
+        <source>Inactive</source>
+        <translation>Inactif</translation>
+    </message>
+    <message>
+        <location filename="../ui/models/api/apiAccountInfoModel.cpp" line="51"/>
+        <source>%1 out of %2</source>
+        <translation>%1 sur %2</translation>
+    </message>
+</context>
+<context>
+    <name>ApiServicesModel</name>
+    <message>
+        <location filename="../ui/models/api/apiServicesModel.cpp" line="77"/>
+        <source>&lt;p&gt;&lt;a style=&quot;color: #EB5757;&quot;&gt;Not available in your region. If you have VPN enabled, disable it, return to the previous screen, and try again.&lt;/a&gt;</source>
+        <translation>&lt;p&gt;&lt;a style=&quot;color: #EB5757;&quot;&gt;Non disponible dans votre région. Si un VPN est activé, désactivez-le, revenez à l'écran précédent et réessayez.&lt;/a&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>AppSplitTunnelingUiController</name>
+    <message>
+        <location filename="../ui/controllers/appSplitTunnelingUiController.cpp" line="28"/>
+        <source>Application added: %1</source>
+        <translation>Application ajoutée : %1</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/appSplitTunnelingUiController.cpp" line="30"/>
+        <source>The application has already been added</source>
+        <translation>L'application a déjà été ajoutée</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/appSplitTunnelingUiController.cpp" line="40"/>
+        <source>The selected applications have been added</source>
+        <translation>Les applications sélectionnées ont été ajoutées</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/appSplitTunnelingUiController.cpp" line="50"/>
+        <source>Application removed: %1</source>
+        <translation>Application supprimée : %1</translation>
+    </message>
+</context>
+<context>
+    <name>CaptchaDialogType</name>
+    <message>
+        <location filename="../ui/qml/Controls2/CaptchaDialogType.qml" line="18"/>
+        <source>Enter the digits from the image to continue</source>
+        <translation>Saisissez les chiffres de l'image pour continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Controls2/CaptchaDialogType.qml" line="228"/>
+        <source>Digits from the image</source>
+        <translation>Chiffres de l'image</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Controls2/CaptchaDialogType.qml" line="231"/>
+        <source>_ _ _ _ _ _</source>
+        <translation>_ _ _ _ _ _</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Controls2/CaptchaDialogType.qml" line="254"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Controls2/CaptchaDialogType.qml" line="271"/>
+        <source>Close</source>
+        <translation>Fermer</translation>
+    </message>
+</context>
+<context>
+    <name>ChangelogDrawer</name>
+    <message>
+        <location filename="../ui/qml/Components/ChangelogDrawer.qml" line="70"/>
+        <source>Update</source>
+        <translation>Mettre à jour</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Components/ChangelogDrawer.qml" line="96"/>
+        <source>Skip</source>
+        <translation>Ignorer</translation>
+    </message>
+</context>
+<context>
+    <name>ConnectButton</name>
+    <message>
+        <location filename="../ui/qml/Components/ConnectButton.qml" line="54"/>
+        <source>Unable to disconnect during configuration preparation</source>
+        <translation>Impossible de se déconnecter pendant la préparation de la configuration</translation>
+    </message>
+</context>
+<context>
+    <name>ConnectionTypeSelectionDrawer</name>
+    <message>
+        <location filename="../ui/qml/Components/ConnectionTypeSelectionDrawer.qml" line="36"/>
+        <source>Add new connection</source>
+        <translation>Ajouter une connexion</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Components/ConnectionTypeSelectionDrawer.qml" line="44"/>
+        <source>Configure your server</source>
+        <translation>Configurez votre serveur</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Components/ConnectionTypeSelectionDrawer.qml" line="59"/>
+        <source>Open config file, key or QR code</source>
+        <translation>Ouvrir un fichier de configuration, une clé ou un QR code</translation>
+    </message>
+</context>
+<context>
+    <name>ConnectionUiController</name>
+    <message>
+        <location filename="../ui/controllers/connectionUiController.cpp" line="59"/>
+        <source>Connecting...</source>
+        <translation>Connexion...</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/connectionUiController.cpp" line="66"/>
+        <source>Connected</source>
+        <translation>Connecté</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/connectionUiController.cpp" line="75"/>
+        <source>Reconnecting...</source>
+        <translation>Reconnexion...</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/connectionUiController.cpp" line="80"/>
+        <location filename="../ui/controllers/connectionUiController.cpp" line="95"/>
+        <location filename="../ui/controllers/connectionUiController.cpp" line="101"/>
+        <location filename="../ui/controllers/connectionUiController.h" line="65"/>
+        <source>Connect</source>
+        <translation>Se connecter</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/connectionUiController.cpp" line="85"/>
+        <source>Disconnecting...</source>
+        <translation>Déconnexion...</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/connectionUiController.cpp" line="90"/>
+        <source>Preparing...</source>
+        <translation>Préparation...</translation>
+    </message>
+</context>
+<context>
+    <name>ContextMenuType</name>
+    <message>
+        <location filename="../ui/qml/Controls2/ContextMenuType.qml" line="55"/>
+        <source>C&amp;ut</source>
+        <translation>Cou&amp;per</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Controls2/ContextMenuType.qml" line="60"/>
+        <source>&amp;Copy</source>
+        <translation>&amp;Copier</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Controls2/ContextMenuType.qml" line="65"/>
+        <source>&amp;Paste</source>
+        <translation>Co&amp;ller</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Controls2/ContextMenuType.qml" line="72"/>
+        <source>&amp;SelectAll</source>
+        <translation>Tout &amp;sélectionner</translation>
+    </message>
+</context>
+<context>
+    <name>HomeContainersListView</name>
+    <message>
+        <location filename="../ui/qml/Components/HomeContainersListView.qml" line="55"/>
+        <source>Unable change protocol while there is an active connection</source>
+        <translation>Impossible de changer de protocole tant qu'une connexion est active</translation>
+    </message>
+</context>
+<context>
+    <name>HomeSplitTunnelingDrawer</name>
+    <message>
+        <location filename="../ui/qml/Components/HomeSplitTunnelingDrawer.qml" line="34"/>
+        <source>Split tunneling</source>
+        <translation>Split tunneling</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Components/HomeSplitTunnelingDrawer.qml" line="35"/>
+        <source>Allows you to connect to some sites or applications through a VPN connection and bypass others</source>
+        <translation>Permet de faire passer certains sites ou applications par le VPN et d'en exclure d'autres</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Components/HomeSplitTunnelingDrawer.qml" line="45"/>
+        <source>Split tunneling on the server</source>
+        <translation>Split tunneling sur le serveur</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Components/HomeSplitTunnelingDrawer.qml" line="46"/>
+        <source>Enabled 
+Can&apos;t be disabled for current server</source>
+        <translation>Activé 
+Ne peut pas être désactivé pour le serveur actuel</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Components/HomeSplitTunnelingDrawer.qml" line="64"/>
+        <source>Site-based split tunneling</source>
+        <translation>Split tunneling par site</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Components/HomeSplitTunnelingDrawer.qml" line="65"/>
+        <location filename="../ui/qml/Components/HomeSplitTunnelingDrawer.qml" line="84"/>
+        <source>Enabled</source>
+        <translation>Activé</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Components/HomeSplitTunnelingDrawer.qml" line="65"/>
+        <location filename="../ui/qml/Components/HomeSplitTunnelingDrawer.qml" line="84"/>
+        <source>Disabled</source>
+        <translation>Désactivé</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Components/HomeSplitTunnelingDrawer.qml" line="83"/>
+        <source>App-based split tunneling</source>
+        <translation>Split tunneling par application</translation>
+    </message>
+</context>
+<context>
+    <name>ImportUiController</name>
+    <message>
+        <location filename="../ui/controllers/importUiController.cpp" line="185"/>
+        <source>Scanned %1 of %2.</source>
+        <translation>%1 sur %2 analysés.</translation>
+    </message>
+</context>
+<context>
+    <name>InstallUiController</name>
+    <message>
+        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="125"/>
+        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="167"/>
+        <source>%1 installed successfully. </source>
+        <translation>%1 installé avec succès. </translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="127"/>
+        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="169"/>
+        <source>%1 is already installed on the server. </source>
+        <translation>%1 est déjà installé sur le serveur. </translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="131"/>
+        <source>
+Added containers that were already installed on the server</source>
+        <translation>
+Les conteneurs déjà installés sur le serveur ont été ajoutés</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="173"/>
+        <source>
+Already installed containers were found on the server. All installed containers have been added to the application</source>
+        <translation>
+Des conteneurs déjà installés ont été trouvés sur le serveur. Tous les conteneurs installés ont été ajoutés à l'application</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="288"/>
+        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="327"/>
+        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="351"/>
+        <source>Settings updated successfully</source>
+        <translation>Paramètres mis à jour avec succès</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="471"/>
+        <source>Server &apos;%1&apos; was rebooted</source>
+        <translation>Le serveur « %1 » a été redémarré</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="485"/>
+        <source>Server &apos;%1&apos; was removed</source>
+        <translation>Le serveur « %1 » a été supprimé</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="494"/>
+        <source>All containers from server &apos;%1&apos; have been removed</source>
+        <translation>Tous les conteneurs du serveur « %1 » ont été supprimés</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="520"/>
+        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="538"/>
+        <source>%1 has been removed from the server &apos;%2&apos;</source>
+        <translation>%1 a été supprimé du serveur « %2 »</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="553"/>
+        <source>%1 cached profile cleared</source>
+        <translation>Profil %1 mis en cache effacé</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="607"/>
+        <source>Please login as the user</source>
+        <translation>Veuillez vous connecter en tant qu'utilisateur</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/selfhosted/installUiController.cpp" line="631"/>
+        <source>Server added successfully</source>
+        <translation>Serveur ajouté avec succès</translation>
+    </message>
+</context>
+<context>
+    <name>InstalledAppsDrawer</name>
+    <message>
+        <location filename="../ui/qml/Components/InstalledAppsDrawer.qml" line="57"/>
+        <source>Choose application</source>
+        <translation>Choisir une application</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Components/InstalledAppsDrawer.qml" line="124"/>
+        <source>application name</source>
+        <translation>nom de l'application</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Components/InstalledAppsDrawer.qml" line="137"/>
+        <source>Add selected</source>
+        <translation>Ajouter la sélection</translation>
+    </message>
+</context>
+<context>
+    <name>IpSplitTunnelingController</name>
+    <message>
+        <location filename="../core/controllers/ipSplitTunnelingController.cpp" line="224"/>
+        <source>Failed to parse JSON data: %1</source>
+        <translation>Échec de l'analyse des données JSON : %1</translation>
+    </message>
+    <message>
+        <location filename="../core/controllers/ipSplitTunnelingController.cpp" line="229"/>
+        <source>The JSON data is not an array</source>
+        <translation>Les données JSON ne sont pas un tableau</translation>
+    </message>
+</context>
+<context>
+    <name>IpSplitTunnelingUiController</name>
+    <message>
+        <location filename="../ui/controllers/ipSplitTunnelingUiController.cpp" line="22"/>
+        <source>New site added: %1</source>
+        <translation>Nouveau site ajouté : %1</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/ipSplitTunnelingUiController.cpp" line="31"/>
+        <source>Site removed: %1</source>
+        <translation>Site supprimé : %1</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/ipSplitTunnelingUiController.cpp" line="38"/>
+        <source>Site list cleared!</source>
+        <translation>Liste des sites effacée !</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/ipSplitTunnelingUiController.cpp" line="45"/>
+        <source>Can&apos;t open file: %1</source>
+        <translation>Impossible d'ouvrir le fichier : %1</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/ipSplitTunnelingUiController.cpp" line="51"/>
+        <source>Import completed</source>
+        <translation>Importation terminée</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/ipSplitTunnelingUiController.cpp" line="64"/>
+        <source>Export completed</source>
+        <translation>Exportation terminée</translation>
+    </message>
+</context>
+<context>
+    <name>MarketplaceUpdateController</name>
+    <message>
+        <location filename="../ui/controllers/marketplaceUpdateController.cpp" line="153"/>
+        <source>Update available</source>
+        <translation>Mise à jour disponible</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/marketplaceUpdateController.cpp" line="154"/>
+        <source>A new version of %1 is available.</source>
+        <translation>Une nouvelle version de %1 est disponible.</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/marketplaceUpdateController.cpp" line="155"/>
+        <source>Update</source>
+        <translation>Mettre à jour</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/marketplaceUpdateController.cpp" line="156"/>
+        <source>Skip</source>
+        <translation>Ignorer</translation>
+    </message>
+</context>
+<context>
+    <name>MinMaxRowType</name>
+    <message>
+        <location filename="../ui/qml/Controls2/MinMaxRowType.qml" line="78"/>
+        <source>Min</source>
+        <translation>Min</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Controls2/MinMaxRowType.qml" line="113"/>
+        <source>Max</source>
+        <translation>Max</translation>
+    </message>
+</context>
+<context>
+    <name>NotificationHandler</name>
+    <message>
+        <location filename="../ui/utils/notificationHandler.cpp" line="57"/>
+        <location filename="../ui/utils/notificationHandler.cpp" line="64"/>
+        <source>AmneziaVPN</source>
+        <translation>AmneziaVPN</translation>
+    </message>
+    <message>
+        <location filename="../ui/utils/notificationHandler.cpp" line="58"/>
+        <source>VPN Connected</source>
+        <translation>VPN connecté</translation>
+    </message>
+    <message>
+        <location filename="../ui/utils/notificationHandler.cpp" line="65"/>
+        <source>VPN Disconnected</source>
+        <translation>VPN déconnecté</translation>
+    </message>
+    <message>
+        <location filename="../ui/utils/notificationHandler.cpp" line="88"/>
+        <source>AmneziaVPN notification</source>
+        <translation>Notification AmneziaVPN</translation>
+    </message>
+    <message>
+        <location filename="../ui/utils/notificationHandler.cpp" line="89"/>
+        <source>Unsecured network detected: </source>
+        <translation>Réseau non sécurisé détecté : </translation>
+    </message>
+</context>
+<context>
+    <name>PageDeinstalling</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageDeinstalling.qml" line="52"/>
+        <source>Removing services from %1</source>
+        <translation>Suppression des services de %1</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageDeinstalling.qml" line="81"/>
+        <source>Usually it takes no more than 5 minutes</source>
+        <translation>Cela prend généralement moins de 5 minutes</translation>
+    </message>
+</context>
+<context>
+    <name>PageDevMenu</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageDevMenu.qml" line="60"/>
+        <source>Gateway endpoint</source>
+        <translation>Point d'accès de la passerelle</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageDevMenu.qml" line="77"/>
+        <source>Save</source>
+        <translation>Enregistrer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageDevMenu.qml" line="85"/>
+        <source>Settings saved</source>
+        <translation>Paramètres enregistrés</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageDevMenu.qml" line="99"/>
+        <source>Dev gateway environment</source>
+        <translation>Environnement de passerelle de développement</translation>
+    </message>
+</context>
+<context>
+    <name>PageHome</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageHome.qml" line="121"/>
+        <source>Logging enabled</source>
+        <translation>Journalisation activée</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageHome.qml" line="149"/>
+        <source>Dev gateway enabled</source>
+        <translation>Passerelle de développement activée</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageHome.qml" line="191"/>
+        <source>Split tunneling enabled</source>
+        <translation>Split tunneling activé</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageHome.qml" line="191"/>
+        <source>Split tunneling disabled</source>
+        <translation>Split tunneling désactivé</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageHome.qml" line="426"/>
+        <source>AmneziaWG 2.0 is outdated and no longer supported. Continued use requires a fresh installation of the AmneziaWG 3.1 container.</source>
+        <translation>AmneziaWG 2.0 est obsolète et n'est plus pris en charge. Pour continuer à l'utiliser, une nouvelle installation du conteneur AmneziaWG 3.1 est nécessaire.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageHome.qml" line="472"/>
+        <source>Unable change protocol while trying to make an active connection</source>
+        <translation>Impossible de changer de protocole pendant l'établissement d'une connexion</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageHome.qml" line="476"/>
+        <location filename="../ui/qml/Pages2/PageHome.qml" line="686"/>
+        <source>Cannot change protocol during active connection</source>
+        <translation>Impossible de changer de protocole pendant une connexion active</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageHome.qml" line="518"/>
+        <location filename="../ui/qml/Pages2/PageHome.qml" line="636"/>
+        <source>VPN protocol</source>
+        <translation>Protocole VPN</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageHome.qml" line="571"/>
+        <source>Servers</source>
+        <translation>Serveurs</translation>
+    </message>
+</context>
+<context>
+    <name>PageProtocolAwgClientSettings</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="56"/>
+        <source>AmneziaWG settings</source>
+        <translation>Paramètres AmneziaWG</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="80"/>
+        <source>MTU</source>
+        <translation>MTU</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="132"/>
+        <source>I1 - First special junk packet</source>
+        <translation>I1 - Premier paquet parasite spécial</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="142"/>
+        <source>I2 - Second special junk packet</source>
+        <translation>I2 - Deuxième paquet parasite spécial</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="152"/>
+        <source>I3 - Third special junk packet</source>
+        <translation>I3 - Troisième paquet parasite spécial</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="162"/>
+        <source>I4 - Fourth special junk packet</source>
+        <translation>I4 - Quatrième paquet parasite spécial</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="172"/>
+        <source>I5 - Fifth special junk packet</source>
+        <translation>I5 - Cinquième paquet parasite spécial</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="189"/>
+        <source>HeaderProtectionKey</source>
+        <translation>HeaderProtectionKey</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="199"/>
+        <source>ContentPaddingAddition - Content padding addition</source>
+        <translation>ContentPaddingAddition - Ajout de remplissage de contenu</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="211"/>
+        <source>RekeyAfterTime - Rekey after time</source>
+        <translation>RekeyAfterTime - Renouvellement de clé après délai</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="223"/>
+        <source>RekeyTimeout - Rekey timeout</source>
+        <translation>RekeyTimeout - Délai d'expiration du renouvellement de clé</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="235"/>
+        <source>RejectAfterTime - Reject after time</source>
+        <translation>RejectAfterTime - Rejet après délai</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="247"/>
+        <source>KeepaliveTimeout - Keepalive timeout</source>
+        <translation>KeepaliveTimeout - Délai d'expiration du keepalive</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="259"/>
+        <source>MaxHandshakeAttempts - Max handshake attempts</source>
+        <translation>MaxHandshakeAttempts - Nombre maximal de tentatives de handshake</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="276"/>
+        <source>RandomTrailers</source>
+        <translation>RandomTrailers</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="289"/>
+        <source>DisableCookies</source>
+        <translation>DisableCookies</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="306"/>
+        <source>Server settings</source>
+        <translation>Paramètres du serveur</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="314"/>
+        <source>Port</source>
+        <translation>Port</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="409"/>
+        <source>Save</source>
+        <translation>Enregistrer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="418"/>
+        <source>Save settings?</source>
+        <translation>Enregistrer les paramètres ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="419"/>
+        <source>Only the settings for this device will be changed</source>
+        <translation>Seuls les paramètres de cet appareil seront modifiés</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="420"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="421"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgClientSettings.qml" line="425"/>
+        <source>Unable change settings while there is an active connection</source>
+        <translation>Impossible de modifier les paramètres tant qu'une connexion est active</translation>
+    </message>
+</context>
+<context>
+    <name>PageProtocolAwgSettings</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="68"/>
+        <source>AmneziaWG settings</source>
+        <translation>Paramètres AmneziaWG</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="81"/>
+        <source>VPN address subnet</source>
+        <translation>Sous-réseau d'adresses VPN</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="108"/>
+        <source>Port</source>
+        <translation>Port</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="131"/>
+        <source>Jc - Junk packet count</source>
+        <translation>Jc - Nombre de paquets parasites</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="141"/>
+        <source>Jmin - Junk packet minimum size</source>
+        <translation>Jmin - Taille minimale des paquets parasites</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="151"/>
+        <source>Jmax - Junk packet maximum size</source>
+        <translation>Jmax - Taille maximale des paquets parasites</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="161"/>
+        <source>S1 - Init packet junk size</source>
+        <translation>S1 - Taille du parasite du paquet d'initialisation</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="171"/>
+        <source>S2 - Response packet junk size</source>
+        <translation>S2 - Taille du parasite du paquet de réponse</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="183"/>
+        <source>S3 - Cookie reply packet junk size</source>
+        <translation>S3 - Taille du parasite du paquet de réponse cookie</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="195"/>
+        <source>S4 - Transport packet junk size</source>
+        <translation>S4 - Taille du parasite du paquet de transport</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="207"/>
+        <source>H1 - Init packet magic header</source>
+        <translation>H1 - En-tête magique du paquet d'initialisation</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="219"/>
+        <source>H2 - Response packet magic header</source>
+        <translation>H2 - En-tête magique du paquet de réponse</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="231"/>
+        <source>H3 - Underload packet magic header</source>
+        <translation>H3 - En-tête magique du paquet de sous-charge</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="243"/>
+        <source>H4 - Transport packet magic header</source>
+        <translation>H4 - En-tête magique du paquet de transport</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="253"/>
+        <source>I1 - Special junk 1</source>
+        <translation>I1 - Parasite spécial 1</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="263"/>
+        <source>I2 - Special junk 2</source>
+        <translation>I2 - Parasite spécial 2</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="273"/>
+        <source>I3 - Special junk 3</source>
+        <translation>I3 - Parasite spécial 3</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="283"/>
+        <source>I4 - Special junk 4</source>
+        <translation>I4 - Parasite spécial 4</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="293"/>
+        <source>I5 - Special junk 5</source>
+        <translation>I5 - Parasite spécial 5</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="310"/>
+        <source>HeaderProtectionKey</source>
+        <translation>HeaderProtectionKey</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="326"/>
+        <source>ContentPaddingAddition - Content padding addition</source>
+        <translation>ContentPaddingAddition - Ajout de remplissage de contenu</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="339"/>
+        <source>RekeyAfterTime - Rekey after time</source>
+        <translation>RekeyAfterTime - Renouvellement de clé après délai</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="352"/>
+        <source>RekeyTimeout - Rekey timeout</source>
+        <translation>RekeyTimeout - Délai d'expiration du renouvellement de clé</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="365"/>
+        <source>RejectAfterTime - Reject after time</source>
+        <translation>RejectAfterTime - Rejet après délai</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="378"/>
+        <source>KeepaliveTimeout - Keepalive timeout</source>
+        <translation>KeepaliveTimeout - Délai d'expiration du keepalive</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="391"/>
+        <source>MaxHandshakeAttempts - Max handshake attempts</source>
+        <translation>MaxHandshakeAttempts - Nombre maximal de tentatives de handshake</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="408"/>
+        <source>RandomTrailers</source>
+        <translation>RandomTrailers</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="428"/>
+        <source>DisableCookies</source>
+        <translation>DisableCookies</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="467"/>
+        <source>Save</source>
+        <translation>Enregistrer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="482"/>
+        <source>The values of the H1-H4 fields must be unique</source>
+        <translation>Les valeurs des champs H1 à H4 doivent être uniques</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="490"/>
+        <source>The value of the field S1 + message initiation size (148) must not equal S2 + message response size (92) + S3 + cookie reply size (64) + S4 + transport packet size (32)</source>
+        <translation>La valeur du champ S1 + la taille du message d'initiation (148) ne doit pas être égale à S2 + la taille du message de réponse (92) + S3 + la taille de la réponse cookie (64) + S4 + la taille du paquet de transport (32)</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="495"/>
+        <source>Save settings?</source>
+        <translation>Enregistrer les paramètres ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="496"/>
+        <source>All users with whom you shared a connection with will no longer be able to connect to it.</source>
+        <translation>Tous les utilisateurs avec qui vous avez partagé une connexion ne pourront plus s'y connecter.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="497"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="498"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolAwgSettings.qml" line="502"/>
+        <source>Unable change settings while there is an active connection</source>
+        <translation>Impossible de modifier les paramètres tant qu'une connexion est active</translation>
+    </message>
+</context>
+<context>
+    <name>PageProtocolOpenVpnSettings</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="55"/>
+        <source>OpenVPN Settings</source>
+        <translation>Paramètres OpenVPN</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="76"/>
+        <source>VPN address subnet</source>
+        <translation>Sous-réseau d'adresses VPN</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="94"/>
+        <source>Network protocol</source>
+        <translation>Protocole réseau</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="131"/>
+        <source>Port</source>
+        <translation>Port</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="153"/>
+        <source>Auto-negotiate encryption</source>
+        <translation>Négociation automatique du chiffrement</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="172"/>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="173"/>
+        <source>Hash</source>
+        <translation>Hachage</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="183"/>
+        <source>SHA512</source>
+        <translation>SHA512</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="184"/>
+        <source>SHA384</source>
+        <translation>SHA384</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="185"/>
+        <source>SHA256</source>
+        <translation>SHA256</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="186"/>
+        <source>SHA3-512</source>
+        <translation>SHA3-512</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="187"/>
+        <source>SHA3-384</source>
+        <translation>SHA3-384</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="188"/>
+        <source>SHA3-256</source>
+        <translation>SHA3-256</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="189"/>
+        <source>whirlpool</source>
+        <translation>whirlpool</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="190"/>
+        <source>BLAKE2b512</source>
+        <translation>BLAKE2b512</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="191"/>
+        <source>BLAKE2s256</source>
+        <translation>BLAKE2s256</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="192"/>
+        <source>SHA1</source>
+        <translation>SHA1</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="233"/>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="234"/>
+        <source>Cipher</source>
+        <translation>Chiffrement</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="244"/>
+        <source>AES-256-GCM</source>
+        <translation>AES-256-GCM</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="245"/>
+        <source>AES-192-GCM</source>
+        <translation>AES-192-GCM</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="246"/>
+        <source>AES-128-GCM</source>
+        <translation>AES-128-GCM</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="247"/>
+        <source>AES-256-CBC</source>
+        <translation>AES-256-CBC</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="248"/>
+        <source>AES-192-CBC</source>
+        <translation>AES-192-CBC</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="249"/>
+        <source>AES-128-CBC</source>
+        <translation>AES-128-CBC</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="250"/>
+        <source>ChaCha20-Poly1305</source>
+        <translation>ChaCha20-Poly1305</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="251"/>
+        <source>ARIA-256-CBC</source>
+        <translation>ARIA-256-CBC</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="252"/>
+        <source>CAMELLIA-256-CBC</source>
+        <translation>CAMELLIA-256-CBC</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="253"/>
+        <source>none</source>
+        <translation>none</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="305"/>
+        <source>TLS auth</source>
+        <translation>Authentification TLS</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="322"/>
+        <source>Block DNS requests outside of VPN</source>
+        <translation>Bloquer les requêtes DNS en dehors du VPN</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="343"/>
+        <source>Additional client configuration commands</source>
+        <translation>Commandes de configuration client supplémentaires</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="362"/>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="399"/>
+        <source>Commands:</source>
+        <translation>Commandes :</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="380"/>
+        <source>Additional server configuration commands</source>
+        <translation>Commandes de configuration serveur supplémentaires</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="420"/>
+        <source>Save</source>
+        <translation>Enregistrer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="425"/>
+        <source>Save settings?</source>
+        <translation>Enregistrer les paramètres ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="426"/>
+        <source>All users with whom you shared a connection with will no longer be able to connect to it.</source>
+        <translation>Tous les utilisateurs avec qui vous avez partagé une connexion ne pourront plus s'y connecter.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="427"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="428"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolOpenVpnSettings.qml" line="432"/>
+        <source>Unable change settings while there is an active connection</source>
+        <translation>Impossible de modifier les paramètres tant qu'une connexion est active</translation>
+    </message>
+</context>
+<context>
+    <name>PageProtocolRaw</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolRaw.qml" line="52"/>
+        <source> settings</source>
+        <translation> paramètres</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolRaw.qml" line="68"/>
+        <source>Show connection options</source>
+        <translation>Afficher les options de connexion</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolRaw.qml" line="124"/>
+        <source>Connection options %1</source>
+        <translation>Options de connexion %1</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolRaw.qml" line="176"/>
+        <source>Remove </source>
+        <translation>Supprimer </translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolRaw.qml" line="180"/>
+        <source>Remove %1 from server?</source>
+        <translation>Supprimer %1 du serveur ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolRaw.qml" line="181"/>
+        <source>All users with whom you shared a connection with will no longer be able to connect to it.</source>
+        <translation>Tous les utilisateurs avec qui vous avez partagé une connexion ne pourront plus s'y connecter.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolRaw.qml" line="182"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolRaw.qml" line="183"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+</context>
+<context>
+    <name>PageProtocolWireGuardClientSettings</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolWireGuardClientSettings.qml" line="58"/>
+        <source>WG settings</source>
+        <translation>Paramètres WG</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolWireGuardClientSettings.qml" line="68"/>
+        <source>MTU</source>
+        <translation>MTU</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolWireGuardClientSettings.qml" line="86"/>
+        <source>Server settings</source>
+        <translation>Paramètres du serveur</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolWireGuardClientSettings.qml" line="98"/>
+        <source>Port</source>
+        <translation>Port</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolWireGuardClientSettings.qml" line="117"/>
+        <source>Save</source>
+        <translation>Enregistrer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolWireGuardClientSettings.qml" line="120"/>
+        <source>Save settings?</source>
+        <translation>Enregistrer les paramètres ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolWireGuardClientSettings.qml" line="121"/>
+        <source>Only the settings for this device will be changed</source>
+        <translation>Seuls les paramètres de cet appareil seront modifiés</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolWireGuardClientSettings.qml" line="122"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolWireGuardClientSettings.qml" line="123"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolWireGuardClientSettings.qml" line="127"/>
+        <source>Unable change settings while there is an active connection</source>
+        <translation>Impossible de modifier les paramètres tant qu'une connexion est active</translation>
+    </message>
+</context>
+<context>
+    <name>PageProtocolWireGuardSettings</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolWireGuardSettings.qml" line="59"/>
+        <source>WG settings</source>
+        <translation>Paramètres WG</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolWireGuardSettings.qml" line="70"/>
+        <source>VPN address subnet</source>
+        <translation>Sous-réseau d'adresses VPN</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolWireGuardSettings.qml" line="89"/>
+        <source>Port</source>
+        <translation>Port</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolWireGuardSettings.qml" line="115"/>
+        <source>Save</source>
+        <translation>Enregistrer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolWireGuardSettings.qml" line="120"/>
+        <source>Save settings?</source>
+        <translation>Enregistrer les paramètres ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolWireGuardSettings.qml" line="121"/>
+        <source>All users with whom you shared a connection with will no longer be able to connect to it.</source>
+        <translation>Tous les utilisateurs avec qui vous avez partagé une connexion ne pourront plus s'y connecter.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolWireGuardSettings.qml" line="122"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolWireGuardSettings.qml" line="123"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolWireGuardSettings.qml" line="127"/>
+        <source>Unable change settings while there is an active connection</source>
+        <translation>Impossible de modifier les paramètres tant qu'une connexion est active</translation>
+    </message>
+</context>
+<context>
+    <name>PageProtocolXrayFlowSettings</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayFlowSettings.qml" line="49"/>
+        <source>Flow</source>
+        <translation>Flow</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayFlowSettings.qml" line="56"/>
+        <source>Empty</source>
+        <translation>Vide</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayFlowSettings.qml" line="97"/>
+        <source>xtls-rprx-vision is available only with the RAW (TCP) transport.</source>
+        <translation>xtls-rprx-vision n'est disponible qu'avec le transport RAW (TCP).</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayFlowSettings.qml" line="118"/>
+        <source>Save</source>
+        <translation>Enregistrer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayFlowSettings.qml" line="120"/>
+        <source>Save settings?</source>
+        <translation>Enregistrer les paramètres ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayFlowSettings.qml" line="121"/>
+        <source>All users with whom you shared a connection with will no longer be able to connect to it.</source>
+        <translation>Tous les utilisateurs avec qui vous avez partagé une connexion ne pourront plus s'y connecter.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayFlowSettings.qml" line="122"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayFlowSettings.qml" line="123"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayFlowSettings.qml" line="126"/>
+        <source>Unable change settings while there is an active connection</source>
+        <translation>Impossible de modifier les paramètres tant qu'une connexion est active</translation>
+    </message>
+</context>
+<context>
+    <name>PageProtocolXraySecuritySettings</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="51"/>
+        <source>Security</source>
+        <translation>Sécurité</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="58"/>
+        <source>None</source>
+        <translation>Aucune</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="70"/>
+        <source>TLS</source>
+        <translation>TLS</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="82"/>
+        <source>Reality</source>
+        <translation>Reality</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="95"/>
+        <source>REALITY is not supported with the mKCP transport. Use None or TLS.</source>
+        <translation>REALITY n'est pas pris en charge avec le transport mKCP. Utilisez None ou TLS.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="115"/>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="116"/>
+        <source>ALPN</source>
+        <translation>ALPN</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="160"/>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="161"/>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="232"/>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="233"/>
+        <source>Fingerprint</source>
+        <translation>Empreinte</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="203"/>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="275"/>
+        <source>Server Name (SNI)</source>
+        <translation>Nom du serveur (SNI)</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="212"/>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="284"/>
+        <source>Enter a valid IP address or domain name</source>
+        <translation>Saisissez une adresse IP ou un nom de domaine valide</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="308"/>
+        <source>Save</source>
+        <translation>Enregistrer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="315"/>
+        <source>Save settings?</source>
+        <translation>Enregistrer les paramètres ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="316"/>
+        <source>All users with whom you shared a connection with will no longer be able to connect to it.</source>
+        <translation>Tous les utilisateurs avec qui vous avez partagé une connexion ne pourront plus s'y connecter.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="317"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="318"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySecuritySettings.qml" line="321"/>
+        <source>Unable change settings while there is an active connection</source>
+        <translation>Impossible de modifier les paramètres tant qu'une connexion est active</translation>
+    </message>
+</context>
+<context>
+    <name>PageProtocolXraySettings</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySettings.qml" line="39"/>
+        <source>Empty</source>
+        <translation>Vide</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySettings.qml" line="82"/>
+        <source>You have read-only access to this server. XRay settings cannot be edited.</source>
+        <translation>Vous disposez d'un accès en lecture seule à ce serveur. Les paramètres XRay ne peuvent pas être modifiés.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySettings.qml" line="93"/>
+        <source>XRay VLESS settings</source>
+        <translation>Paramètres XRay VLESS</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySettings.qml" line="94"/>
+        <source>More about settings</source>
+        <translation>En savoir plus sur les paramètres</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySettings.qml" line="115"/>
+        <source>Port</source>
+        <translation>Port</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySettings.qml" line="116"/>
+        <source>Valid range: 1–65535.</source>
+        <translation>Plage valide : 1–65535.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySettings.qml" line="161"/>
+        <source>Transport</source>
+        <translation>Transport</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySettings.qml" line="175"/>
+        <source>Security</source>
+        <translation>Sécurité</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySettings.qml" line="189"/>
+        <source>Flow</source>
+        <translation>Flow</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySettings.qml" line="214"/>
+        <source>Save</source>
+        <translation>Enregistrer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySettings.qml" line="222"/>
+        <source>Save settings?</source>
+        <translation>Enregistrer les paramètres ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySettings.qml" line="223"/>
+        <source>All users with whom you shared a connection with will no longer be able to connect to it.</source>
+        <translation>Tous les utilisateurs avec qui vous avez partagé une connexion ne pourront plus s'y connecter.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySettings.qml" line="224"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySettings.qml" line="225"/>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySettings.qml" line="260"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySettings.qml" line="228"/>
+        <source>Unable change settings while there is an active connection</source>
+        <translation>Impossible de modifier les paramètres tant qu'une connexion est active</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySettings.qml" line="250"/>
+        <source>Reset settings</source>
+        <translation>Réinitialiser les paramètres</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySettings.qml" line="256"/>
+        <source>Settings were reset to defaults. Tap Save to apply them on the server.</source>
+        <translation>Les paramètres ont été réinitialisés aux valeurs par défaut. Appuyez sur Enregistrer pour les appliquer sur le serveur.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySettings.qml" line="259"/>
+        <source>Reset settings?</source>
+        <translation>Réinitialiser les paramètres ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySettings.qml" line="259"/>
+        <source>All XRay settings will be restored to defaults.</source>
+        <translation>Tous les paramètres XRay seront restaurés aux valeurs par défaut.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySettings.qml" line="260"/>
+        <source>Reset</source>
+        <translation>Réinitialiser</translation>
+    </message>
+</context>
+<context>
+    <name>PageProtocolXraySnapshots</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="31"/>
+        <source>Save XRay configuration</source>
+        <translation>Enregistrer la configuration XRay</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="32"/>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="116"/>
+        <source>JSON files (*.json)</source>
+        <translation>Fichiers JSON (*.json)</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="41"/>
+        <source>Configuration saved</source>
+        <translation>Configuration enregistrée</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="73"/>
+        <source>XRay Configurations</source>
+        <translation>Configurations XRay</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="79"/>
+        <source>Create configuration based on current settings</source>
+        <translation>Créer une configuration à partir des paramètres actuels</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="93"/>
+        <source>Export settings</source>
+        <translation>Exporter les paramètres</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="110"/>
+        <source>Import settings</source>
+        <translation>Importer les paramètres</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="111"/>
+        <source>In JSON format</source>
+        <translation>Au format JSON</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="115"/>
+        <source>Open XRay configuration</source>
+        <translation>Ouvrir une configuration XRay</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="121"/>
+        <source>Failed to import configuration</source>
+        <translation>Échec de l'importation de la configuration</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="123"/>
+        <source>Configuration imported successfully</source>
+        <translation>Configuration importée avec succès</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="140"/>
+        <source>Configurations</source>
+        <translation>Configurations</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="160"/>
+        <source>No saved configurations yet.
+Create one from the current settings.</source>
+        <translation>Aucune configuration enregistrée pour le moment.
+Créez-en une à partir des paramètres actuels.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="236"/>
+        <source>Apply configuration</source>
+        <translation>Appliquer la configuration</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="251"/>
+        <source>Export configuration</source>
+        <translation>Exporter la configuration</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="266"/>
+        <source>Delete configuration</source>
+        <translation>Supprimer la configuration</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="276"/>
+        <source>Delete configuration?</source>
+        <translation>Supprimer la configuration ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="277"/>
+        <source>This action cannot be undone.</source>
+        <translation>Cette action est irréversible.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="278"/>
+        <source>Delete</source>
+        <translation>Supprimer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXraySnapshots.qml" line="278"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+</context>
+<context>
+    <name>PageProtocolXrayTransportSettings</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="61"/>
+        <source>Transport</source>
+        <translation>Transport</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="69"/>
+        <source>RAW (TCP)</source>
+        <translation>RAW (TCP)</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="81"/>
+        <source>XHTTP</source>
+        <translation>XHTTP</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="82"/>
+        <source>Advanced users</source>
+        <translation>Utilisateurs avancés</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="94"/>
+        <source>mKCP</source>
+        <translation>mKCP</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="116"/>
+        <source>mKCP Settings</source>
+        <translation>Paramètres mKCP</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="125"/>
+        <source>TTI</source>
+        <translation>TTI</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="126"/>
+        <source>Transmission time interval (ms). Valid range: 10–100.</source>
+        <translation>Intervalle de transmission (ms). Plage valide : 10–100.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="145"/>
+        <source>uplinkCapacity</source>
+        <translation>uplinkCapacity</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="146"/>
+        <source>Uplink capacity (MB/s). Maximum: 2147483647.</source>
+        <translation>Capacité montante (Mo/s). Maximum : 2147483647.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="165"/>
+        <source>downlinkCapacity</source>
+        <translation>downlinkCapacity</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="166"/>
+        <source>Downlink capacity (MB/s). Maximum: 2147483647.</source>
+        <translation>Capacité descendante (Mo/s). Maximum : 2147483647.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="185"/>
+        <source>readBufferSize</source>
+        <translation>readBufferSize</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="186"/>
+        <source>Read buffer size (MB). Range: 1–2147483647.</source>
+        <translation>Taille du tampon de lecture (Mo). Plage : 1–2147483647.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="205"/>
+        <source>writeBufferSize</source>
+        <translation>writeBufferSize</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="206"/>
+        <source>Write buffer size (MB). Range: 1–2147483647.</source>
+        <translation>Taille du tampon d'écriture (Mo). Plage : 1–2147483647.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="224"/>
+        <source>Congestion</source>
+        <translation>Congestion</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="246"/>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="247"/>
+        <source>Mode</source>
+        <translation>Mode</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="289"/>
+        <source>HTTP Profile</source>
+        <translation>Profil HTTP</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="299"/>
+        <source>Host</source>
+        <translation>Host</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="308"/>
+        <source>Enter a valid IP address or domain name</source>
+        <translation>Saisissez une adresse IP ou un nom de domaine valide</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="319"/>
+        <source>Path</source>
+        <translation>Path</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="327"/>
+        <source>Path must start with &quot;/&quot;</source>
+        <translation>Le chemin doit commencer par « / »</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="340"/>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="341"/>
+        <source>UplinkHTTPMethod</source>
+        <translation>UplinkHTTPMethod</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="381"/>
+        <source>Disable gRPC Header</source>
+        <translation>Désactiver l'en-tête gRPC</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="382"/>
+        <source>noGRPCHeader</source>
+        <translation>noGRPCHeader</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="393"/>
+        <source>Disable SSE Header</source>
+        <translation>Désactiver l'en-tête SSE</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="394"/>
+        <source>noSSEHeader</source>
+        <translation>noSSEHeader</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="409"/>
+        <source>Session &amp; Sequence</source>
+        <translation>Session et séquence</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="421"/>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="422"/>
+        <source>SessionPlacement</source>
+        <translation>SessionPlacement</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="463"/>
+        <source>SessionKey</source>
+        <translation>SessionKey</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="483"/>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="484"/>
+        <source>SeqPlacement</source>
+        <translation>SeqPlacement</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="525"/>
+        <source>SeqKey</source>
+        <translation>SeqKey</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="545"/>
+        <source>Header/Cookie apply only in Packet-up mode</source>
+        <translation>Header/Cookie ne s'appliquent qu'en mode Packet-up</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="546"/>
+        <source>UplinkDataPlacement</source>
+        <translation>UplinkDataPlacement</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="587"/>
+        <source>UplinkDataKey</source>
+        <translation>UplinkDataKey</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="606"/>
+        <source>Traffic Shaping</source>
+        <translation>Mise en forme du trafic</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="615"/>
+        <source>UplinkChunkSize</source>
+        <translation>UplinkChunkSize</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="616"/>
+        <source>Uplink chunk size in bytes. Maximum: 2147483647. 0 = off.</source>
+        <translation>Taille des blocs montants en octets. Maximum : 2147483647. 0 = désactivé.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="635"/>
+        <source>scMaxBufferedPosts</source>
+        <translation>scMaxBufferedPosts</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="636"/>
+        <source>Max buffered POSTs. Range: 0–2147483647.</source>
+        <translation>Nombre maximal de POST mis en tampon. Plage : 0–2147483647.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="655"/>
+        <source>scMaxEachPostBytes</source>
+        <translation>scMaxEachPostBytes</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="677"/>
+        <source>scStreamUpServerSecs</source>
+        <translation>scStreamUpServerSecs</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="699"/>
+        <source>scMinPostsIntervalMs</source>
+        <translation>scMinPostsIntervalMs</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="722"/>
+        <source>Padding and multiplexing</source>
+        <translation>Remplissage et multiplexage</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="728"/>
+        <source>xPadding</source>
+        <translation>xPadding</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="740"/>
+        <source>XMux</source>
+        <translation>XMux</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="741"/>
+        <source>On</source>
+        <translation>Activé</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="741"/>
+        <source>Off</source>
+        <translation>Désactivé</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="770"/>
+        <source>Save</source>
+        <translation>Enregistrer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="777"/>
+        <source>Save settings?</source>
+        <translation>Enregistrer les paramètres ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="778"/>
+        <source>All users with whom you shared a connection with will no longer be able to connect to it.</source>
+        <translation>Tous les utilisateurs avec qui vous avez partagé une connexion ne pourront plus s'y connecter.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="779"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="780"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayTransportSettings.qml" line="783"/>
+        <source>Unable change settings while there is an active connection</source>
+        <translation>Impossible de modifier les paramètres tant qu'une connexion est active</translation>
+    </message>
+</context>
+<context>
+    <name>PageProtocolXrayXPaddingBytesSettings</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXPaddingBytesSettings.qml" line="48"/>
+        <source>xPaddingBytes</source>
+        <translation>xPaddingBytes</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXPaddingBytesSettings.qml" line="56"/>
+        <source>Range</source>
+        <translation>Plage</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXPaddingBytesSettings.qml" line="91"/>
+        <source>Save</source>
+        <translation>Enregistrer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXPaddingBytesSettings.qml" line="93"/>
+        <source>Save settings?</source>
+        <translation>Enregistrer les paramètres ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXPaddingBytesSettings.qml" line="94"/>
+        <source>All users with whom you shared a connection with will no longer be able to connect to it.</source>
+        <translation>Tous les utilisateurs avec qui vous avez partagé une connexion ne pourront plus s'y connecter.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXPaddingBytesSettings.qml" line="95"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXPaddingBytesSettings.qml" line="96"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXPaddingBytesSettings.qml" line="99"/>
+        <source>Unable change settings while there is an active connection</source>
+        <translation>Impossible de modifier les paramètres tant qu'une connexion est active</translation>
+    </message>
+</context>
+<context>
+    <name>PageProtocolXrayXPaddingSettings</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXPaddingSettings.qml" line="48"/>
+        <source>xPadding</source>
+        <translation>xPadding</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXPaddingSettings.qml" line="54"/>
+        <source>xPaddingBytes</source>
+        <translation>xPaddingBytes</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXPaddingSettings.qml" line="68"/>
+        <source>xPaddingObfsMode</source>
+        <translation>xPaddingObfsMode</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXPaddingSettings.qml" line="81"/>
+        <source>xPaddingKey</source>
+        <translation>xPaddingKey</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXPaddingSettings.qml" line="99"/>
+        <source>xPaddingHeader</source>
+        <translation>xPaddingHeader</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXPaddingSettings.qml" line="120"/>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXPaddingSettings.qml" line="121"/>
+        <source>xPaddingPlacement</source>
+        <translation>xPaddingPlacement</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXPaddingSettings.qml" line="165"/>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXPaddingSettings.qml" line="166"/>
+        <source>xPaddingMethod</source>
+        <translation>xPaddingMethod</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXPaddingSettings.qml" line="220"/>
+        <source>Save</source>
+        <translation>Enregistrer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXPaddingSettings.qml" line="222"/>
+        <source>Save settings?</source>
+        <translation>Enregistrer les paramètres ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXPaddingSettings.qml" line="223"/>
+        <source>All users with whom you shared a connection with will no longer be able to connect to it.</source>
+        <translation>Tous les utilisateurs avec qui vous avez partagé une connexion ne pourront plus s'y connecter.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXPaddingSettings.qml" line="224"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXPaddingSettings.qml" line="225"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXPaddingSettings.qml" line="228"/>
+        <source>Unable change settings while there is an active connection</source>
+        <translation>Impossible de modifier les paramètres tant qu'une connexion est active</translation>
+    </message>
+</context>
+<context>
+    <name>PageProtocolXrayXmuxSettings</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXmuxSettings.qml" line="61"/>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXmuxSettings.qml" line="67"/>
+        <source>xmux</source>
+        <translation>xmux</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXmuxSettings.qml" line="87"/>
+        <source>maxConcurrency</source>
+        <translation>maxConcurrency</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXmuxSettings.qml" line="110"/>
+        <source>maxConnections</source>
+        <translation>maxConnections</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXmuxSettings.qml" line="133"/>
+        <source>cMaxReuseTimes</source>
+        <translation>cMaxReuseTimes</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXmuxSettings.qml" line="156"/>
+        <source>hMaxRequestTimes</source>
+        <translation>hMaxRequestTimes</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXmuxSettings.qml" line="179"/>
+        <source>hMaxReusableSecs</source>
+        <translation>hMaxReusableSecs</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXmuxSettings.qml" line="200"/>
+        <source>hKeepAlivePeriod</source>
+        <translation>hKeepAlivePeriod</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXmuxSettings.qml" line="201"/>
+        <source>HTTP keep-alive period. Integer, may be negative.</source>
+        <translation>Durée de maintien de la connexion HTTP. Entier, éventuellement négatif.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXmuxSettings.qml" line="233"/>
+        <source>Save</source>
+        <translation>Enregistrer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXmuxSettings.qml" line="235"/>
+        <source>Save settings?</source>
+        <translation>Enregistrer les paramètres ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXmuxSettings.qml" line="236"/>
+        <source>All users with whom you shared a connection with will no longer be able to connect to it.</source>
+        <translation>Tous les utilisateurs avec qui vous avez partagé une connexion ne pourront plus s'y connecter.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXmuxSettings.qml" line="237"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXmuxSettings.qml" line="238"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageProtocolXrayXmuxSettings.qml" line="241"/>
+        <source>Unable change settings while there is an active connection</source>
+        <translation>Impossible de modifier les paramètres tant qu'une connexion est active</translation>
+    </message>
+</context>
+<context>
+    <name>PageServiceDnsSettings</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceDnsSettings.qml" line="52"/>
+        <source>A DNS service is installed on your server, and it is only accessible via VPN.
+</source>
+        <translation>Un service DNS est installé sur votre serveur, il n'est accessible que via le VPN.
+</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceDnsSettings.qml" line="53"/>
+        <source>The DNS address is the same as the address of your server. You can configure DNS in the settings, under the connections tab.</source>
+        <translation>L'adresse DNS est identique à l'adresse de votre serveur. Vous pouvez configurer le DNS dans les paramètres, sous l'onglet des connexions.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceDnsSettings.qml" line="68"/>
+        <source>Remove </source>
+        <translation>Supprimer </translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceDnsSettings.qml" line="72"/>
+        <source>Remove %1 from server?</source>
+        <translation>Supprimer %1 du serveur ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceDnsSettings.qml" line="73"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceDnsSettings.qml" line="74"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceDnsSettings.qml" line="79"/>
+        <source>Cannot remove AmneziaDNS from running server</source>
+        <translation>Impossible de supprimer AmneziaDNS d'un serveur en cours d'exécution</translation>
+    </message>
+</context>
+<context>
+    <name>PageServiceMtProxySettings</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="215"/>
+        <source>Checking...</source>
+        <translation>Vérification...</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="218"/>
+        <source>Updating</source>
+        <translation>Mise à jour</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="222"/>
+        <source>Not deployed</source>
+        <translation>Non déployé</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="225"/>
+        <source>Running</source>
+        <translation>En cours d'exécution</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="228"/>
+        <source>Stopped</source>
+        <translation>Arrêté</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="231"/>
+        <source>Error</source>
+        <translation>Erreur</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="234"/>
+        <source>Unknown</source>
+        <translation>Inconnu</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="349"/>
+        <source>MTProxy started</source>
+        <translation>MTProxy démarré</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="349"/>
+        <source>MTProxy stopped</source>
+        <translation>MTProxy arrêté</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="362"/>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="910"/>
+        <source>Settings locked: connection timed out (error code %1). Re-open the page to retry.</source>
+        <translation>Paramètres verrouillés : délai de connexion dépassé (code d'erreur %1). Rouvrez la page pour réessayer.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="442"/>
+        <source>MTProxy settings</source>
+        <translation>Paramètres MTProxy</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="443"/>
+        <source>Read more about this settings</source>
+        <translation>En savoir plus sur ces paramètres</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="453"/>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1884"/>
+        <source>No internet connection. Connect to the internet to change MTProxy settings.</source>
+        <translation>Aucune connexion Internet. Connectez-vous à Internet pour modifier les paramètres MTProxy.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="478"/>
+        <source>Connection</source>
+        <translation>Connexion</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="482"/>
+        <source>Settings</source>
+        <translation>Paramètres</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="532"/>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1419"/>
+        <source>Use Telegram connection link</source>
+        <translation>Utiliser le lien de connexion Telegram</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="558"/>
+        <source>Deploy MTProxy first</source>
+        <translation>Déployez d'abord MTProxy</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="574"/>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="633"/>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="713"/>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="748"/>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="789"/>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="860"/>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1849"/>
+        <source>Copied</source>
+        <translation>Copié</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="619"/>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="865"/>
+        <source>Telegram connection link</source>
+        <translation>Lien de connexion Telegram</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="620"/>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="866"/>
+        <source>MTProxy connection link</source>
+        <translation>Lien de connexion MTProxy</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="647"/>
+        <source>Or enter the proxy details manually.</source>
+        <translation>Ou saisissez les détails du proxy manuellement.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="653"/>
+        <source>How to do it</source>
+        <translation>Comment faire</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="695"/>
+        <source>Host</source>
+        <translation>Host</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="731"/>
+        <source>Port</source>
+        <translation>Port</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="770"/>
+        <source>Secret</source>
+        <translation>Secret</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="802"/>
+        <source>Delete MTProxy</source>
+        <translation>Supprimer MTProxy</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="805"/>
+        <source>Remove %1 from server?</source>
+        <translation>Supprimer %1 du serveur ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="806"/>
+        <source>The proxy will be stopped and all users will lose access.</source>
+        <translation>Le proxy sera arrêté et tous les utilisateurs perdront l'accès.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="807"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="808"/>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="957"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="880"/>
+        <source>Enable MTProxy</source>
+        <translation>Activer MTProxy</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="908"/>
+        <source>Enable MTProxy to edit settings</source>
+        <translation>Activez MTProxy pour modifier les paramètres</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="911"/>
+        <source>Cannot reach the server — settings are unavailable</source>
+        <translation>Serveur injoignable — les paramètres sont indisponibles</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="925"/>
+        <source>Base secret</source>
+        <translation>Secret de base</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="936"/>
+        <source>Not generated</source>
+        <translation>Non généré</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="954"/>
+        <source>Generate new secret?</source>
+        <translation>Générer un nouveau secret ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="955"/>
+        <source>All existing connection links will stop working. Users will need new links.</source>
+        <translation>Tous les liens de connexion existants cesseront de fonctionner. Les utilisateurs auront besoin de nouveaux liens.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="956"/>
+        <source>Generate</source>
+        <translation>Générer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="966"/>
+        <source>New secret saved. It will be applied when MTProxy is started.</source>
+        <translation>Nouveau secret enregistré. Il sera appliqué au démarrage de MTProxy.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="984"/>
+        <source>Public host / IP</source>
+        <translation>Hôte / IP public</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="995"/>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1003"/>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1906"/>
+        <source>Enter a valid IP address or domain name</source>
+        <translation>Saisissez une adresse IP ou un nom de domaine valide</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1020"/>
+        <source>Leave empty to use server IP automatically</source>
+        <translation>Laissez vide pour utiliser automatiquement l'IP du serveur</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1033"/>
+        <source>⚠ This overrides the server IP in connection links. Make sure this host/domain points to your server.</source>
+        <translation>⚠ Ceci remplace l'IP du serveur dans les liens de connexion. Assurez-vous que cet hôte/domaine pointe bien vers votre serveur.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1046"/>
+        <source>Server port</source>
+        <translation>Port du serveur</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1077"/>
+        <source>FakeTLS may not work on ports other than 443</source>
+        <translation>FakeTLS peut ne pas fonctionner sur un port autre que 443</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1088"/>
+        <source>The promoted channel is set in @MTProxyBot. Paste the proxy tag here: exactly 32 hexadecimal characters (0-9, A-F), as in the bot message — or leave empty.</source>
+        <translation>La chaîne promue se configure dans @MTProxyBot. Collez ici le tag du proxy : exactement 32 caractères hexadécimaux (0-9, A-F), tels qu'indiqués dans le message du bot — ou laissez vide.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1101"/>
+        <source>Promoted channel tag (optional)</source>
+        <translation>Tag de chaîne promue (facultatif)</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1102"/>
+        <source>32 hex chars from @MTProxyBot (e.g. 3b7b2fa9…)</source>
+        <translation>32 caractères hexadécimaux de @MTProxyBot (ex. 3b7b2fa9…)</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1123"/>
+        <source>Proxy tag must be exactly 32 hexadecimal characters (0-9, A-F).</source>
+        <translation>Le tag du proxy doit comporter exactement 32 caractères hexadécimaux (0-9, A-F).</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1133"/>
+        <source>Proxy tag must be exactly 32 hexadecimal characters (0-9, A-F). Leave empty if unused.</source>
+        <translation>Le tag du proxy doit comporter exactement 32 caractères hexadécimaux (0-9, A-F). Laissez vide s'il n'est pas utilisé.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1152"/>
+        <source>Get a tag from</source>
+        <translation>Obtenir un tag depuis</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1173"/>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1188"/>
+        <source>Transport mode</source>
+        <translation>Mode de transport</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1189"/>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1193"/>
+        <source>FakeTLS</source>
+        <translation>FakeTLS</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1189"/>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1193"/>
+        <source>Standard MTProto</source>
+        <translation>Standard MTProto</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1222"/>
+        <source>FakeTLS domain</source>
+        <translation>Domaine FakeTLS</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1237"/>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1244"/>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1921"/>
+        <source>Enter a valid domain name</source>
+        <translation>Saisissez un nom de domaine valide</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1265"/>
+        <source>The domain is encoded into the FakeTLS client secret (ee + base_secret + hex(domain)). It must support HTTPS / TLS 1.3.</source>
+        <translation>Le domaine est encodé dans le secret client FakeTLS (ee + base_secret + hex(domaine)). Il doit prendre en charge HTTPS / TLS 1.3.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1272"/>
+        <source>⚠ Changing the domain will invalidate all previously issued FakeTLS connection links.</source>
+        <translation>⚠ Changer de domaine invalidera tous les liens de connexion FakeTLS déjà émis.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1285"/>
+        <source>Advanced</source>
+        <translation>Avancé</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1307"/>
+        <source>Additional secrets</source>
+        <translation>Secrets supplémentaires</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1315"/>
+        <source>Add extra secrets to allow gradual migration without disconnecting existing users.</source>
+        <translation>Ajoutez des secrets supplémentaires pour permettre une migration progressive sans déconnecter les utilisateurs existants.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1516"/>
+        <source>Add additional secret</source>
+        <translation>Ajouter un secret supplémentaire</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1531"/>
+        <source>Worker mode</source>
+        <translation>Mode des workers</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1548"/>
+        <source>Auto</source>
+        <translation>Automatique</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1555"/>
+        <source>Manual</source>
+        <translation>Manuel</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1568"/>
+        <source>Workers are set to 0 automatically for FakeTLS mode.</source>
+        <translation>Le nombre de workers est automatiquement mis à 0 en mode FakeTLS.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1581"/>
+        <source>Workers count</source>
+        <translation>Nombre de workers</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1640"/>
+        <source>Server is behind NAT / Docker bridge</source>
+        <translation>Le serveur est derrière un NAT / pont Docker</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1641"/>
+        <source>Enable if your server is not directly accessible from the internet, e.g. Docker or private network</source>
+        <translation>Activez cette option si votre serveur n'est pas directement accessible depuis Internet, par exemple derrière Docker ou un réseau privé</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1658"/>
+        <source>Internal IP</source>
+        <translation>IP interne</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1667"/>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1675"/>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1702"/>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1710"/>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1925"/>
+        <source>Enter a valid IPv4 address</source>
+        <translation>Saisissez une adresse IPv4 valide</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1693"/>
+        <source>External IP</source>
+        <translation>IP externe</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1741"/>
+        <source>Diagnostics</source>
+        <translation>Diagnostics</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1769"/>
+        <source>Public port reachable</source>
+        <translation>Port public joignable</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1773"/>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1793"/>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1813"/>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1833"/>
+        <source>—</source>
+        <translation>—</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1773"/>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1793"/>
+        <source>Yes</source>
+        <translation>Oui</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1773"/>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1793"/>
+        <source>No</source>
+        <translation>Non</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1789"/>
+        <source>Telegram upstream reachable</source>
+        <translation>Serveur Telegram joignable</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1809"/>
+        <source>Clients connected</source>
+        <translation>Clients connectés</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1829"/>
+        <source>Last config refresh</source>
+        <translation>Dernier rafraîchissement de la configuration</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1842"/>
+        <source>Stats endpoint</source>
+        <translation>Point d'accès des statistiques</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1855"/>
+        <source>Refreshing…</source>
+        <translation>Actualisation…</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1855"/>
+        <source>Tap ↻ to refresh diagnostics</source>
+        <translation>Appuyez sur ↻ pour actualiser les diagnostics</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1867"/>
+        <source>If you change the settings, the proxy connection link will change. The old link will stop working.</source>
+        <translation>Si vous modifiez les paramètres, le lien de connexion du proxy changera. L'ancien lien cessera de fonctionner.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1881"/>
+        <source>Save</source>
+        <translation>Enregistrer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1901"/>
+        <source>The port must be in the range of 1 to 65535</source>
+        <translation>Le port doit être compris entre 1 et 65535</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1913"/>
+        <source>Proxy tag must be exactly 32 hexadecimal characters (0-9, A-F), or leave empty.</source>
+        <translation>Le tag du proxy doit comporter exactement 32 caractères hexadécimaux (0-9, A-F), ou rester vide.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1928"/>
+        <source>NAT internal IP: enter a valid IPv4 address</source>
+        <translation>IP interne du NAT : saisissez une adresse IPv4 valide</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceMtProxySettings.qml" line="1932"/>
+        <source>NAT external IP: enter a valid IPv4 address</source>
+        <translation>IP externe du NAT : saisissez une adresse IPv4 valide</translation>
+    </message>
+</context>
+<context>
+    <name>PageServiceSftpSettings</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceSftpSettings.qml" line="23"/>
+        <source>Settings updated successfully</source>
+        <translation>Paramètres mis à jour avec succès</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceSftpSettings.qml" line="64"/>
+        <source>SFTP settings</source>
+        <translation>Paramètres SFTP</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceSftpSettings.qml" line="75"/>
+        <source>Host</source>
+        <translation>Host</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceSftpSettings.qml" line="85"/>
+        <location filename="../ui/qml/Pages2/PageServiceSftpSettings.qml" line="106"/>
+        <location filename="../ui/qml/Pages2/PageServiceSftpSettings.qml" line="127"/>
+        <location filename="../ui/qml/Pages2/PageServiceSftpSettings.qml" line="150"/>
+        <source>Copied</source>
+        <translation>Copié</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceSftpSettings.qml" line="96"/>
+        <source>Port</source>
+        <translation>Port</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceSftpSettings.qml" line="117"/>
+        <source>User name</source>
+        <translation>Nom d'utilisateur</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceSftpSettings.qml" line="138"/>
+        <source>Password</source>
+        <translation>Mot de passe</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceSftpSettings.qml" line="172"/>
+        <source>Mount folder on device</source>
+        <translation>Monter le dossier sur l'appareil</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceSftpSettings.qml" line="197"/>
+        <source>In order to mount remote SFTP folder as local drive, perform following steps: &lt;br&gt;</source>
+        <translation>Pour monter le dossier SFTP distant en tant que lecteur local, procédez comme suit : &lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceSftpSettings.qml" line="199"/>
+        <location filename="../ui/qml/Pages2/PageServiceSftpSettings.qml" line="202"/>
+        <source>&lt;br&gt;1. Install the latest version of </source>
+        <translation>&lt;br&gt;1. Installez la dernière version de </translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceSftpSettings.qml" line="200"/>
+        <location filename="../ui/qml/Pages2/PageServiceSftpSettings.qml" line="203"/>
+        <source>&lt;br&gt;2. Install the latest version of </source>
+        <translation>&lt;br&gt;2. Installez la dernière version de </translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceSftpSettings.qml" line="232"/>
+        <source>Detailed instructions</source>
+        <translation>Instructions détaillées</translation>
+    </message>
+</context>
+<context>
+    <name>PageServiceSocksProxySettings</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="25"/>
+        <source>Settings updated successfully</source>
+        <translation>Paramètres mis à jour avec succès</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="64"/>
+        <location filename="../ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="188"/>
+        <source>SOCKS5 settings</source>
+        <translation>Paramètres SOCKS5</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="73"/>
+        <source>Host</source>
+        <translation>Host</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="83"/>
+        <location filename="../ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="102"/>
+        <location filename="../ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="121"/>
+        <location filename="../ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="142"/>
+        <source>Copied</source>
+        <translation>Copié</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="92"/>
+        <location filename="../ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="199"/>
+        <source>Port</source>
+        <translation>Port</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="111"/>
+        <source>User name</source>
+        <translation>Nom d'utilisateur</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="130"/>
+        <location filename="../ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="243"/>
+        <source>Password</source>
+        <translation>Mot de passe</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="220"/>
+        <source>Username</source>
+        <translation>Nom d'utilisateur</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="272"/>
+        <location filename="../ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="307"/>
+        <source>Change connection settings</source>
+        <translation>Modifier les paramètres de connexion</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="276"/>
+        <source>The port must be in the range of 1 to 65535</source>
+        <translation>Le port doit être compris entre 1 et 65535</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="280"/>
+        <source>Password cannot be empty</source>
+        <translation>Le mot de passe ne peut pas être vide</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceSocksProxySettings.qml" line="283"/>
+        <source>Username cannot be empty</source>
+        <translation>Le nom d'utilisateur ne peut pas être vide</translation>
+    </message>
+</context>
+<context>
+    <name>PageServiceTelemtSettings</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="215"/>
+        <source>Checking...</source>
+        <translation>Vérification...</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="218"/>
+        <source>Updating</source>
+        <translation>Mise à jour</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="222"/>
+        <source>Not deployed</source>
+        <translation>Non déployé</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="225"/>
+        <source>Running</source>
+        <translation>En cours d'exécution</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="228"/>
+        <source>Stopped</source>
+        <translation>Arrêté</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="231"/>
+        <source>Error</source>
+        <translation>Erreur</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="234"/>
+        <source>Unknown</source>
+        <translation>Inconnu</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="349"/>
+        <source>Telemt started</source>
+        <translation>Telemt démarré</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="349"/>
+        <source>Telemt stopped</source>
+        <translation>Telemt arrêté</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="362"/>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="910"/>
+        <source>Settings locked: connection timed out (error code %1). Re-open the page to retry.</source>
+        <translation>Paramètres verrouillés : délai de connexion dépassé (code d'erreur %1). Rouvrez la page pour réessayer.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="442"/>
+        <source>Telemt settings</source>
+        <translation>Paramètres Telemt</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="443"/>
+        <source>Read more about this settings</source>
+        <translation>En savoir plus sur ces paramètres</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="453"/>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1741"/>
+        <source>No internet connection. Connect to the internet to change Telemt settings.</source>
+        <translation>Aucune connexion Internet. Connectez-vous à Internet pour modifier les paramètres Telemt.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="478"/>
+        <source>Connection</source>
+        <translation>Connexion</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="482"/>
+        <source>Settings</source>
+        <translation>Paramètres</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="532"/>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1419"/>
+        <source>Use Telegram connection link</source>
+        <translation>Utiliser le lien de connexion Telegram</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="558"/>
+        <source>Deploy Telemt first</source>
+        <translation>Déployez d'abord Telemt</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="574"/>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="633"/>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="713"/>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="748"/>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="789"/>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="860"/>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1706"/>
+        <source>Copied</source>
+        <translation>Copié</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="619"/>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="865"/>
+        <source>Telegram connection link</source>
+        <translation>Lien de connexion Telegram</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="620"/>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="866"/>
+        <source>Telemt connection link</source>
+        <translation>Lien de connexion Telemt</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="647"/>
+        <source>Or enter the proxy details manually.</source>
+        <translation>Ou saisissez les détails du proxy manuellement.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="653"/>
+        <source>How to do it</source>
+        <translation>Comment faire</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="695"/>
+        <source>Host</source>
+        <translation>Host</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="731"/>
+        <source>Port</source>
+        <translation>Port</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="770"/>
+        <source>Secret</source>
+        <translation>Secret</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="802"/>
+        <source>Delete Telemt</source>
+        <translation>Supprimer Telemt</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="805"/>
+        <source>Remove %1 from server?</source>
+        <translation>Supprimer %1 du serveur ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="806"/>
+        <source>The proxy will be stopped and all users will lose access.</source>
+        <translation>Le proxy sera arrêté et tous les utilisateurs perdront l'accès.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="807"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="808"/>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="957"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="880"/>
+        <source>Enable Telemt</source>
+        <translation>Activer Telemt</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="908"/>
+        <source>Enable Telemt to edit settings</source>
+        <translation>Activez Telemt pour modifier les paramètres</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="911"/>
+        <source>Cannot reach the server — settings are unavailable</source>
+        <translation>Serveur injoignable — les paramètres sont indisponibles</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="925"/>
+        <source>Base secret</source>
+        <translation>Secret de base</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="936"/>
+        <source>Not generated</source>
+        <translation>Non généré</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="954"/>
+        <source>Generate new secret?</source>
+        <translation>Générer un nouveau secret ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="955"/>
+        <source>All existing connection links will stop working. Users will need new links.</source>
+        <translation>Tous les liens de connexion existants cesseront de fonctionner. Les utilisateurs auront besoin de nouveaux liens.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="956"/>
+        <source>Generate</source>
+        <translation>Générer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="966"/>
+        <source>New secret saved. It will be applied when Telemt is started.</source>
+        <translation>Nouveau secret enregistré. Il sera appliqué au démarrage de Telemt.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="984"/>
+        <source>Public host / IP</source>
+        <translation>Hôte / IP public</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="995"/>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1003"/>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1762"/>
+        <source>Enter a valid IP address or domain name</source>
+        <translation>Saisissez une adresse IP ou un nom de domaine valide</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1020"/>
+        <source>Leave empty to use server IP automatically</source>
+        <translation>Laissez vide pour utiliser automatiquement l'IP du serveur</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1033"/>
+        <source>⚠ This overrides the server IP in connection links. Make sure this host/domain points to your server.</source>
+        <translation>⚠ Ceci remplace l'IP du serveur dans les liens de connexion. Assurez-vous que cet hôte/domaine pointe bien vers votre serveur.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1046"/>
+        <source>Server port</source>
+        <translation>Port du serveur</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1077"/>
+        <source>FakeTLS may not work on ports other than 443</source>
+        <translation>FakeTLS peut ne pas fonctionner sur un port autre que 443</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1088"/>
+        <source>The promoted channel is set in @MTProxyBot. Paste the proxy tag here: exactly 32 hexadecimal characters (0-9, A-F), as in the bot message — or leave empty.</source>
+        <translation>La chaîne promue se configure dans @MTProxyBot. Collez ici le tag du proxy : exactement 32 caractères hexadécimaux (0-9, A-F), tels qu'indiqués dans le message du bot — ou laissez vide.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1101"/>
+        <source>Promoted channel tag (optional)</source>
+        <translation>Tag de chaîne promue (facultatif)</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1102"/>
+        <source>32 hex chars from @MTProxyBot (e.g. 3b7b2fa9…)</source>
+        <translation>32 caractères hexadécimaux de @MTProxyBot (ex. 3b7b2fa9…)</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1123"/>
+        <source>Proxy tag must be exactly 32 hexadecimal characters (0-9, A-F).</source>
+        <translation>Le tag du proxy doit comporter exactement 32 caractères hexadécimaux (0-9, A-F).</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1133"/>
+        <source>Proxy tag must be exactly 32 hexadecimal characters (0-9, A-F). Leave empty if unused.</source>
+        <translation>Le tag du proxy doit comporter exactement 32 caractères hexadécimaux (0-9, A-F). Laissez vide s'il n'est pas utilisé.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1152"/>
+        <source>Get a tag from</source>
+        <translation>Obtenir un tag depuis</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1173"/>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1188"/>
+        <source>Transport mode</source>
+        <translation>Mode de transport</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1189"/>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1193"/>
+        <source>FakeTLS</source>
+        <translation>FakeTLS</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1189"/>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1193"/>
+        <source>Standard MTProto</source>
+        <translation>Standard MTProto</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1222"/>
+        <source>FakeTLS domain</source>
+        <translation>Domaine FakeTLS</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1237"/>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1244"/>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1777"/>
+        <source>Enter a valid domain name</source>
+        <translation>Saisissez un nom de domaine valide</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1265"/>
+        <source>The domain is encoded into the FakeTLS client secret (ee + base_secret + hex(domain)). It must support HTTPS / TLS 1.3.</source>
+        <translation>Le domaine est encodé dans le secret client FakeTLS (ee + base_secret + hex(domaine)). Il doit prendre en charge HTTPS / TLS 1.3.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1272"/>
+        <source>⚠ Changing the domain will invalidate all previously issued FakeTLS connection links.</source>
+        <translation>⚠ Changer de domaine invalidera tous les liens de connexion FakeTLS déjà émis.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1285"/>
+        <source>Advanced</source>
+        <translation>Avancé</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1307"/>
+        <source>Additional secrets</source>
+        <translation>Secrets supplémentaires</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1315"/>
+        <source>Add extra secrets to allow gradual migration without disconnecting existing users.</source>
+        <translation>Ajoutez des secrets supplémentaires pour permettre une migration progressive sans déconnecter les utilisateurs existants.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1516"/>
+        <source>Add additional secret</source>
+        <translation>Ajouter un secret supplémentaire</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1532"/>
+        <source>Set public IP manually</source>
+        <translation>Définir l'IP publique manuellement</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1533"/>
+        <source>By default the proxy auto-detects its public IP. Enable to override it manually, e.g. when the server is behind NAT / Docker bridge</source>
+        <translation>Par défaut, le proxy détecte automatiquement son IP publique. Activez cette option pour la définir manuellement, par exemple si le serveur est derrière un NAT / pont Docker</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1550"/>
+        <source>Public IP</source>
+        <translation>IP publique</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1559"/>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1567"/>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1781"/>
+        <source>Enter a valid IPv4 address</source>
+        <translation>Saisissez une adresse IPv4 valide</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1598"/>
+        <source>Diagnostics</source>
+        <translation>Diagnostics</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1626"/>
+        <source>Public port reachable</source>
+        <translation>Port public joignable</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1630"/>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1650"/>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1670"/>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1690"/>
+        <source>—</source>
+        <translation>—</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1630"/>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1650"/>
+        <source>Yes</source>
+        <translation>Oui</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1630"/>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1650"/>
+        <source>No</source>
+        <translation>Non</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1646"/>
+        <source>Telegram upstream reachable</source>
+        <translation>Serveur Telegram joignable</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1666"/>
+        <source>Clients connected</source>
+        <translation>Clients connectés</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1686"/>
+        <source>Last config refresh</source>
+        <translation>Dernier rafraîchissement de la configuration</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1699"/>
+        <source>Stats endpoint</source>
+        <translation>Point d'accès des statistiques</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1712"/>
+        <source>Refreshing…</source>
+        <translation>Actualisation…</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1712"/>
+        <source>Tap ↻ to refresh diagnostics</source>
+        <translation>Appuyez sur ↻ pour actualiser les diagnostics</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1724"/>
+        <source>If you change the settings, the proxy connection link will change. The old link will stop working.</source>
+        <translation>Si vous modifiez les paramètres, le lien de connexion du proxy changera. L'ancien lien cessera de fonctionner.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1738"/>
+        <source>Save</source>
+        <translation>Enregistrer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1757"/>
+        <source>The port must be in the range of 1 to 65535</source>
+        <translation>Le port doit être compris entre 1 et 65535</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1769"/>
+        <source>Proxy tag must be exactly 32 hexadecimal characters (0-9, A-F), or leave empty.</source>
+        <translation>Le tag du proxy doit comporter exactement 32 caractères hexadécimaux (0-9, A-F), ou rester vide.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTelemtSettings.qml" line="1784"/>
+        <source>Public IP: enter a valid IPv4 address</source>
+        <translation>IP publique : saisissez une adresse IPv4 valide</translation>
+    </message>
+</context>
+<context>
+    <name>PageServiceTorWebsiteSettings</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTorWebsiteSettings.qml" line="24"/>
+        <source>Settings updated successfully</source>
+        <translation>Paramètres mis à jour avec succès</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTorWebsiteSettings.qml" line="59"/>
+        <source>Tor website settings</source>
+        <translation>Paramètres du site Tor</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTorWebsiteSettings.qml" line="75"/>
+        <source>Website address</source>
+        <translation>Adresse du site</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTorWebsiteSettings.qml" line="86"/>
+        <source>Copied</source>
+        <translation>Copié</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTorWebsiteSettings.qml" line="102"/>
+        <source>Use &lt;a href=&quot;https://www.torproject.org/download/&quot; style=&quot;color: #FBB26A;&quot;&gt;Tor Browser&lt;/a&gt; to open this URL.</source>
+        <translation>Utilisez le &lt;a href=&quot;https://www.torproject.org/download/&quot; style=&quot;color: #FBB26A;&quot;&gt;navigateur Tor&lt;/a&gt; pour ouvrir cette adresse.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTorWebsiteSettings.qml" line="117"/>
+        <source>After creating your onion site, it takes a few minutes for the Tor network to make it available for use.</source>
+        <translation>Après la création de votre site onion, le réseau Tor met quelques minutes à le rendre accessible.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageServiceTorWebsiteSettings.qml" line="126"/>
+        <source>When configuring WordPress set the this onion address as domain.</source>
+        <translation>Lors de la configuration de WordPress, définissez cette adresse onion comme domaine.</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettings</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettings.qml" line="48"/>
+        <source>Settings</source>
+        <translation>Paramètres</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettings.qml" line="85"/>
+        <source>Close application</source>
+        <translation>Fermer l'application</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettings.qml" line="117"/>
+        <source>Servers</source>
+        <translation>Serveurs</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettings.qml" line="128"/>
+        <source>Connection</source>
+        <translation>Connexion</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettings.qml" line="139"/>
+        <source>Application</source>
+        <translation>Application</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettings.qml" line="150"/>
+        <source>News &amp; Notifications</source>
+        <translation>Actualités et notifications</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettings.qml" line="166"/>
+        <source>Backup</source>
+        <translation>Sauvegarde</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettings.qml" line="177"/>
+        <source>About AmneziaVPN</source>
+        <translation>À propos d'AmneziaVPN</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettings.qml" line="188"/>
+        <source>Dev console</source>
+        <translation>Console de développement</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsAbout</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsAbout.qml" line="61"/>
+        <source>Support Amnezia</source>
+        <translation>Soutenir Amnezia</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsAbout.qml" line="76"/>
+        <source>Amnezia is a free and open-source application. You can support the developers if you like it.</source>
+        <translation>Amnezia est une application libre et open source. Vous pouvez soutenir les développeurs si elle vous plaît.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsAbout.qml" line="86"/>
+        <source>Contacts</source>
+        <translation>Contacts</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsAbout.qml" line="119"/>
+        <source>Software version: %1</source>
+        <translation>Version du logiciel : %1</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsAbout.qml" line="149"/>
+        <source>Check for updates</source>
+        <translation>Rechercher des mises à jour</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsAbout.qml" line="170"/>
+        <source>Privacy Policy</source>
+        <translation>Politique de confidentialité</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsAbout.qml" line="189"/>
+        <source>Telegram group</source>
+        <translation>Groupe Telegram</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsAbout.qml" line="190"/>
+        <source>To discuss features</source>
+        <translation>Pour discuter des fonctionnalités</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsAbout.qml" line="193"/>
+        <source>https://t.me/amnezia_vpn_en</source>
+        <translation>https://t.me/amnezia_vpn_en</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsAbout.qml" line="200"/>
+        <source>support@amnezia.org</source>
+        <translation>support@amnezia.org</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsAbout.qml" line="201"/>
+        <source>For reviews and bug reports</source>
+        <translation>Pour les avis et les rapports de bogues</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsAbout.qml" line="204"/>
+        <source>mailto:support@amnezia.org</source>
+        <translation>mailto:support@amnezia.org</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsAbout.qml" line="211"/>
+        <source>GitHub</source>
+        <translation>GitHub</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsAbout.qml" line="212"/>
+        <source>Discover the source code</source>
+        <translation>Découvrir le code source</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsAbout.qml" line="215"/>
+        <source>https://github.com/amnezia-vpn/amnezia-client</source>
+        <translation>https://github.com/amnezia-vpn/amnezia-client</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsAbout.qml" line="222"/>
+        <source>Website</source>
+        <translation>Site web</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsAbout.qml" line="223"/>
+        <source>Visit official website</source>
+        <translation>Visiter le site officiel</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsApiAvailableCountries</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiAvailableCountries.qml" line="147"/>
+        <source>Subscription expired</source>
+        <translation>Abonnement expiré</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiAvailableCountries.qml" line="147"/>
+        <source>Subscription expiring soon</source>
+        <translation>Abonnement bientôt expiré</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiAvailableCountries.qml" line="166"/>
+        <source>Renew subscription</source>
+        <translation>Renouveler l'abonnement</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiAvailableCountries.qml" line="180"/>
+        <source>Location for connection</source>
+        <translation>Emplacement de connexion</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiAvailableCountries.qml" line="209"/>
+        <source>Unable change server location while trying to make an active connection</source>
+        <translation>Impossible de changer d'emplacement de serveur pendant l'établissement d'une connexion</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiAvailableCountries.qml" line="213"/>
+        <source>Unable change server location while there is an active connection</source>
+        <translation>Impossible de changer d'emplacement de serveur tant qu'une connexion est active</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsApiDevices</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiDevices.qml" line="45"/>
+        <source>Active Devices</source>
+        <translation>Appareils actifs</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiDevices.qml" line="46"/>
+        <source>Manage currently connected devices</source>
+        <translation>Gérer les appareils actuellement connectés</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiDevices.qml" line="55"/>
+        <source>You can find the identifier on the Support tab or, for older versions of the app, by tapping &apos;+&apos; and then the three dots at the top of the page.</source>
+        <translation>Vous trouverez l'identifiant dans l'onglet Assistance ou, pour les anciennes versions de l'application, en appuyant sur « + » puis sur les trois points en haut de la page.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiDevices.qml" line="69"/>
+        <source> (current device)</source>
+        <translation> (appareil actuel)</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiDevices.qml" line="70"/>
+        <source>Support tag: </source>
+        <translation>Tag d'assistance : </translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiDevices.qml" line="70"/>
+        <source>Last updated: </source>
+        <translation>Dernière mise à jour : </translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiDevices.qml" line="75"/>
+        <source>Cannot unlink device during active connection</source>
+        <translation>Impossible de dissocier un appareil pendant une connexion active</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiDevices.qml" line="79"/>
+        <source>Are you sure you want to unlink this device?</source>
+        <translation>Voulez-vous vraiment dissocier cet appareil ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiDevices.qml" line="80"/>
+        <source>This will unlink the device from your subscription. You can reconnect it anytime by pressing&#xa0;&quot;Reload API config&quot; in subscription settings on device.</source>
+        <translation>Cela dissociera l'appareil de votre abonnement. Vous pourrez le reconnecter à tout moment en appuyant sur « Recharger la configuration API » dans les paramètres d'abonnement de l'appareil.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiDevices.qml" line="81"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiDevices.qml" line="82"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsApiInstructions</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiInstructions.qml" line="22"/>
+        <source>Windows</source>
+        <translation>Windows</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiInstructions.qml" line="23"/>
+        <source>documentation/instructions/connect-amnezia-premium#windows</source>
+        <translation>documentation/instructions/connect-amnezia-premium#windows</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiInstructions.qml" line="29"/>
+        <source>macOS</source>
+        <translation>macOS</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiInstructions.qml" line="30"/>
+        <source>documentation/instructions/connect-amnezia-premium#macos</source>
+        <translation>documentation/instructions/connect-amnezia-premium#macos</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiInstructions.qml" line="36"/>
+        <source>Android</source>
+        <translation>Android</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiInstructions.qml" line="37"/>
+        <source>documentation/instructions/connect-amnezia-premium#android</source>
+        <translation>documentation/instructions/connect-amnezia-premium#android</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiInstructions.qml" line="43"/>
+        <source>AndroidTV</source>
+        <translation>AndroidTV</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiInstructions.qml" line="44"/>
+        <source>documentation/instructions/android_tv_connect/</source>
+        <translation>documentation/instructions/android_tv_connect/</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiInstructions.qml" line="50"/>
+        <source>iOS</source>
+        <translation>iOS</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiInstructions.qml" line="51"/>
+        <source>documentation/instructions/connect-amnezia-premium#ios</source>
+        <translation>documentation/instructions/connect-amnezia-premium#ios</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiInstructions.qml" line="57"/>
+        <source>Linux</source>
+        <translation>Linux</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiInstructions.qml" line="58"/>
+        <source>documentation/instructions/connect-amnezia-premium#linux</source>
+        <translation>documentation/instructions/connect-amnezia-premium#linux</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiInstructions.qml" line="64"/>
+        <source>Routers</source>
+        <translation>Routeurs</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiInstructions.qml" line="65"/>
+        <source>documentation/instructions/connect-amnezia-premium#routers</source>
+        <translation>documentation/instructions/connect-amnezia-premium#routers</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiInstructions.qml" line="101"/>
+        <source>How to connect on another device</source>
+        <translation>Comment se connecter depuis un autre appareil</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiInstructions.qml" line="102"/>
+        <source>Setup guides on the Amnezia website</source>
+        <translation>Guides de configuration sur le site d'Amnezia</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsApiNativeConfigs</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiNativeConfigs.qml" line="23"/>
+        <source>Save AmneziaVPN config</source>
+        <translation>Enregistrer la configuration AmneziaVPN</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiNativeConfigs.qml" line="60"/>
+        <source>Configuration Files</source>
+        <translation>Fichiers de configuration</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiNativeConfigs.qml" line="61"/>
+        <source>For router setup or the AmneziaWG app</source>
+        <translation>Pour la configuration d'un routeur ou l'application AmneziaWG</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiNativeConfigs.qml" line="73"/>
+        <source>The configuration needs to be reissued</source>
+        <translation>La configuration doit être réémise</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiNativeConfigs.qml" line="135"/>
+        <source> configuration file</source>
+        <translation> fichier de configuration</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiNativeConfigs.qml" line="149"/>
+        <source>Generate a new configuration file</source>
+        <translation>Générer un nouveau fichier de configuration</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiNativeConfigs.qml" line="150"/>
+        <source>The previously created one will stop working</source>
+        <translation>Le fichier créé précédemment cessera de fonctionner</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiNativeConfigs.qml" line="168"/>
+        <source>Revoke the current configuration file</source>
+        <translation>Révoquer le fichier de configuration actuel</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiNativeConfigs.qml" line="198"/>
+        <source>Config file saved</source>
+        <translation>Fichier de configuration enregistré</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiNativeConfigs.qml" line="212"/>
+        <source>The config has been revoked</source>
+        <translation>La configuration a été révoquée</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiNativeConfigs.qml" line="219"/>
+        <source>Generate a new %1 configuration file?</source>
+        <translation>Générer un nouveau fichier de configuration %1 ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiNativeConfigs.qml" line="221"/>
+        <source>Revoke the current %1 configuration file?</source>
+        <translation>Révoquer le fichier de configuration %1 actuel ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiNativeConfigs.qml" line="224"/>
+        <source>Your previous configuration file will no longer work, and it will not be possible to connect using it</source>
+        <translation>Votre ancien fichier de configuration ne fonctionnera plus et il ne sera plus possible de s'y connecter</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiNativeConfigs.qml" line="225"/>
+        <source>Download</source>
+        <translation>Télécharger</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiNativeConfigs.qml" line="225"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiNativeConfigs.qml" line="226"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsApiServerInfo</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="29"/>
+        <source>Subscription Status</source>
+        <translation>État de l'abonnement</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="38"/>
+        <source>Valid Until</source>
+        <translation>Valable jusqu'au</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="47"/>
+        <source>Active Connections</source>
+        <translation>Connexions actives</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="158"/>
+        <source>Subscription expired</source>
+        <translation>Abonnement expiré</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="159"/>
+        <source>Subscription expiring soon</source>
+        <translation>Abonnement bientôt expiré</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="189"/>
+        <location filename="../ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="254"/>
+        <source>Renew subscription</source>
+        <translation>Renouveler l'abonnement</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="277"/>
+        <source>Configurations have been updated for some countries. Download and install the updated configuration files</source>
+        <translation>Les configurations ont été mises à jour pour certains pays. Téléchargez et installez les fichiers de configuration mis à jour</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="298"/>
+        <source>Subscription Key</source>
+        <translation>Clé d'abonnement</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="320"/>
+        <source>Configuration Files</source>
+        <translation>Fichiers de configuration</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="322"/>
+        <source>Manage configuration files</source>
+        <translation>Gérer les fichiers de configuration</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="340"/>
+        <source>Active Devices</source>
+        <translation>Appareils actifs</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="342"/>
+        <source>Manage currently connected devices</source>
+        <translation>Gérer les appareils actuellement connectés</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="359"/>
+        <source>Support</source>
+        <translation>Assistance</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="374"/>
+        <source>How to connect on another device</source>
+        <translation>Comment se connecter depuis un autre appareil</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="399"/>
+        <source>Reload API config</source>
+        <translation>Recharger la configuration API</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="402"/>
+        <source>Reload API config?</source>
+        <translation>Recharger la configuration API ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="403"/>
+        <location filename="../ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="441"/>
+        <location filename="../ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="478"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="404"/>
+        <location filename="../ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="442"/>
+        <location filename="../ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="479"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="408"/>
+        <source>Cannot reload API config during active connection</source>
+        <translation>Impossible de recharger la configuration API pendant une connexion active</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="436"/>
+        <source>Unlink this device</source>
+        <translation>Dissocier cet appareil</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="439"/>
+        <source>Are you sure you want to unlink this device?</source>
+        <translation>Voulez-vous vraiment dissocier cet appareil ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="440"/>
+        <source>This will unlink the device from your subscription. You can reconnect it anytime by pressing&#xa0;&quot;Reload API config&quot; in subscription settings on device.</source>
+        <translation>Cela dissociera l'appareil de votre abonnement. Vous pourrez le reconnecter à tout moment en appuyant sur « Recharger la configuration API » dans les paramètres d'abonnement de l'appareil.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="446"/>
+        <source>Cannot unlink device during active connection</source>
+        <translation>Impossible de dissocier un appareil pendant une connexion active</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="474"/>
+        <source>Remove from application</source>
+        <translation>Retirer de l'application</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="477"/>
+        <source>Remove from application?</source>
+        <translation>Retirer de l'application ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiServerInfo.qml" line="483"/>
+        <source>Cannot remove server during active connection</source>
+        <translation>Impossible de supprimer un serveur pendant une connexion active</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsApiSubscriptionKey</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiSubscriptionKey.qml" line="93"/>
+        <source>Copy key</source>
+        <translation>Copier la clé</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiSubscriptionKey.qml" line="98"/>
+        <source>Copied</source>
+        <translation>Copié</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiSubscriptionKey.qml" line="114"/>
+        <source>Save key as a file</source>
+        <translation>Enregistrer la clé dans un fichier</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiSubscriptionKey.qml" line="121"/>
+        <source>Save AmneziaVPN config</source>
+        <translation>Enregistrer la configuration AmneziaVPN</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiSubscriptionKey.qml" line="122"/>
+        <source>Config files (*.vpn)</source>
+        <translation>Fichiers de configuration (*.vpn)</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiSubscriptionKey.qml" line="133"/>
+        <source>Config file saved</source>
+        <translation>Fichier de configuration enregistré</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiSubscriptionKey.qml" line="150"/>
+        <source>Show key text</source>
+        <translation>Afficher le texte de la clé</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiSubscriptionKey.qml" line="191"/>
+        <source>To read the QR code in the Amnezia app, tap + in the main menu → &apos;QR code&apos;</source>
+        <translation>Pour lire le QR code dans l'application Amnezia, appuyez sur « + » dans le menu principal → « QR code »</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsApiSupport</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiSupport.qml" line="22"/>
+        <source>Telegram</source>
+        <translation>Telegram</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiSupport.qml" line="30"/>
+        <source>Email</source>
+        <translation>E-mail</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiSupport.qml" line="38"/>
+        <source>Email Billing &amp; Orders</source>
+        <translation>E-mail facturation et commandes</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiSupport.qml" line="46"/>
+        <source>Website</source>
+        <translation>Site web</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiSupport.qml" line="81"/>
+        <source>Support</source>
+        <translation>Assistance</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiSupport.qml" line="82"/>
+        <source>Our technical support specialists are available to assist you at any time</source>
+        <translation>Nos spécialistes du support technique sont à votre disposition à tout moment</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiSupport.qml" line="110"/>
+        <source>Support tag</source>
+        <translation>Tag d'assistance</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApiSupport.qml" line="120"/>
+        <source>Copied</source>
+        <translation>Copié</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsAppSplitTunneling</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsAppSplitTunneling.qml" line="27"/>
+        <source>Cannot change split tunneling settings during active connection</source>
+        <translation>Impossible de modifier les paramètres de split tunneling pendant une connexion active</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsAppSplitTunneling.qml" line="49"/>
+        <source>Only the apps from the list should have access via VPN</source>
+        <translation>Seules les applications de la liste doivent passer par le VPN</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsAppSplitTunneling.qml" line="56"/>
+        <source>Apps from the list should not have access via VPN</source>
+        <translation>Les applications de la liste ne doivent pas passer par le VPN</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsAppSplitTunneling.qml" line="87"/>
+        <source>App split tunneling</source>
+        <translation>Split tunneling par application</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsAppSplitTunneling.qml" line="112"/>
+        <source>Mode</source>
+        <translation>Mode</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsAppSplitTunneling.qml" line="154"/>
+        <source>Only &quot;Apps from the list should not have access via VPN&quot; mode is available on Windows</source>
+        <translation>Sous Windows, seul le mode « Les applications de la liste ne doivent pas passer par le VPN » est disponible</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsAppSplitTunneling.qml" line="200"/>
+        <source>Remove </source>
+        <translation>Supprimer </translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsAppSplitTunneling.qml" line="201"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsAppSplitTunneling.qml" line="202"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsAppSplitTunneling.qml" line="245"/>
+        <source>application name</source>
+        <translation>nom de l'application</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsAppSplitTunneling.qml" line="255"/>
+        <source>Open executable file</source>
+        <translation>Ouvrir un fichier exécutable</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsAppSplitTunneling.qml" line="256"/>
+        <source>Executable files (*.*)</source>
+        <translation>Fichiers exécutables (*.*)</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsApplication</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApplication.qml" line="48"/>
+        <source>Application</source>
+        <translation>Application</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApplication.qml" line="66"/>
+        <source>Allow application screenshots</source>
+        <translation>Autoriser les captures d'écran de l'application</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApplication.qml" line="87"/>
+        <source>Enable notifications</source>
+        <translation>Activer les notifications</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApplication.qml" line="88"/>
+        <source>Enable notifications to show the VPN state in the status bar</source>
+        <translation>Activez les notifications pour afficher l'état du VPN dans la barre d'état</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApplication.qml" line="108"/>
+        <source>Auto start</source>
+        <translation>Démarrage automatique</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApplication.qml" line="109"/>
+        <source>Launch the application every time the device is starts</source>
+        <translation>Lancer l'application à chaque démarrage de l'appareil</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApplication.qml" line="131"/>
+        <source>Auto connect</source>
+        <translation>Connexion automatique</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApplication.qml" line="132"/>
+        <source>Connect to VPN on app start</source>
+        <translation>Se connecter au VPN au démarrage de l'application</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApplication.qml" line="154"/>
+        <source>Start minimized</source>
+        <translation>Démarrer en mode réduit</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApplication.qml" line="155"/>
+        <source>Launch application minimized (works with autostart option turned on)</source>
+        <translation>Lancer l'application en mode réduit (fonctionne avec le démarrage automatique activé)</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApplication.qml" line="180"/>
+        <source>News Notification</source>
+        <translation>Notification d'actualités</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApplication.qml" line="181"/>
+        <source>Show a notification icon for unread news</source>
+        <translation>Afficher une icône de notification pour les actualités non lues</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApplication.qml" line="205"/>
+        <source>Language</source>
+        <translation>Langue</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApplication.qml" line="221"/>
+        <source>Logging</source>
+        <translation>Journalisation</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApplication.qml" line="222"/>
+        <source>Enabled</source>
+        <translation>Activé</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApplication.qml" line="222"/>
+        <source>Disabled</source>
+        <translation>Désactivé</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApplication.qml" line="237"/>
+        <source>Reset settings and remove all data from the application</source>
+        <translation>Réinitialiser les paramètres et supprimer toutes les données de l'application</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApplication.qml" line="242"/>
+        <source>Reset settings and remove all data from the application?</source>
+        <translation>Réinitialiser les paramètres et supprimer toutes les données de l'application ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApplication.qml" line="243"/>
+        <source>All settings will be reset to default. All installed AmneziaVPN services will still remain on the server.</source>
+        <translation>Tous les paramètres seront réinitialisés par défaut. Tous les services AmneziaVPN installés resteront sur le serveur.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApplication.qml" line="244"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApplication.qml" line="245"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsApplication.qml" line="249"/>
+        <source>Cannot reset settings during active connection</source>
+        <translation>Impossible de réinitialiser les paramètres pendant une connexion active</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsBackup</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsBackup.qml" line="26"/>
+        <source>Settings restored from backup file</source>
+        <translation>Paramètres restaurés depuis le fichier de sauvegarde</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsBackup.qml" line="69"/>
+        <source>Back up your configuration</source>
+        <translation>Sauvegardez votre configuration</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsBackup.qml" line="70"/>
+        <source>You can save your settings to a backup file to restore them the next time you install the application.</source>
+        <translation>Vous pouvez enregistrer vos paramètres dans un fichier de sauvegarde afin de les restaurer lors de la prochaine installation de l'application.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsBackup.qml" line="88"/>
+        <source>The backup will contain your passwords and private keys for all servers added to AmneziaVPN. Keep this information in a secure place.</source>
+        <translation>La sauvegarde contiendra vos mots de passe et vos clés privées pour tous les serveurs ajoutés à AmneziaVPN. Conservez ces informations en lieu sûr.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsBackup.qml" line="102"/>
+        <source>Make a backup</source>
+        <translation>Créer une sauvegarde</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsBackup.qml" line="109"/>
+        <source>Save backup file</source>
+        <translation>Enregistrer le fichier de sauvegarde</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsBackup.qml" line="110"/>
+        <location filename="../ui/qml/Pages2/PageSettingsBackup.qml" line="148"/>
+        <source>Backup files (*.backup)</source>
+        <translation>Fichiers de sauvegarde (*.backup)</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsBackup.qml" line="119"/>
+        <source>Backup file saved</source>
+        <translation>Fichier de sauvegarde enregistré</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsBackup.qml" line="141"/>
+        <source>Restore from backup</source>
+        <translation>Restaurer depuis une sauvegarde</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsBackup.qml" line="147"/>
+        <source>Open backup file</source>
+        <translation>Ouvrir un fichier de sauvegarde</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsBackup.qml" line="162"/>
+        <source>Import settings from a backup file?</source>
+        <translation>Importer les paramètres depuis un fichier de sauvegarde ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsBackup.qml" line="163"/>
+        <source>All current settings will be reset</source>
+        <translation>Tous les paramètres actuels seront réinitialisés</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsBackup.qml" line="164"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsBackup.qml" line="165"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsBackup.qml" line="169"/>
+        <source>Cannot restore backup settings during active connection</source>
+        <translation>Impossible de restaurer une sauvegarde pendant une connexion active</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsConnection</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsConnection.qml" line="49"/>
+        <source>Connection</source>
+        <translation>Connexion</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsConnection.qml" line="65"/>
+        <source>Use AmneziaDNS</source>
+        <translation>Utiliser AmneziaDNS</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsConnection.qml" line="66"/>
+        <source>If AmneziaDNS is installed on the server</source>
+        <translation>Si AmneziaDNS est installé sur le serveur</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsConnection.qml" line="83"/>
+        <source>DNS servers</source>
+        <translation>Serveurs DNS</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsConnection.qml" line="84"/>
+        <source>When AmneziaDNS is not used or installed</source>
+        <translation>Lorsqu'AmneziaDNS n'est pas utilisé ou installé</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsConnection.qml" line="99"/>
+        <source>Site-based split tunneling</source>
+        <translation>Split tunneling par site</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsConnection.qml" line="100"/>
+        <source>Allows you to select which sites you want to access through the VPN</source>
+        <translation>Permet de choisir les sites auxquels vous souhaitez accéder via le VPN</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsConnection.qml" line="123"/>
+        <source>App-based split tunneling</source>
+        <translation>Split tunneling par application</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsConnection.qml" line="124"/>
+        <source>Allows you to use the VPN only for certain Apps</source>
+        <translation>Permet d'utiliser le VPN uniquement pour certaines applications</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsConnection.qml" line="142"/>
+        <source>KillSwitch</source>
+        <translation>KillSwitch</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsConnection.qml" line="143"/>
+        <source>Blocks network connections without VPN</source>
+        <translation>Bloque les connexions réseau en dehors du VPN</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsDns</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsDns.qml" line="46"/>
+        <source>Default server does not support custom DNS</source>
+        <translation>Le serveur par défaut ne prend pas en charge les DNS personnalisés</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsDns.qml" line="59"/>
+        <source>DNS servers</source>
+        <translation>Serveurs DNS</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsDns.qml" line="67"/>
+        <source>If AmneziaDNS is not used or installed</source>
+        <translation>Si AmneziaDNS n'est pas utilisé ou installé</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsDns.qml" line="84"/>
+        <source>Primary DNS</source>
+        <translation>DNS primaire</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsDns.qml" line="99"/>
+        <source>Secondary DNS</source>
+        <translation>DNS secondaire</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsDns.qml" line="122"/>
+        <source>Restore default</source>
+        <translation>Restaurer les valeurs par défaut</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsDns.qml" line="125"/>
+        <source>Restore default DNS settings?</source>
+        <translation>Restaurer les paramètres DNS par défaut ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsDns.qml" line="126"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsDns.qml" line="127"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsDns.qml" line="134"/>
+        <source>Settings have been reset</source>
+        <translation>Les paramètres ont été réinitialisés</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsDns.qml" line="149"/>
+        <source>Save</source>
+        <translation>Enregistrer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsDns.qml" line="153"/>
+        <source>Primary DNS cannot be empty</source>
+        <translation>Le DNS primaire ne peut pas être vide</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsDns.qml" line="165"/>
+        <source>Settings saved</source>
+        <translation>Paramètres enregistrés</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsKillSwitch</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsKillSwitch.qml" line="40"/>
+        <source>KillSwitch</source>
+        <translation>KillSwitch</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsKillSwitch.qml" line="41"/>
+        <source>Enable to ensure network traffic goes through a secure VPN tunnel, preventing accidental exposure of your IP and DNS queries if the connection drops</source>
+        <translation>Activez cette option pour garantir que le trafic réseau passe par un tunnel VPN sécurisé, afin d'éviter l'exposition accidentelle de votre IP et de vos requêtes DNS en cas de coupure de la connexion</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsKillSwitch.qml" line="52"/>
+        <source>KillSwitch settings cannot be changed during an active connection</source>
+        <translation>Les paramètres du KillSwitch ne peuvent pas être modifiés pendant une connexion active</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsKillSwitch.qml" line="68"/>
+        <source>Soft KillSwitch</source>
+        <translation>KillSwitch souple</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsKillSwitch.qml" line="69"/>
+        <source>Internet access is blocked if the VPN disconnects unexpectedly</source>
+        <translation>L'accès à Internet est bloqué si le VPN se déconnecte de manière inattendue</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsKillSwitch.qml" line="92"/>
+        <source>Strict KillSwitch</source>
+        <translation>KillSwitch strict</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsKillSwitch.qml" line="93"/>
+        <source>Internet connection is blocked even when VPN is turned off manually or hasn&apos;t started</source>
+        <translation>La connexion Internet est bloquée même lorsque le VPN est désactivé manuellement ou n'a pas démarré</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsKillSwitch.qml" line="96"/>
+        <source>Just a little heads-up</source>
+        <translation>Petit avertissement</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsKillSwitch.qml" line="97"/>
+        <source>If the VPN disconnects or drops while Strict KillSwitch is enabled, internet access will be blocked. To restore access, reconnect VPN or disable/change the KillSwitch.</source>
+        <translation>Si le VPN se déconnecte ou tombe alors que le KillSwitch strict est activé, l'accès à Internet sera bloqué. Pour le rétablir, reconnectez le VPN ou désactivez/modifiez le KillSwitch.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsKillSwitch.qml" line="98"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsKillSwitch.qml" line="99"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsKillSwitch.qml" line="123"/>
+        <source>DNS Exceptions</source>
+        <translation>Exceptions DNS</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsKillSwitch.qml" line="124"/>
+        <source>DNS servers listed here will remain accessible when KillSwitch is active.</source>
+        <translation>Les serveurs DNS listés ici resteront accessibles lorsque le KillSwitch est actif.</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsKillSwitchExceptions</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="44"/>
+        <source>DNS Exceptions</source>
+        <translation>Exceptions DNS</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="45"/>
+        <source>DNS servers listed here will remain accessible when KillSwitch is active</source>
+        <translation>Les serveurs DNS listés ici resteront accessibles lorsque le KillSwitch est actif</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="105"/>
+        <source>Delete </source>
+        <translation>Supprimer </translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="106"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="107"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="137"/>
+        <source>IPv4 address</source>
+        <translation>Adresse IPv4</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="167"/>
+        <source>Import / Export addresses</source>
+        <translation>Importer / exporter des adresses</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="174"/>
+        <source>Import</source>
+        <translation>Importer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="187"/>
+        <source>Save address list</source>
+        <translation>Enregistrer la liste d'adresses</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="194"/>
+        <source>Save addresses</source>
+        <translation>Enregistrer les adresses</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="195"/>
+        <location filename="../ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="265"/>
+        <location filename="../ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="281"/>
+        <source>Address files (*.json)</source>
+        <translation>Fichiers d'adresses (*.json)</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="254"/>
+        <source>Import address list</source>
+        <translation>Importer une liste d'adresses</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="261"/>
+        <source>Replace address list</source>
+        <translation>Remplacer la liste d'adresses</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="264"/>
+        <location filename="../ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="280"/>
+        <source>Open address file</source>
+        <translation>Ouvrir un fichier d'adresses</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsKillSwitchExceptions.qml" line="277"/>
+        <source>Add imported addresses to existing ones</source>
+        <translation>Ajouter les adresses importées aux adresses existantes</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsLogging</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsLogging.qml" line="50"/>
+        <source>Logging</source>
+        <translation>Journalisation</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsLogging.qml" line="51"/>
+        <source>Enabling this function will save application&apos;s logs automatically. By default, logging functionality is disabled. Enable log saving in case of application malfunction.</source>
+        <translation>L'activation de cette fonction enregistrera automatiquement les journaux de l'application. Par défaut, la journalisation est désactivée. Activez l'enregistrement des journaux en cas de dysfonctionnement de l'application.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsLogging.qml" line="63"/>
+        <source>Enable logs</source>
+        <translation>Activer les journaux</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsLogging.qml" line="80"/>
+        <source>Clear logs</source>
+        <translation>Effacer les journaux</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsLogging.qml" line="85"/>
+        <source>Clear logs?</source>
+        <translation>Effacer les journaux ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsLogging.qml" line="86"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsLogging.qml" line="87"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsLogging.qml" line="93"/>
+        <source>Logs have been cleaned up</source>
+        <translation>Les journaux ont été effacés</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsLogging.qml" line="143"/>
+        <source>Open logs folder</source>
+        <translation>Ouvrir le dossier des journaux</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsLogging.qml" line="157"/>
+        <source>Export logs</source>
+        <translation>Exporter les journaux</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsLogging.qml" line="181"/>
+        <source>Client logs</source>
+        <translation>Journaux du client</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsLogging.qml" line="182"/>
+        <source>AmneziaVPN logs</source>
+        <translation>Journaux d'AmneziaVPN</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsLogging.qml" line="192"/>
+        <location filename="../ui/qml/Pages2/PageSettingsLogging.qml" line="218"/>
+        <source>Save</source>
+        <translation>Enregistrer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsLogging.qml" line="193"/>
+        <location filename="../ui/qml/Pages2/PageSettingsLogging.qml" line="219"/>
+        <source>Logs files (*.log)</source>
+        <translation>Fichiers journaux (*.log)</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsLogging.qml" line="202"/>
+        <location filename="../ui/qml/Pages2/PageSettingsLogging.qml" line="227"/>
+        <source>Logs file saved</source>
+        <translation>Fichier de journaux enregistré</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsLogging.qml" line="210"/>
+        <source>Service logs</source>
+        <translation>Journaux du service</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsLogging.qml" line="211"/>
+        <source>AmneziaVPN-service logs</source>
+        <translation>Journaux du service AmneziaVPN</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsNewsDetail</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsNewsDetail.qml" line="87"/>
+        <source>Update</source>
+        <translation>Mettre à jour</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsNewsDetail.qml" line="112"/>
+        <source>Skip</source>
+        <translation>Ignorer</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsNewsNotifications</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsNewsNotifications.qml" line="33"/>
+        <source>News &amp; Notifications</source>
+        <translation>Actualités et notifications</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsServerData</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerData.qml" line="28"/>
+        <source>All installed containers have been added to the application</source>
+        <translation>Tous les conteneurs installés ont été ajoutés à l'application</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerData.qml" line="30"/>
+        <source>No new installed containers found</source>
+        <translation>Aucun nouveau conteneur installé n'a été trouvé</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerData.qml" line="98"/>
+        <source>Check the server for previously installed Amnezia services</source>
+        <translation>Rechercher sur le serveur les services Amnezia installés précédemment</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerData.qml" line="99"/>
+        <source>Add them to the application if they were not displayed</source>
+        <translation>Les ajouter à l'application s'ils n'étaient pas affichés</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerData.qml" line="112"/>
+        <source>Reboot server</source>
+        <translation>Redémarrer le serveur</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerData.qml" line="116"/>
+        <source>Do you want to reboot the server?</source>
+        <translation>Voulez-vous redémarrer le serveur ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerData.qml" line="117"/>
+        <source>The reboot process may take approximately 30 seconds. Are you sure you wish to proceed?</source>
+        <translation>Le redémarrage peut prendre environ 30 secondes. Voulez-vous vraiment continuer ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerData.qml" line="118"/>
+        <location filename="../ui/qml/Pages2/PageSettingsServerData.qml" line="148"/>
+        <location filename="../ui/qml/Pages2/PageSettingsServerData.qml" line="178"/>
+        <location filename="../ui/qml/Pages2/PageSettingsServerData.qml" line="207"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerData.qml" line="119"/>
+        <location filename="../ui/qml/Pages2/PageSettingsServerData.qml" line="149"/>
+        <location filename="../ui/qml/Pages2/PageSettingsServerData.qml" line="179"/>
+        <location filename="../ui/qml/Pages2/PageSettingsServerData.qml" line="208"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerData.qml" line="123"/>
+        <source>Cannot reboot server during active connection</source>
+        <translation>Impossible de redémarrer le serveur pendant une connexion active</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerData.qml" line="142"/>
+        <source>Remove server from application</source>
+        <translation>Retirer le serveur de l'application</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerData.qml" line="146"/>
+        <source>Do you want to remove the server from application?</source>
+        <translation>Voulez-vous retirer le serveur de l'application ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerData.qml" line="147"/>
+        <source>All installed AmneziaVPN services will still remain on the server.</source>
+        <translation>Tous les services AmneziaVPN installés resteront sur le serveur.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerData.qml" line="153"/>
+        <source>Cannot remove server during active connection</source>
+        <translation>Impossible de supprimer un serveur pendant une connexion active</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerData.qml" line="172"/>
+        <source>Clear server from Amnezia software</source>
+        <translation>Désinstaller les logiciels Amnezia du serveur</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerData.qml" line="176"/>
+        <source>Do you want to clear server from Amnezia software?</source>
+        <translation>Voulez-vous désinstaller les logiciels Amnezia du serveur ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerData.qml" line="177"/>
+        <source>All users whom you shared a connection with will no longer be able to connect to it.</source>
+        <translation>Tous les utilisateurs avec qui vous avez partagé une connexion ne pourront plus s'y connecter.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerData.qml" line="183"/>
+        <source>Cannot clear server from Amnezia software during active connection</source>
+        <translation>Impossible de désinstaller les logiciels Amnezia du serveur pendant une connexion active</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerData.qml" line="201"/>
+        <source>Reset API config</source>
+        <translation>Réinitialiser la configuration API</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerData.qml" line="205"/>
+        <source>Do you want to reset API config?</source>
+        <translation>Voulez-vous réinitialiser la configuration API ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerData.qml" line="212"/>
+        <source>Cannot reset API config during active connection</source>
+        <translation>Impossible de réinitialiser la configuration API pendant une connexion active</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsServerInfo</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerInfo.qml" line="140"/>
+        <source>Protocols</source>
+        <translation>Protocoles</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerInfo.qml" line="151"/>
+        <source>Services</source>
+        <translation>Services</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerInfo.qml" line="160"/>
+        <source>Management</source>
+        <translation>Gestion</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsServerProtocol</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerProtocol.qml" line="56"/>
+        <source> settings</source>
+        <translation> paramètres</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerProtocol.qml" line="57"/>
+        <source>This protocol is no longer supported.</source>
+        <translation>Ce protocole n'est plus pris en charge.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerProtocol.qml" line="71"/>
+        <source>AmneziaWG 2.0 is outdated and does not include the latest security improvements, but it will continue to work. Moving to AmneziaWG 3.1 by deploying a new container on the server is recommended for stronger protocol security</source>
+        <translation>AmneziaWG 2.0 est obsolète et n'intègre pas les dernières améliorations de sécurité, mais il continuera de fonctionner. Il est recommandé de passer à AmneziaWG 3.1 en déployant un nouveau conteneur sur le serveur pour renforcer la sécurité du protocole</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerProtocol.qml" line="90"/>
+        <source> connection settings</source>
+        <translation> paramètres de connexion</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerProtocol.qml" line="99"/>
+        <source>Click the &quot;connect&quot; button to create a connection configuration</source>
+        <translation>Appuyez sur le bouton « Se connecter » pour créer une configuration de connexion</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerProtocol.qml" line="119"/>
+        <source> server settings</source>
+        <translation> paramètres du serveur</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerProtocol.qml" line="151"/>
+        <source>Clear profile</source>
+        <translation>Effacer le profil</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerProtocol.qml" line="154"/>
+        <source>Clear %1 profile?</source>
+        <translation>Effacer le profil %1 ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerProtocol.qml" line="155"/>
+        <source>The connection configuration will be deleted for this device only</source>
+        <translation>La configuration de connexion sera supprimée pour cet appareil uniquement</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerProtocol.qml" line="156"/>
+        <location filename="../ui/qml/Pages2/PageSettingsServerProtocol.qml" line="201"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerProtocol.qml" line="157"/>
+        <location filename="../ui/qml/Pages2/PageSettingsServerProtocol.qml" line="202"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerProtocol.qml" line="161"/>
+        <source>Unable to clear %1 profile while there is an active connection</source>
+        <translation>Impossible d'effacer le profil %1 tant qu'une connexion est active</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerProtocol.qml" line="195"/>
+        <source>Remove </source>
+        <translation>Supprimer </translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerProtocol.qml" line="199"/>
+        <source>Remove %1 from server?</source>
+        <translation>Supprimer %1 du serveur ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerProtocol.qml" line="200"/>
+        <source>All users with whom you shared a connection will no longer be able to connect to it.</source>
+        <translation>Tous les utilisateurs avec qui vous avez partagé une connexion ne pourront plus s'y connecter.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServerProtocol.qml" line="207"/>
+        <source>Cannot remove active container</source>
+        <translation>Impossible de supprimer un conteneur actif</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsServersList</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsServersList.qml" line="38"/>
+        <source>Servers</source>
+        <translation>Serveurs</translation>
+    </message>
+</context>
+<context>
+    <name>PageSettingsSplitTunneling</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="29"/>
+        <source>Cannot change split tunneling settings during active connection</source>
+        <translation>Impossible de modifier les paramètres de split tunneling pendant une connexion active</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="32"/>
+        <source>Default server does not support split tunneling function</source>
+        <translation>Le serveur par défaut ne prend pas en charge la fonction de split tunneling</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="65"/>
+        <source>Only the sites listed here will be accessed through the VPN</source>
+        <translation>Seuls les sites listés ici seront accessibles via le VPN</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="70"/>
+        <source>Addresses from the list should not be accessed via VPN</source>
+        <translation>Les adresses de la liste ne doivent pas être accessibles via le VPN</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="101"/>
+        <source>Split tunneling</source>
+        <translation>Split tunneling</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="128"/>
+        <source>Mode</source>
+        <translation>Mode</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="210"/>
+        <source>Remove </source>
+        <translation>Supprimer </translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="211"/>
+        <location filename="../ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="361"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="212"/>
+        <location filename="../ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="362"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="262"/>
+        <source>website or IP</source>
+        <translation>site web ou IP</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="308"/>
+        <source>Additional options</source>
+        <translation>Options supplémentaires</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="315"/>
+        <source>Import</source>
+        <translation>Importer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="328"/>
+        <source>Save site list</source>
+        <translation>Enregistrer la liste de sites</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="335"/>
+        <source>Save sites</source>
+        <translation>Enregistrer les sites</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="336"/>
+        <location filename="../ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="462"/>
+        <location filename="../ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="475"/>
+        <source>Sites files (*.json)</source>
+        <translation>Fichiers de sites (*.json)</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="356"/>
+        <source>Clear site list</source>
+        <translation>Effacer la liste de sites</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="359"/>
+        <source>Clear site list?</source>
+        <translation>Effacer la liste de sites ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="360"/>
+        <source>All sites will be removed from list.</source>
+        <translation>Tous les sites seront retirés de la liste.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="424"/>
+        <source>Import a list of sites</source>
+        <translation>Importer une liste de sites</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="459"/>
+        <source>Replace site list</source>
+        <translation>Remplacer la liste de sites</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="461"/>
+        <location filename="../ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="474"/>
+        <source>Open sites file</source>
+        <translation>Ouvrir un fichier de sites</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSettingsSplitTunneling.qml" line="472"/>
+        <source>Add imported sites to existing ones</source>
+        <translation>Ajouter les sites importés aux sites existants</translation>
+    </message>
+</context>
+<context>
+    <name>PageSetupWizardApiFreeInfo</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardApiFreeInfo.qml" line="74"/>
+        <source>Free features</source>
+        <translation>Fonctionnalités gratuites</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardApiFreeInfo.qml" line="125"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+</context>
+<context>
+    <name>PageSetupWizardApiPremiumInfo</name>
+    <message numerus="yes">
+        <location filename="../ui/qml/Pages2/PageSetupWizardApiPremiumInfo.qml" line="102"/>
+        <source>Try free for %n day(s)</source>
+        <translation>
+            <numerusform>Essayez gratuitement pendant %n jour</numerusform>
+            <numerusform>Essayez gratuitement pendant %n jours</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardApiPremiumInfo.qml" line="140"/>
+        <source>Recommended</source>
+        <translation>Recommandé</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardApiPremiumInfo.qml" line="167"/>
+        <source>Change plan</source>
+        <translation>Changer d'offre</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardApiPremiumInfo.qml" line="180"/>
+        <source>Premium features</source>
+        <translation>Fonctionnalités premium</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardApiPremiumInfo.qml" line="209"/>
+        <source>Charged to your Apple ID at confirmation. Renews automatically unless auto-renew is turned off at least 24 hours before period end. Manage in Apple ID settings.</source>
+        <translation>Débité sur votre identifiant Apple à la confirmation. Renouvellement automatique sauf désactivation au moins 24 heures avant la fin de la période. Gérez cela dans les réglages de votre identifiant Apple.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardApiPremiumInfo.qml" line="268"/>
+        <location filename="../ui/qml/Pages2/PageSetupWizardApiPremiumInfo.qml" line="309"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../ui/qml/Pages2/PageSetupWizardApiPremiumInfo.qml" line="271"/>
+        <source>Start %n-day free trial</source>
+        <translation>
+            <numerusform>Démarrer l'essai gratuit de %n jour</numerusform>
+            <numerusform>Démarrer l'essai gratuit de %n jours</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardApiPremiumInfo.qml" line="273"/>
+        <source>Subscribe — %1 for %2</source>
+        <translation>S'abonner — %1 pour %2</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardApiPremiumInfo.qml" line="296"/>
+        <source>Upgrade plan?</source>
+        <translation>Passer à une offre supérieure ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardApiPremiumInfo.qml" line="297"/>
+        <source>The current plan will be replaced with the %1 / %2 plan. The change will take effect immediately after confirmation</source>
+        <translation>L'offre actuelle sera remplacée par l'offre %1 / %2. Le changement prendra effet immédiatement après confirmation</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardApiPremiumInfo.qml" line="300"/>
+        <source>Downgrade plan?</source>
+        <translation>Passer à une offre inférieure ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardApiPremiumInfo.qml" line="301"/>
+        <source>The current plan will be replaced with the %1 / %2 plan. The store will apply the change based on its billing rules</source>
+        <translation>L'offre actuelle sera remplacée par l'offre %1 / %2. La boutique appliquera le changement selon ses règles de facturation</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardApiPremiumInfo.qml" line="304"/>
+        <source>Confirm subscription change?</source>
+        <translation>Confirmer le changement d'abonnement ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardApiPremiumInfo.qml" line="305"/>
+        <source>An active subscription already exists. The current plan will be replaced with the %1 / %2 plan</source>
+        <translation>Un abonnement actif existe déjà. L'offre actuelle sera remplacée par l'offre %1 / %2</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardApiPremiumInfo.qml" line="309"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../ui/qml/Pages2/PageSetupWizardApiPremiumInfo.qml" line="335"/>
+        <source>%n day(s) free, then %1/%2. Auto-renews until canceled. Cancel anytime in Settings.</source>
+        <translation>
+            <numerusform>%n jour gratuit, puis %1/%2. Renouvellement automatique jusqu'à annulation. Annulable à tout moment dans les paramètres.</numerusform>
+            <numerusform>%n jours gratuits, puis %1/%2. Renouvellement automatique jusqu'à annulation. Annulable à tout moment dans les paramètres.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardApiPremiumInfo.qml" line="338"/>
+        <source>%1/%2, auto-renewal. Cancel anytime in the Settings.</source>
+        <translation>%1/%2, renouvellement automatique. Annulable à tout moment dans les paramètres.</translation>
+    </message>
+</context>
+<context>
+    <name>PageSetupWizardApiServicesList</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardApiServicesList.qml" line="52"/>
+        <source>VPN by Amnezia</source>
+        <translation>VPN par Amnezia</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardApiServicesList.qml" line="53"/>
+        <source>Choose a VPN service that suits your needs.</source>
+        <translation>Choisissez le service VPN qui correspond à vos besoins.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardApiServicesList.qml" line="91"/>
+        <source>Recommended</source>
+        <translation>Recommandé</translation>
+    </message>
+</context>
+<context>
+    <name>PageSetupWizardApiTrialEmail</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardApiTrialEmail.qml" line="65"/>
+        <source>Create an account</source>
+        <translation>Créer un compte</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardApiTrialEmail.qml" line="66"/>
+        <source>To manage your subscription</source>
+        <translation>Pour gérer votre abonnement</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardApiTrialEmail.qml" line="77"/>
+        <location filename="../ui/qml/Pages2/PageSetupWizardApiTrialEmail.qml" line="78"/>
+        <source>Email</source>
+        <translation>E-mail</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardApiTrialEmail.qml" line="102"/>
+        <source>We will create an account for your trial subscription and send important subscription updates to this email address</source>
+        <translation>Nous créerons un compte pour votre abonnement d'essai et enverrons les informations importantes le concernant à cette adresse e-mail</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardApiTrialEmail.qml" line="118"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardApiTrialEmail.qml" line="126"/>
+        <source>Enter a valid email address</source>
+        <translation>Saisissez une adresse e-mail valide</translation>
+    </message>
+</context>
+<context>
+    <name>PageSetupWizardConfigSource</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="50"/>
+        <source>Connection</source>
+        <translation>Connexion</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="77"/>
+        <source>Settings</source>
+        <translation>Paramètres</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="87"/>
+        <source>Enable logs</source>
+        <translation>Activer les journaux</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="101"/>
+        <source>Export client logs</source>
+        <translation>Exporter les journaux du client</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="111"/>
+        <source>Save</source>
+        <translation>Enregistrer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="112"/>
+        <source>Logs files (*.log)</source>
+        <translation>Fichiers journaux (*.log)</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="121"/>
+        <source>Logs file saved</source>
+        <translation>Fichier de journaux enregistré</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="131"/>
+        <source>Support tag</source>
+        <translation>Tag d'assistance</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="142"/>
+        <source>Copied</source>
+        <translation>Copié</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="161"/>
+        <source>Insert the key, add a configuration file or scan the QR-code</source>
+        <translation>Insérez la clé, ajoutez un fichier de configuration ou scannez le QR code</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="171"/>
+        <source>Insert key</source>
+        <translation>Insérer la clé</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="172"/>
+        <source>Insert</source>
+        <translation>Insérer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="190"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="207"/>
+        <source>Other connection options</source>
+        <translation>Autres options de connexion</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="228"/>
+        <source>Recommended</source>
+        <translation>Recommandé</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="260"/>
+        <source>Site Amnezia</source>
+        <translation>Site Amnezia</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="284"/>
+        <source>VPN by Amnezia</source>
+        <translation>VPN par Amnezia</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="285"/>
+        <source>The easiest way to connect to the VPN</source>
+        <translation>Le moyen le plus simple de se connecter au VPN</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="303"/>
+        <source>Self-hosted VPN</source>
+        <translation>VPN auto-hébergé</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="304"/>
+        <source>Configure Amnezia VPN on your own server</source>
+        <translation>Configurer Amnezia VPN sur votre propre serveur</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="316"/>
+        <source>Restore from backup</source>
+        <translation>Restaurer depuis une sauvegarde</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="324"/>
+        <source>Open backup file</source>
+        <translation>Ouvrir un fichier de sauvegarde</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="325"/>
+        <source>Backup files (*.backup)</source>
+        <translation>Fichiers de sauvegarde (*.backup)</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="342"/>
+        <source>File with connection settings</source>
+        <translation>Fichier contenant les paramètres de connexion</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="348"/>
+        <source>Open config file</source>
+        <translation>Ouvrir un fichier de configuration</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="361"/>
+        <source>QR code</source>
+        <translation>QR code</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="377"/>
+        <source>Restore purchases</source>
+        <translation>Restaurer les achats</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardConfigSource.qml" line="392"/>
+        <source>I have nothing</source>
+        <translation>Je n'ai rien</translation>
+    </message>
+</context>
+<context>
+    <name>PageSetupWizardCredentials</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardCredentials.qml" line="48"/>
+        <source>Configure your server</source>
+        <translation>Configurez votre serveur</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardCredentials.qml" line="82"/>
+        <location filename="../ui/qml/Pages2/PageSetupWizardCredentials.qml" line="94"/>
+        <location filename="../ui/qml/Pages2/PageSetupWizardCredentials.qml" line="224"/>
+        <source>Password or SSH private key</source>
+        <translation>Mot de passe ou clé privée SSH</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardCredentials.qml" line="97"/>
+        <source>SSH key requirements: supported key types are ED25519 and RSA in PEM format. Paste the private key, including the BEGIN/END lines. If your key doesn’t work, generate a compatible one</source>
+        <translation>Exigences pour la clé SSH : les types pris en charge sont ED25519 et RSA au format PEM. Collez la clé privée, y compris les lignes BEGIN/END. Si votre clé ne fonctionne pas, générez-en une compatible</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardCredentials.qml" line="112"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardCredentials.qml" line="144"/>
+        <source>All data you enter will remain strictly confidential and will not be shared or disclosed to the Amnezia or any third parties</source>
+        <translation>Toutes les données que vous saisissez resteront strictement confidentielles et ne seront ni partagées ni divulguées à Amnezia ou à des tiers</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardCredentials.qml" line="155"/>
+        <source>How to run your VPN server</source>
+        <translation>Comment faire fonctionner votre serveur VPN</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardCredentials.qml" line="156"/>
+        <source>Where to get connection data, step-by-step instructions for buying a VPS</source>
+        <translation>Où trouver les données de connexion, instructions pas à pas pour acheter un VPS</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardCredentials.qml" line="176"/>
+        <source>Ip address cannot be empty</source>
+        <translation>L'adresse IP ne peut pas être vide</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardCredentials.qml" line="179"/>
+        <source>Enter the address in the format 255.255.255.255:88</source>
+        <translation>Saisissez l'adresse au format 255.255.255.255:88</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardCredentials.qml" line="184"/>
+        <source>Login cannot be empty</source>
+        <translation>L'identifiant ne peut pas être vide</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardCredentials.qml" line="190"/>
+        <source>Password/private key cannot be empty</source>
+        <translation>Le mot de passe ou la clé privée ne peut pas être vide</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardCredentials.qml" line="206"/>
+        <source>Server IP address [:port]</source>
+        <translation>Adresse IP du serveur [:port]</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardCredentials.qml" line="207"/>
+        <source>255.255.255.255:22</source>
+        <translation>255.255.255.255:22</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardCredentials.qml" line="215"/>
+        <source>SSH Username</source>
+        <translation>Nom d'utilisateur SSH</translation>
+    </message>
+</context>
+<context>
+    <name>PageSetupWizardEasy</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardEasy.qml" line="85"/>
+        <source>Choose Installation Type</source>
+        <translation>Choisissez le type d'installation</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardEasy.qml" line="138"/>
+        <source>Manual</source>
+        <translation>Manuel</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardEasy.qml" line="139"/>
+        <source>Choose a VPN protocol</source>
+        <translation>Choisissez un protocole VPN</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardEasy.qml" line="159"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardEasy.qml" line="200"/>
+        <source>Skip setup</source>
+        <translation>Ignorer la configuration</translation>
+    </message>
+</context>
+<context>
+    <name>PageSetupWizardInstalling</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardInstalling.qml" line="25"/>
+        <location filename="../ui/qml/Pages2/PageSetupWizardInstalling.qml" line="69"/>
+        <source>Usually it takes no more than 5 minutes</source>
+        <translation>Cela prend généralement moins de 5 minutes</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardInstalling.qml" line="57"/>
+        <source>The server has already been added to the application</source>
+        <translation>Le serveur a déjà été ajouté à l'application</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardInstalling.qml" line="63"/>
+        <source>Amnezia has detected that your server is currently </source>
+        <translation>Amnezia a détecté que votre serveur est actuellement </translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardInstalling.qml" line="64"/>
+        <source>busy installing other software. Amnezia installation </source>
+        <translation>occupé à installer d'autres logiciels. L'installation d'Amnezia </translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardInstalling.qml" line="65"/>
+        <source>will pause until the server finishes installing other software</source>
+        <translation>sera suspendue jusqu'à ce que le serveur ait fini d'installer les autres logiciels</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardInstalling.qml" line="104"/>
+        <source>Installing</source>
+        <translation>Installation</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardInstalling.qml" line="150"/>
+        <source>Cancel installation</source>
+        <translation>Annuler l'installation</translation>
+    </message>
+</context>
+<context>
+    <name>PageSetupWizardProtocolSettings</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardProtocolSettings.qml" line="69"/>
+        <source>Installing %1</source>
+        <translation>Installation de %1</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardProtocolSettings.qml" line="88"/>
+        <source>More detailed</source>
+        <translation>Plus de détails</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardProtocolSettings.qml" line="175"/>
+        <source>Close</source>
+        <translation>Fermer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardProtocolSettings.qml" line="193"/>
+        <source>Network protocol</source>
+        <translation>Protocole réseau</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardProtocolSettings.qml" line="214"/>
+        <source>Port</source>
+        <translation>Port</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardProtocolSettings.qml" line="235"/>
+        <source>Install</source>
+        <translation>Installer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardProtocolSettings.qml" line="241"/>
+        <source>The port must be in the range of 1 to 65535</source>
+        <translation>Le port doit être compris entre 1 et 65535</translation>
+    </message>
+</context>
+<context>
+    <name>PageSetupWizardProtocols</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardProtocols.qml" line="78"/>
+        <source>VPN protocol</source>
+        <translation>Protocole VPN</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardProtocols.qml" line="79"/>
+        <source>Choose the one with the highest priority for you. Later, you can install other protocols and additional services, such as DNS proxy and SFTP.</source>
+        <translation>Choisissez celui qui est prioritaire pour vous. Vous pourrez installer d'autres protocoles et services supplémentaires par la suite, comme un proxy DNS et SFTP.</translation>
+    </message>
+</context>
+<context>
+    <name>PageSetupWizardQrReader</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardQrReader.qml" line="38"/>
+        <source>Point the camera at the QR code and hold for a couple of seconds. </source>
+        <translation>Dirigez l'appareil photo vers le QR code et maintenez-le quelques secondes. </translation>
+    </message>
+</context>
+<context>
+    <name>PageSetupWizardStart</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardStart.qml" line="42"/>
+        <source>Let&apos;s get started</source>
+        <translation>C'est parti</translation>
+    </message>
+</context>
+<context>
+    <name>PageSetupWizardTextKey</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardTextKey.qml" line="47"/>
+        <source>Connection key</source>
+        <translation>Clé de connexion</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardTextKey.qml" line="48"/>
+        <source>A line that starts with vpn://...</source>
+        <translation>Une ligne qui commence par vpn://...</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardTextKey.qml" line="66"/>
+        <source>Key</source>
+        <translation>Clé</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardTextKey.qml" line="68"/>
+        <source>Insert</source>
+        <translation>Insérer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardTextKey.qml" line="89"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+</context>
+<context>
+    <name>PageSetupWizardViewConfig</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardViewConfig.qml" line="75"/>
+        <source>New connection</source>
+        <translation>Nouvelle connexion</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardViewConfig.qml" line="115"/>
+        <source>Collapse content</source>
+        <translation>Réduire le contenu</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardViewConfig.qml" line="115"/>
+        <source>Show content</source>
+        <translation>Afficher le contenu</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardViewConfig.qml" line="132"/>
+        <source>Enable WireGuard obfuscation. It may be useful if WireGuard is blocked on your provider.</source>
+        <translation>Activer l'obfuscation WireGuard. Cela peut être utile si WireGuard est bloqué par votre fournisseur.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardViewConfig.qml" line="163"/>
+        <source>Use connection codes only from sources you trust. Codes from public sources may have been created to intercept your data.</source>
+        <translation>N'utilisez que des codes de connexion provenant de sources fiables. Les codes issus de sources publiques peuvent avoir été créés pour intercepter vos données.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageSetupWizardViewConfig.qml" line="207"/>
+        <source>Connect</source>
+        <translation>Se connecter</translation>
+    </message>
+</context>
+<context>
+    <name>PageShare</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="35"/>
+        <source>Config revoked</source>
+        <translation>Configuration révoquée</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="51"/>
+        <source>Save AmneziaVPN config</source>
+        <translation>Enregistrer la configuration AmneziaVPN</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="58"/>
+        <source>Save OpenVPN config</source>
+        <translation>Enregistrer la configuration OpenVPN</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="65"/>
+        <source>Save WireGuard config</source>
+        <translation>Enregistrer la configuration WireGuard</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="72"/>
+        <source>Save AmneziaWG config</source>
+        <translation>Enregistrer la configuration AmneziaWG</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="79"/>
+        <source>Save XRay config</source>
+        <translation>Enregistrer la configuration XRay</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="88"/>
+        <source>Connection to </source>
+        <translation>Connexion à </translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="89"/>
+        <source>File with connection settings to </source>
+        <translation>Fichier contenant les paramètres de connexion à </translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="108"/>
+        <source>For the AmneziaVPN app</source>
+        <translation>Pour l'application AmneziaVPN</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="113"/>
+        <source>OpenVPN native format</source>
+        <translation>Format natif OpenVPN</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="118"/>
+        <source>WireGuard native format</source>
+        <translation>Format natif WireGuard</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="123"/>
+        <source>AmneziaWG native format</source>
+        <translation>Format natif AmneziaWG</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="128"/>
+        <source>XRay native format</source>
+        <translation>Format natif XRay</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="156"/>
+        <source>Share VPN Access</source>
+        <translation>Partager l'accès au VPN</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="190"/>
+        <source>Share full access to the server and VPN</source>
+        <translation>Partager l'accès complet au serveur et au VPN</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="191"/>
+        <source>Use for your own devices, or share with those you trust to manage the server.</source>
+        <translation>À utiliser pour vos propres appareils, ou à partager avec les personnes à qui vous confiez la gestion du serveur.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="198"/>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="541"/>
+        <source>Share</source>
+        <translation>Partager</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="233"/>
+        <source>Connection</source>
+        <translation>Connexion</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="248"/>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="559"/>
+        <source>Users</source>
+        <translation>Utilisateurs</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="271"/>
+        <source>Share VPN access without the ability to manage the server</source>
+        <translation>Partager l'accès au VPN sans possibilité de gérer le serveur</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="282"/>
+        <source>User name</source>
+        <translation>Nom d'utilisateur</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="301"/>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="302"/>
+        <source>Server</source>
+        <translation>Serveur</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="366"/>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="367"/>
+        <source>Protocol</source>
+        <translation>Protocole</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="479"/>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="480"/>
+        <source>Connection format</source>
+        <translation>Format de connexion</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="575"/>
+        <source>Search</source>
+        <translation>Rechercher</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="704"/>
+        <source>Creation date: %1</source>
+        <translation>Date de création : %1</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="716"/>
+        <source>Latest handshake: %1</source>
+        <translation>Dernier handshake : %1</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="728"/>
+        <source>Data received: %1</source>
+        <translation>Données reçues : %1</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="740"/>
+        <source>Data sent: %1</source>
+        <translation>Données envoyées : %1</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="750"/>
+        <source>Allowed IPs: %1</source>
+        <translation>IP autorisées : %1</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="765"/>
+        <source>Rename</source>
+        <translation>Renommer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="790"/>
+        <source>Client name</source>
+        <translation>Nom du client</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="801"/>
+        <source>Save</source>
+        <translation>Enregistrer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="837"/>
+        <source>Revoke</source>
+        <translation>Révoquer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="840"/>
+        <source>Revoke the config for a user - %1?</source>
+        <translation>Révoquer la configuration de l'utilisateur « %1 » ?</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="841"/>
+        <source>The user will no longer be able to connect to your server.</source>
+        <translation>L'utilisateur ne pourra plus se connecter à votre serveur.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="842"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShare.qml" line="843"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+</context>
+<context>
+    <name>PageShareConnection</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShareConnection.qml" line="25"/>
+        <source>Share</source>
+        <translation>Partager</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShareConnection.qml" line="26"/>
+        <source>Copy</source>
+        <translation>Copier</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShareConnection.qml" line="30"/>
+        <source>Save AmneziaVPN config</source>
+        <translation>Enregistrer la configuration AmneziaVPN</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShareConnection.qml" line="150"/>
+        <source>Copy config string</source>
+        <translation>Copier la chaîne de configuration</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShareConnection.qml" line="168"/>
+        <source>Show connection settings</source>
+        <translation>Afficher les paramètres de connexion</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShareConnection.qml" line="189"/>
+        <location filename="../ui/qml/Pages2/PageShareConnection.qml" line="199"/>
+        <source>Copied</source>
+        <translation>Copié</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShareConnection.qml" line="326"/>
+        <source>To read the QR code in the Amnezia app, tap + in the main menu → &apos;QR code&apos;</source>
+        <translation>Pour lire le QR code dans l'application Amnezia, appuyez sur « + » dans le menu principal → « QR code »</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShareConnection.qml" line="342"/>
+        <source>This config is too large for a QR code. Share the file or copy the connection settings instead.</source>
+        <translation>Cette configuration est trop volumineuse pour un QR code. Partagez plutôt le fichier ou copiez les paramètres de connexion.</translation>
+    </message>
+</context>
+<context>
+    <name>PageShareFullAccess</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShareFullAccess.qml" line="57"/>
+        <source>Full access to the server and VPN</source>
+        <translation>Accès complet au serveur et au VPN</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShareFullAccess.qml" line="67"/>
+        <source>We recommend that you use full access to the server only for your own additional devices.
+</source>
+        <translation>Nous vous recommandons de n'utiliser l'accès complet au serveur que pour vos propres appareils supplémentaires.
+</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShareFullAccess.qml" line="68"/>
+        <source>If you share full access with other people, they can remove and add protocols and services to the server, which will cause the VPN to work incorrectly for all users. </source>
+        <translation>Si vous partagez l'accès complet avec d'autres personnes, elles peuvent supprimer et ajouter des protocoles et des services sur le serveur, ce qui fera dysfonctionner le VPN pour tous les utilisateurs. </translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShareFullAccess.qml" line="87"/>
+        <location filename="../ui/qml/Pages2/PageShareFullAccess.qml" line="88"/>
+        <source>Server</source>
+        <translation>Serveur</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShareFullAccess.qml" line="115"/>
+        <source>Accessing </source>
+        <translation>Accès à </translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShareFullAccess.qml" line="116"/>
+        <source>File with accessing settings to </source>
+        <translation>Fichier contenant les paramètres d'accès à </translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShareFullAccess.qml" line="147"/>
+        <source>Share</source>
+        <translation>Partager</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageShareFullAccess.qml" line="155"/>
+        <source>Access error!</source>
+        <translation>Erreur d'accès !</translation>
+    </message>
+</context>
+<context>
+    <name>PageStart</name>
+    <message>
+        <location filename="../ui/qml/Pages2/PageStart.qml" line="207"/>
+        <source>Logging was disabled after 14 days, log files were deleted</source>
+        <translation>La journalisation a été désactivée au bout de 14 jours, les fichiers journaux ont été supprimés</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageStart.qml" line="211"/>
+        <source>Settings restored from backup file</source>
+        <translation>Paramètres restaurés depuis le fichier de sauvegarde</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Pages2/PageStart.qml" line="217"/>
+        <source>Logging is enabled. Note that logs will be automaticallydisabled after 14 days, and all log files will be deleted.</source>
+        <translation>La journalisation est activée. Notez qu'elle sera automatiquement désactivée au bout de 14 jours et que tous les fichiers journaux seront supprimés.</translation>
+    </message>
+</context>
+<context>
+    <name>PopupType</name>
+    <message>
+        <location filename="../ui/qml/Controls2/PopupType.qml" line="101"/>
+        <source>Close</source>
+        <translation>Fermer</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="11"/>
+        <source>No error</source>
+        <translation>Aucune erreur</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="13"/>
+        <source>Function not implemented</source>
+        <translation>Fonction non implémentée</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="14"/>
+        <source>Background service is not running</source>
+        <translation>Le service en arrière-plan n'est pas en cours d'exécution</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="15"/>
+        <source>The selected protocol is not supported on the current platform</source>
+        <translation>Le protocole sélectionné n'est pas pris en charge sur la plateforme actuelle</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="18"/>
+        <source>Server check failed</source>
+        <translation>Échec de la vérification du serveur</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="19"/>
+        <source>Server port already used. Check for another software</source>
+        <translation>Le port du serveur est déjà utilisé. Vérifiez si un autre logiciel l'occupe</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="20"/>
+        <source>Server error: Docker container missing</source>
+        <translation>Erreur serveur : conteneur Docker manquant</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="21"/>
+        <source>Server error: Docker failed</source>
+        <translation>Erreur serveur : échec de Docker</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="22"/>
+        <source>Installation canceled by user</source>
+        <translation>Installation annulée par l'utilisateur</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="23"/>
+        <source>The user is not a member of the sudo group</source>
+        <translation>L'utilisateur n'est pas membre du groupe sudo</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="24"/>
+        <source>Server error: Package manager error</source>
+        <translation>Erreur serveur : erreur du gestionnaire de paquets</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="25"/>
+        <source>The sudo package is not pre-installed on the server</source>
+        <translation>Le paquet sudo n'est pas préinstallé sur le serveur</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="26"/>
+        <source>The server user&apos;s home directory is not accessible</source>
+        <translation>Le répertoire personnel de l'utilisateur du serveur n'est pas accessible</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="27"/>
+        <source>Action not allowed in sudoers</source>
+        <translation>Action non autorisée dans sudoers</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="28"/>
+        <source>The user&apos;s password is required</source>
+        <translation>Le mot de passe de l'utilisateur est requis</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="29"/>
+        <source>Docker error: runc doesn&apos;t work on cgroups v2</source>
+        <translation>Erreur Docker : runc ne fonctionne pas avec cgroups v2</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="30"/>
+        <source>Server error: cgroup mountpoint does not exist</source>
+        <translation>Erreur serveur : le point de montage cgroup n'existe pas</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="31"/>
+        <source>Docker error: The pull rate limit has been reached</source>
+        <translation>Erreur Docker : la limite de téléchargement (pull rate limit) a été atteinte</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="32"/>
+        <source>Server error: Linux kernel is too old</source>
+        <translation>Erreur serveur : le noyau Linux est trop ancien</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="34"/>
+        <source>Server error: invalid or unreadable XRay server configuration</source>
+        <translation>Erreur serveur : configuration du serveur XRay invalide ou illisible</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="37"/>
+        <source>Server error: XRay server has no VLESS clients</source>
+        <translation>Erreur serveur : le serveur XRay n'a aucun client VLESS</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="40"/>
+        <source>Server error: failed to read XRay Reality keys from the server</source>
+        <translation>Erreur serveur : impossible de lire les clés XRay Reality depuis le serveur</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="42"/>
+        <source>Server error: The default container runtime available for installation on this server is not supported.
+ Install Docker Engine on the server manually and try again.</source>
+        <translation>Erreur serveur : le moteur de conteneurs disponible par défaut sur ce serveur n'est pas pris en charge.
+ Installez Docker Engine manuellement sur le serveur, puis réessayez.</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="43"/>
+        <source>Container runtime error: The container runtime service is not running.
+ Check the container runtime service on the server, or wait about a minute and try again.</source>
+        <translation>Erreur du moteur de conteneurs : le service du moteur de conteneurs n'est pas en cours d'exécution.
+ Vérifiez ce service sur le serveur, ou patientez environ une minute et réessayez.</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="46"/>
+        <source>SSH request was denied</source>
+        <translation>La requête SSH a été refusée</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="47"/>
+        <source>SSH request was interrupted</source>
+        <translation>La requête SSH a été interrompue</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="48"/>
+        <source>SSH internal error</source>
+        <translation>Erreur interne SSH</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="49"/>
+        <source>Invalid private key or invalid passphrase entered</source>
+        <translation>Clé privée invalide ou phrase secrète saisie incorrecte</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="50"/>
+        <source>The selected private key format is not supported, use openssh ED25519 key types or PEM key types</source>
+        <translation>Le format de clé privée sélectionné n'est pas pris en charge, utilisez une clé openssh ED25519 ou une clé au format PEM</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="51"/>
+        <source>Timeout connecting to server</source>
+        <translation>Délai de connexion au serveur dépassé</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="54"/>
+        <source>SCP error: Generic failure</source>
+        <translation>Erreur SCP : échec générique</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="70"/>
+        <source>The config does not contain any containers and credentials for connecting to the server</source>
+        <translation>La configuration ne contient aucun conteneur ni aucune information d'identification pour se connecter au serveur</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="71"/>
+        <source>Backup files cannot be imported here. Use &apos;Restore from backup&apos; instead.</source>
+        <translation>Les fichiers de sauvegarde ne peuvent pas être importés ici. Utilisez plutôt « Restaurer depuis une sauvegarde ».</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="72"/>
+        <source>Backup file is corrupted or has invalid format</source>
+        <translation>Le fichier de sauvegarde est corrompu ou son format est invalide</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="73"/>
+        <source>This legacy Amnezia subscription format is no longer supported</source>
+        <translation>Cet ancien format d'abonnement Amnezia n'est plus pris en charge</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="74"/>
+        <source>This protocol is no longer supported. Please select another protocol or remove this container from the server settings.</source>
+        <translation>Ce protocole n'est plus pris en charge. Veuillez sélectionner un autre protocole ou supprimer ce conteneur dans les paramètres du serveur.</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="76"/>
+        <source>VPN Protocols is not installed.
+ Please install VPN container at first</source>
+        <translation>Aucun protocole VPN n'est installé.
+ Veuillez d'abord installer un conteneur VPN</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="82"/>
+        <location filename="../core/utils/errorStrings.cpp" line="91"/>
+        <source>Error when retrieving configuration from API</source>
+        <translation>Erreur lors de la récupération de la configuration depuis l'API</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="83"/>
+        <source>This config has already been added to the application</source>
+        <translation>Cette configuration a déjà été ajoutée à l'application</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="92"/>
+        <source>Please update the application to use this feature</source>
+        <translation>Veuillez mettre à jour l'application pour utiliser cette fonctionnalité</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="93"/>
+        <source>Your Amnezia Premium subscription has expired.
+ Please check your email for renewal instructions.
+ If you haven&apos;t received an email, please contact our support.</source>
+        <translation>Votre abonnement Amnezia Premium a expiré.
+ Veuillez consulter votre boîte mail pour les instructions de renouvellement.
+ Si vous n'avez reçu aucun e-mail, contactez notre support.</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="94"/>
+        <source>Unable to process purchase</source>
+        <translation>Impossible de traiter l'achat</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="95"/>
+        <source>No active subscription found</source>
+        <translation>Aucun abonnement actif trouvé</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="96"/>
+        <source>No purchased subscriptions found. Please purchase a subscription first</source>
+        <translation>Aucun abonnement acheté n'a été trouvé. Veuillez d'abord souscrire un abonnement</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="97"/>
+        <source>This email address has already been used to activate a trial</source>
+        <translation>Cette adresse e-mail a déjà été utilisée pour activer un essai</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="98"/>
+        <source>CAPTCHA verification is required</source>
+        <translation>Une vérification CAPTCHA est requise</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="99"/>
+        <source>CAPTCHA was incorrect. Please try again</source>
+        <translation>Le CAPTCHA était incorrect. Veuillez réessayer</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="100"/>
+        <source>CAPTCHA refreshed. Please try again</source>
+        <translation>CAPTCHA actualisé. Veuillez réessayer</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="101"/>
+        <source>Too many requests. Please try again later</source>
+        <translation>Trop de requêtes. Veuillez réessayer plus tard</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="143"/>
+        <source>ErrorCode: %1. </source>
+        <translation>Code d'erreur : %1. </translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="57"/>
+        <source>OpenVPN config missing</source>
+        <translation>Configuration OpenVPN manquante</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="58"/>
+        <source>OpenVPN management server error</source>
+        <translation>Erreur du serveur de gestion OpenVPN</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="61"/>
+        <source>OpenVPN executable missing</source>
+        <translation>Exécutable OpenVPN manquant</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="62"/>
+        <source>Amnezia helper service error</source>
+        <translation>Erreur du service d'assistance Amnezia</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="63"/>
+        <source>OpenSSL failed</source>
+        <translation>Échec d'OpenSSL</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="66"/>
+        <source>Can&apos;t connect: another VPN connection is active</source>
+        <translation>Connexion impossible : une autre connexion VPN est active</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="67"/>
+        <source>Can&apos;t setup OpenVPN TAP network adapter</source>
+        <translation>Impossible de configurer l'adaptateur réseau TAP d'OpenVPN</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="68"/>
+        <source>VPN pool error: no available addresses</source>
+        <translation>Erreur du pool VPN : aucune adresse disponible</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="75"/>
+        <source>Unable to open config file</source>
+        <translation>Impossible d'ouvrir le fichier de configuration</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="79"/>
+        <source>VPN connection error</source>
+        <translation>Erreur de connexion VPN</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="84"/>
+        <source>In the response from the server, an empty config was received</source>
+        <translation>Une configuration vide a été reçue dans la réponse du serveur</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="85"/>
+        <source>SSL error occurred</source>
+        <translation>Une erreur SSL s'est produite</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="86"/>
+        <source>Server response timeout on api request</source>
+        <translation>Délai de réponse du serveur dépassé lors de la requête API</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="87"/>
+        <source>Missing AGW public key</source>
+        <translation>Clé publique AGW manquante</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="88"/>
+        <source>Failed to decrypt response payload</source>
+        <translation>Échec du déchiffrement du contenu de la réponse</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="89"/>
+        <source>Missing list of available services</source>
+        <translation>Liste des services disponibles manquante</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="90"/>
+        <source>The limit of allowed configurations per subscription has been exceeded</source>
+        <translation>La limite de configurations autorisées par abonnement a été dépassée</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="104"/>
+        <source>Your payment is pending confirmation in Google Play. Once the payment is completed, the subscription will be added automatically on the next app launch.</source>
+        <translation>Votre paiement est en attente de confirmation dans Google Play. Une fois le paiement terminé, l'abonnement sera ajouté automatiquement au prochain lancement de l'application.</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="106"/>
+        <source>Your payment is awaiting confirmation. Once it is approved, the subscription will be added automatically.</source>
+        <translation>Votre paiement est en attente de confirmation. Une fois approuvé, l'abonnement sera ajouté automatiquement.</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="108"/>
+        <source>Your payment is pending confirmation. Please complete the payment and then restore your subscription.</source>
+        <translation>Votre paiement est en attente de confirmation. Veuillez finaliser le paiement, puis restaurer votre abonnement.</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="113"/>
+        <source>No purchases to restore. If you have an active subscription, make sure you&apos;re signed in with the same Google account used for the purchase.</source>
+        <translation>Aucun achat à restaurer. Si vous avez un abonnement actif, vérifiez que vous êtes connecté avec le compte Google utilisé pour l'achat.</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="115"/>
+        <source>No purchases to restore. If you have an active subscription, make sure you&apos;re signed in with the same Apple ID used for the purchase.</source>
+        <translation>Aucun achat à restaurer. Si vous avez un abonnement actif, vérifiez que vous êtes connecté avec l'identifiant Apple utilisé pour l'achat.</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="117"/>
+        <source>No purchases to restore. If you have an active subscription, make sure you&apos;re signed in with the same account used for the purchase.</source>
+        <translation>Aucun achat à restaurer. Si vous avez un abonnement actif, vérifiez que vous êtes connecté avec le compte utilisé pour l'achat.</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="122"/>
+        <source>QFile error: The file could not be opened</source>
+        <translation>Erreur QFile : impossible d'ouvrir le fichier</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="123"/>
+        <source>QFile error: An error occurred when reading from the file</source>
+        <translation>Erreur QFile : une erreur s'est produite lors de la lecture du fichier</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="124"/>
+        <source>QFile error: The file could not be accessed</source>
+        <translation>Erreur QFile : impossible d'accéder au fichier</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="125"/>
+        <source>QFile error: An unspecified error occurred</source>
+        <translation>Erreur QFile : une erreur non spécifiée s'est produite</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="126"/>
+        <source>QFile error: A fatal error occurred</source>
+        <translation>Erreur QFile : une erreur fatale s'est produite</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="127"/>
+        <source>QFile error: The operation was aborted</source>
+        <translation>Erreur QFile : l'opération a été interrompue</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="130"/>
+        <source>Transaction was canceled by the user</source>
+        <translation>La transaction a été annulée par l'utilisateur</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="131"/>
+        <source>Billing error</source>
+        <translation>Erreur de facturation</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="132"/>
+        <source>Internal Google Play error, please try again later</source>
+        <translation>Erreur interne de Google Play, veuillez réessayer plus tard</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="133"/>
+        <source>Billing is unavailable, please try again later</source>
+        <translation>La facturation est indisponible, veuillez réessayer plus tard</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="134"/>
+        <source>You already own this subscription</source>
+        <translation>Vous possédez déjà cet abonnement</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="135"/>
+        <source>The requested subscription is not available for purchase</source>
+        <translation>L'abonnement demandé n'est pas disponible à l'achat</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="136"/>
+        <source>A network error occurred during the operation, please check the Internet connection</source>
+        <translation>Une erreur réseau s'est produite pendant l'opération, veuillez vérifier votre connexion Internet</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="140"/>
+        <source>Internal error</source>
+        <translation>Erreur interne</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/containers/containerUtils.cpp" line="73"/>
+        <source>IPsec</source>
+        <translation>IPsec</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/containers/containerUtils.cpp" line="80"/>
+        <location filename="../core/protocols/protocolUtils.cpp" line="72"/>
+        <source>MTProxy (Telegram)</source>
+        <translation>MTProxy (Telegram)</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/containers/containerUtils.cpp" line="81"/>
+        <location filename="../core/protocols/protocolUtils.cpp" line="73"/>
+        <source>Telemt (Telegram)</source>
+        <translation>Telemt (Telegram)</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/containers/containerUtils.cpp" line="91"/>
+        <location filename="../core/utils/containers/containerUtils.cpp" line="93"/>
+        <source>This protocol is no longer supported.</source>
+        <translation>Ce protocole n'est plus pris en charge.</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/containers/containerUtils.cpp" line="107"/>
+        <source>IKEv2/IPsec -  Modern stable protocol, a bit faster than others, restores connection after signal loss. It has native support on the latest versions of Android and iOS.</source>
+        <translation>IKEv2/IPsec - Protocole moderne et stable, un peu plus rapide que les autres, il rétablit la connexion après une perte de signal. Il est pris en charge nativement par les dernières versions d'Android et d'iOS.</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/containers/containerUtils.cpp" line="114"/>
+        <source>Create a file vault on your server to securely store and transfer files.</source>
+        <translation>Créez un coffre-fort de fichiers sur votre serveur pour stocker et transférer des fichiers en toute sécurité.</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/containers/containerUtils.cpp" line="117"/>
+        <source>Telegram MTProto proxy server</source>
+        <translation>Serveur proxy MTProto pour Telegram</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/containers/containerUtils.cpp" line="119"/>
+        <source>Telegram MTProto proxy (Telemt, Rust)</source>
+        <translation>Proxy MTProto Telegram (Telemt, Rust)</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/containers/containerUtils.cpp" line="184"/>
+        <source>DNS Service</source>
+        <translation>Service DNS</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/containers/containerUtils.cpp" line="192"/>
+        <source>Telegram MTProto proxy server. Allows Telegram clients to connect through your server using the MTProto protocol. Supports FakeTLS mode for bypassing DPI-based blocking.</source>
+        <translation>Serveur proxy MTProto pour Telegram. Permet aux clients Telegram de se connecter via votre serveur en utilisant le protocole MTProto. Prend en charge le mode FakeTLS pour contourner le blocage par DPI.</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/containers/containerUtils.cpp" line="197"/>
+        <source>Telegram MTProto proxy powered by Telemt (Rust). Supports secure and TLS fronting modes with optional traffic masking.</source>
+        <translation>Proxy MTProto Telegram propulsé par Telemt (Rust). Prend en charge les modes sécurisé et TLS fronting, avec masquage du trafic en option.</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/containers/containerUtils.cpp" line="329"/>
+        <source>Automatic</source>
+        <translation>Automatique</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/containers/containerUtils.cpp" line="337"/>
+        <source>AmneziaWG protocol will be installed. It provides high connection speed and ensures stable operation even in the most challenging network conditions.</source>
+        <translation>Le protocole AmneziaWG sera installé. Il offre une vitesse de connexion élevée et garantit un fonctionnement stable même dans les conditions réseau les plus difficiles.</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/containers/containerUtils.cpp" line="78"/>
+        <source>SFTP file sharing service</source>
+        <translation>Service de partage de fichiers SFTP</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/containers/containerUtils.cpp" line="76"/>
+        <location filename="../core/utils/containers/containerUtils.cpp" line="183"/>
+        <source>Website in Tor network</source>
+        <translation>Site web sur le réseau Tor</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/containers/containerUtils.cpp" line="77"/>
+        <source>AmneziaDNS</source>
+        <translation>AmneziaDNS</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/containers/containerUtils.cpp" line="88"/>
+        <source>OpenVPN is the most popular VPN protocol, with flexible configuration options. It uses its own security protocol with SSL/TLS for key exchange.</source>
+        <translation>OpenVPN est le protocole VPN le plus répandu, avec des options de configuration flexibles. Il utilise son propre protocole de sécurité avec SSL/TLS pour l'échange de clés.</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/containers/containerUtils.cpp" line="95"/>
+        <source>WireGuard - popular VPN protocol with high performance, high speed and low power consumption.</source>
+        <translation>WireGuard - protocole VPN populaire offrant des performances élevées, une grande vitesse et une faible consommation d'énergie.</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/containers/containerUtils.cpp" line="98"/>
+        <location filename="../core/utils/containers/containerUtils.cpp" line="101"/>
+        <location filename="../ui/models/containersModel.cpp" line="41"/>
+        <source>AmneziaWG is a special protocol from Amnezia based on WireGuard. It provides high connection speed and ensures stable operation even in the most challenging network conditions.</source>
+        <translation>AmneziaWG est un protocole spécifique d'Amnezia basé sur WireGuard. Il offre une vitesse de connexion élevée et garantit un fonctionnement stable même dans les conditions réseau les plus difficiles.</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/containers/containerUtils.cpp" line="104"/>
+        <source>XRay with REALITY masks VPN traffic as web traffic and protects against active probing. It is highly resistant to detection and offers high speed.</source>
+        <translation>XRay avec REALITY masque le trafic VPN en trafic web et protège contre le sondage actif. Il résiste très bien à la détection et offre une vitesse élevée.</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/containers/containerUtils.cpp" line="127"/>
+        <source>OpenVPN is one of the most popular and reliable VPN protocols. It uses SSL/TLS encryption, supports a wide variety of devices and operating systems, and is continuously improved by the community due to its open-source nature. It provides a good balance between speed and security but is easily recognized by DPI systems, making it susceptible to blocking.
+
+Features:
+* Available on all AmneziaVPN platforms
+* Normal battery consumption on mobile devices
+* Flexible customization for various devices and OS
+* Operates over both TCP and UDP protocols</source>
+        <translation>OpenVPN est l'un des protocoles VPN les plus populaires et les plus fiables. Il utilise le chiffrement SSL/TLS, prend en charge une grande variété d'appareils et de systèmes d'exploitation, et est continuellement amélioré par la communauté grâce à sa nature open source. Il offre un bon équilibre entre vitesse et sécurité, mais il est facilement reconnu par les systèmes DPI, ce qui le rend sensible au blocage.
+
+Caractéristiques :
+* Disponible sur toutes les plateformes AmneziaVPN
+* Consommation de batterie normale sur les appareils mobiles
+* Personnalisation souple pour différents appareils et systèmes d'exploitation
+* Fonctionne sur les protocoles TCP et UDP</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/containers/containerUtils.cpp" line="138"/>
+        <source>WireGuard is a modern, streamlined VPN protocol offering stable connectivity and excellent performance across all devices. It uses fixed encryption settings, delivering lower latency and higher data transfer speeds compared to OpenVPN. However, WireGuard is easily identifiable by DPI systems due to its distinctive packet signatures, making it susceptible to blocking.
+
+Features:
+* Available on all AmneziaVPN platforms
+* Low power consumption on mobile devices
+* Minimal configuration required
+* Easily detected by DPI systems (susceptible to blocking)
+* Operates over UDP protocol</source>
+        <translation>WireGuard est un protocole VPN moderne et épuré qui offre une connectivité stable et d'excellentes performances sur tous les appareils. Il utilise des paramètres de chiffrement fixes, ce qui réduit la latence et augmente les débits par rapport à OpenVPN. Cependant, WireGuard est facilement identifiable par les systèmes DPI en raison de la signature caractéristique de ses paquets, ce qui le rend sensible au blocage.
+
+Caractéristiques :
+* Disponible sur toutes les plateformes AmneziaVPN
+* Faible consommation d'énergie sur les appareils mobiles
+* Configuration minimale requise
+* Facilement détecté par les systèmes DPI (sensible au blocage)
+* Fonctionne sur le protocole UDP</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/containers/containerUtils.cpp" line="148"/>
+        <source>AmneziaWG is a modern VPN protocol based on WireGuard, combining simplified architecture with high performance across all devices. It addresses WireGuard&apos;s main vulnerability (easy detection by DPI systems) through advanced obfuscation techniques, making VPN traffic indistinguishable from regular internet traffic.
+
+AmneziaWG is an excellent choice for those seeking a fast, stealthy VPN connection.
+
+Features:
+* Available on all AmneziaVPN platforms
+* Low battery consumption on mobile devices
+* Minimal settings required
+* Undetectable by traffic analysis systems (DPI)
+* Operates over UDP protocol</source>
+        <translation>AmneziaWG est un protocole VPN moderne basé sur WireGuard, qui associe une architecture simplifiée à des performances élevées sur tous les appareils. Il corrige la principale faiblesse de WireGuard (sa détection facile par les systèmes DPI) grâce à des techniques d'obfuscation avancées, rendant le trafic VPN indiscernable du trafic Internet ordinaire.
+
+AmneziaWG est un excellent choix pour qui recherche une connexion VPN rapide et discrète.
+
+Caractéristiques :
+* Disponible sur toutes les plateformes AmneziaVPN
+* Faible consommation de batterie sur les appareils mobiles
+* Paramétrage minimal requis
+* Indétectable par les systèmes d'analyse de trafic (DPI)
+* Fonctionne sur le protocole UDP</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/containers/containerUtils.cpp" line="160"/>
+        <source>REALITY is an innovative protocol developed by the creators of XRay, designed specifically to combat high levels of internet censorship. REALITY identifies censorship systems during the TLS handshake, redirecting suspicious traffic seamlessly to legitimate websites like google.com while providing genuine TLS certificates. This allows VPN traffic to blend indistinguishably with regular web traffic without special configuration.
+Unlike older protocols such as VMess, VLESS, and XTLS-Vision, REALITY incorporates an advanced built-in &quot;friend-or-foe&quot; detection mechanism, effectively protecting against DPI and other traffic analysis methods.
+
+Features:
+* Resistant to active probing and DPI detection
+* No special configuration required to disguise traffic
+* Highly effective in heavily censored regions
+* Minimal battery consumption on devices
+* Operates over TCP protocol</source>
+        <translation>REALITY est un protocole innovant développé par les créateurs de XRay, conçu spécifiquement pour lutter contre les niveaux élevés de censure d'Internet. REALITY identifie les systèmes de censure pendant le handshake TLS et redirige de façon transparente le trafic suspect vers des sites légitimes comme google.com, tout en fournissant de véritables certificats TLS. Le trafic VPN se fond ainsi dans le trafic web ordinaire sans configuration particulière.
+Contrairement aux protocoles plus anciens comme VMess, VLESS et XTLS-Vision, REALITY intègre un mécanisme avancé de reconnaissance « ami ou ennemi », qui protège efficacement contre le DPI et les autres méthodes d'analyse de trafic.
+
+Caractéristiques :
+* Résistant au sondage actif et à la détection par DPI
+* Aucune configuration particulière requise pour masquer le trafic
+* Très efficace dans les régions fortement censurées
+* Consommation de batterie minimale sur les appareils
+* Fonctionne sur le protocole TCP</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/containers/containerUtils.cpp" line="173"/>
+        <source>IKEv2, combined with IPSec encryption, is a modern and reliable VPN protocol. It reconnects quickly when switching networks or devices, making it ideal for dynamic network environments. While it provides good security and speed, it&apos;s easily recognized by DPI systems and susceptible to blocking.
+
+Features:
+* Available in AmneziaVPN only on Windows
+* Low battery consumption on mobile devices
+* Minimal configuration required
+* Detectable by DPI analysis systems(easily blocked)
+* Operates over UDP protocol(ports 500 and 4500)</source>
+        <translation>IKEv2, associé au chiffrement IPSec, est un protocole VPN moderne et fiable. Il se reconnecte rapidement lors d'un changement de réseau ou d'appareil, ce qui le rend idéal pour les environnements réseau changeants. Bien qu'il offre une bonne sécurité et de bonnes performances, il est facilement reconnu par les systèmes DPI et sensible au blocage.
+
+Caractéristiques :
+* Disponible dans AmneziaVPN uniquement sous Windows
+* Faible consommation de batterie sur les appareils mobiles
+* Configuration minimale requise
+* Détectable par les systèmes d'analyse DPI (facilement bloqué)
+* Fonctionne sur le protocole UDP (ports 500 et 4500)</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/containers/containerUtils.cpp" line="186"/>
+        <source>After installation, Amnezia will create a
+
+ file storage on your server. You will be able to access it using
+ FileZilla or other SFTP clients, as well as mount the disk on your device to access
+ it directly from your device.
+
+For more detailed information, you can
+ find it in the support section under &quot;Create SFTP file storage.&quot; </source>
+        <translation>Après l'installation, Amnezia créera un
+
+ espace de stockage de fichiers sur votre serveur. Vous pourrez y accéder avec
+ FileZilla ou d'autres clients SFTP, et aussi monter le disque sur votre appareil pour y accéder
+ directement depuis celui-ci.
+
+Pour plus de détails, consultez
+ la section d'assistance, rubrique « Créer un stockage de fichiers SFTP ». </translation>
+    </message>
+    <message>
+        <location filename="../core/utils/containers/containerUtils.cpp" line="110"/>
+        <source>Deploy a WordPress site on the Tor network in two clicks.</source>
+        <translation>Déployez un site WordPress sur le réseau Tor en deux clics.</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/containers/containerUtils.cpp" line="112"/>
+        <source>Replace the current DNS server with your own. This will increase your privacy level.</source>
+        <translation>Remplacez le serveur DNS actuel par le vôtre. Cela augmentera votre niveau de confidentialité.</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/errorStrings.cpp" line="12"/>
+        <source>Unknown error</source>
+        <translation>Erreur inconnue</translation>
+    </message>
+    <message>
+        <location filename="../core/protocols/protocolUtils.cpp" line="70"/>
+        <source>SFTP service</source>
+        <translation>Service SFTP</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/containers/containerUtils.cpp" line="79"/>
+        <location filename="../core/utils/containers/containerUtils.cpp" line="190"/>
+        <location filename="../core/protocols/protocolUtils.cpp" line="71"/>
+        <source>SOCKS5 proxy server</source>
+        <translation>Serveur proxy SOCKS5</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/serialization/vmess_new.cpp" line="57"/>
+        <source>vmess:// url is invalid</source>
+        <translation>L'URL vmess:// est invalide</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/serialization/vmess_new.cpp" line="82"/>
+        <source>Invalid streamSettings protocol: </source>
+        <translation>Protocole streamSettings invalide : </translation>
+    </message>
+    <message>
+        <location filename="../core/utils/serialization/vmess_new.cpp" line="148"/>
+        <source>Unknown transport method: </source>
+        <translation>Méthode de transport inconnue : </translation>
+    </message>
+    <message>
+        <location filename="../core/utils/serialization/vmess.cpp" line="130"/>
+        <source>VMess string should start with &apos;vmess://&apos;</source>
+        <translation>La chaîne VMess doit commencer par « vmess:// »</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/serialization/vmess.cpp" line="137"/>
+        <source>VMess string should be a valid base64 string</source>
+        <translation>La chaîne VMess doit être une chaîne base64 valide</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/serialization/vmess.cpp" line="154"/>
+        <source>JSON should not be empty</source>
+        <translation>Le JSON ne doit pas être vide</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/serialization/vless.cpp" line="45"/>
+        <source>VLESS link should start with vless://</source>
+        <translation>Le lien VLESS doit commencer par vless://</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/serialization/vless.cpp" line="53"/>
+        <source>link parse failed: %1</source>
+        <translation>échec de l'analyse du lien : %1</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/serialization/vless.cpp" line="61"/>
+        <source>empty host</source>
+        <translation>hôte vide</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/serialization/vless.cpp" line="70"/>
+        <source>missing port</source>
+        <translation>port manquant</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/serialization/vless.cpp" line="85"/>
+        <source>missing uuid</source>
+        <translation>uuid manquant</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/serialization/ssd.cpp" line="54"/>
+        <source>Invalid ssd link: json: field %1 must exist</source>
+        <translation>Lien ssd invalide : json : le champ %1 doit exister</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/serialization/ssd.cpp" line="61"/>
+        <source>Invalid ssd link: json: field %1 must be valid port number</source>
+        <translation>Lien ssd invalide : json : le champ %1 doit être un numéro de port valide</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/serialization/ssd.cpp" line="68"/>
+        <source>Invalid ssd link: json: field %1 must be of type &apos;string&apos;</source>
+        <translation>Lien ssd invalide : json : le champ %1 doit être de type « string »</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/serialization/ssd.cpp" line="75"/>
+        <source>Invalid ssd link: json: field %1 must be an array</source>
+        <translation>Lien ssd invalide : json : le champ %1 doit être un tableau</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/serialization/ssd.cpp" line="82"/>
+        <source>Skipping invalid ssd server: server must be an object</source>
+        <translation>Serveur ssd invalide ignoré : le serveur doit être un objet</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/serialization/ssd.cpp" line="88"/>
+        <source>Skipping invalid ssd server: missing required field %1</source>
+        <translation>Serveur ssd invalide ignoré : champ obligatoire %1 manquant</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/serialization/ssd.cpp" line="95"/>
+        <source>Skipping invalid ssd server: field %1 should be of type &apos;string&apos;</source>
+        <translation>Serveur ssd invalide ignoré : le champ %1 doit être de type « string »</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/serialization/ssd.cpp" line="104"/>
+        <source>Invalid ssd link: should begin with ssd://</source>
+        <translation>Lien ssd invalide : il doit commencer par ssd://</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/serialization/ssd.cpp" line="114"/>
+        <source>Invalid ssd link: base64 parse failed</source>
+        <translation>Lien ssd invalide : échec de l'analyse base64</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/serialization/ssd.cpp" line="121"/>
+        <source>Invalid ssd link: json parse failed</source>
+        <translation>Lien ssd invalide : échec de l'analyse json</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/serialization/ssd.cpp" line="144"/>
+        <source>Invalid ssd link: rc4-md5 encryption is not supported by v2ray-core</source>
+        <translation>Lien ssd invalide : le chiffrement rc4-md5 n'est pas pris en charge par v2ray-core</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/serialization/ss.cpp" line="51"/>
+        <source>SS URI is too short</source>
+        <translation>L'URI SS est trop courte</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/serialization/ss.cpp" line="74"/>
+        <location filename="../core/utils/serialization/ss.cpp" line="109"/>
+        <source>Can&apos;t find the colon separator between method and password</source>
+        <translation>Impossible de trouver le séparateur « : » entre la méthode et le mot de passe</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/serialization/ss.cpp" line="83"/>
+        <source>Can&apos;t find the at separator between password and hostname</source>
+        <translation>Impossible de trouver le séparateur « @ » entre le mot de passe et le nom d'hôte</translation>
+    </message>
+    <message>
+        <location filename="../core/utils/serialization/ss.cpp" line="92"/>
+        <source>Can&apos;t find the colon separator between hostname and port</source>
+        <translation>Impossible de trouver le séparateur « : » entre le nom d'hôte et le port</translation>
+    </message>
+    <message>
+        <location filename="../core/models/protocols/awgProtocolConfig.cpp" line="436"/>
+        <source> (version 3.1)</source>
+        <translation> (version 3.1)</translation>
+    </message>
+    <message>
+        <location filename="../core/models/protocols/awgProtocolConfig.cpp" line="437"/>
+        <source> (version 2)</source>
+        <translation> (version 2)</translation>
+    </message>
+    <message>
+        <location filename="../core/models/protocols/awgProtocolConfig.cpp" line="438"/>
+        <source> (version 1.5)</source>
+        <translation> (version 1.5)</translation>
+    </message>
+</context>
+<context>
+    <name>RenameServerDrawer</name>
+    <message>
+        <location filename="../ui/qml/Components/RenameServerDrawer.qml" line="30"/>
+        <source>Server name</source>
+        <translation>Nom du serveur</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Components/RenameServerDrawer.qml" line="41"/>
+        <source>Save</source>
+        <translation>Enregistrer</translation>
+    </message>
+</context>
+<context>
+    <name>SecureServersRepository</name>
+    <message>
+        <location filename="../core/repositories/secureServersRepository.cpp" line="212"/>
+        <source>Server</source>
+        <translation>Serveur</translation>
+    </message>
+</context>
+<context>
+    <name>SelectLanguageDrawer</name>
+    <message>
+        <location filename="../ui/qml/Components/SelectLanguageDrawer.qml" line="48"/>
+        <source>Choose language</source>
+        <translation>Choisir la langue</translation>
+    </message>
+</context>
+<context>
+    <name>ServersListView</name>
+    <message>
+        <location filename="../ui/qml/Components/ServersListView.qml" line="70"/>
+        <source>Subscription expired. Please renew</source>
+        <translation>Abonnement expiré. Veuillez le renouveler</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Components/ServersListView.qml" line="70"/>
+        <source>Subscription expiring soon</source>
+        <translation>Abonnement bientôt expiré</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Components/ServersListView.qml" line="83"/>
+        <source>Unable change server while there is an active connection</source>
+        <translation>Impossible de changer de serveur tant qu'une connexion est active</translation>
+    </message>
+</context>
+<context>
+    <name>ServersUiController</name>
+    <message>
+        <location filename="../ui/controllers/serversUiController.cpp" line="99"/>
+        <source>Legacy API v1 configs are no longer supported. Remove this server to continue.</source>
+        <translation>Les anciennes configurations de l'API v1 ne sont plus prises en charge. Supprimez ce serveur pour continuer.</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/serversUiController.cpp" line="100"/>
+        <source>Use the remove action to delete this legacy config.</source>
+        <translation>Utilisez l'action de suppression pour effacer cette ancienne configuration.</translation>
+    </message>
+</context>
+<context>
+    <name>ServicesCatalogController</name>
+    <message>
+        <location filename="../core/controllers/api/servicesCatalogController.cpp" line="258"/>
+        <source>%1/mo</source>
+        <comment>IAP: price per month in plan subtitle</comment>
+        <translation>%1/mois</translation>
+    </message>
+    <message>
+        <location filename="../core/controllers/api/servicesCatalogController.cpp" line="278"/>
+        <source>from %1 per month</source>
+        <comment>IAP: card footer minimum monthly price from StoreKit</comment>
+        <translation>à partir de %1 par mois</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsUiController</name>
+    <message>
+        <location filename="../ui/controllers/settingsUiController.cpp" line="183"/>
+        <source>All settings have been reset to default values</source>
+        <translation>Tous les paramètres ont été réinitialisés à leurs valeurs par défaut</translation>
+    </message>
+</context>
+<context>
+    <name>SubscriptionExpiredDrawer</name>
+    <message>
+        <location filename="../ui/qml/Components/SubscriptionExpiredDrawer.qml" line="46"/>
+        <source> subscription has expired</source>
+        <translation> abonnement a expiré</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Components/SubscriptionExpiredDrawer.qml" line="59"/>
+        <source>Renew to continue using VPN</source>
+        <translation>Renouvelez pour continuer à utiliser le VPN</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Components/SubscriptionExpiredDrawer.qml" line="71"/>
+        <source>Renew</source>
+        <translation>Renouveler</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/Components/SubscriptionExpiredDrawer.qml" line="95"/>
+        <source>Support</source>
+        <translation>Assistance</translation>
+    </message>
+</context>
+<context>
+    <name>SubscriptionUiController</name>
+    <message>
+        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="241"/>
+        <source>Your subscription has been upgraded</source>
+        <translation>Votre abonnement a été mis à niveau</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="242"/>
+        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="282"/>
+        <source>This subscription has already been added</source>
+        <translation>Cet abonnement a déjà été ajouté</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="254"/>
+        <source>%1 has been added to the app</source>
+        <translation>%1 a été ajouté à l'application</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="289"/>
+        <source>Subscription restored successfully</source>
+        <translation>Abonnement restauré avec succès</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="343"/>
+        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="379"/>
+        <source>Purchase confirmed. Subscription has been added to the app</source>
+        <translation>Achat confirmé. L'abonnement a été ajouté à l'application</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="435"/>
+        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="488"/>
+        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="611"/>
+        <source>%1 installed successfully.</source>
+        <translation>%1 installé avec succès.</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="450"/>
+        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="496"/>
+        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="523"/>
+        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="554"/>
+        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="582"/>
+        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="646"/>
+        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="739"/>
+        <source>Enter the digits from the image to continue</source>
+        <translation>Saisissez les chiffres de l'image pour continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="604"/>
+        <source>This email address has already been used to activate a trial. Like the service? Upgrade to Premium</source>
+        <translation>Cette adresse e-mail a déjà été utilisée pour activer un essai. Le service vous plaît ? Passez à Premium</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="664"/>
+        <source>API config reloaded</source>
+        <translation>Configuration API rechargée</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="668"/>
+        <source>Successfully changed the country of connection to %1</source>
+        <translation>Le pays de connexion a bien été changé pour %1</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="783"/>
+        <source>API config removed</source>
+        <translation>Configuration API supprimée</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/api/subscriptionUiController.cpp" line="792"/>
+        <source>Server &apos;%1&apos; was removed</source>
+        <translation>Le serveur « %1 » a été supprimé</translation>
+    </message>
+</context>
+<context>
+    <name>SystemTrayNotificationHandler</name>
+    <message>
+        <location filename="../ui/utils/systemTrayNotificationHandler.cpp" line="26"/>
+        <location filename="../ui/utils/systemTrayNotificationHandler.cpp" line="75"/>
+        <source>Show</source>
+        <translation>Afficher</translation>
+    </message>
+    <message>
+        <location filename="../ui/utils/systemTrayNotificationHandler.cpp" line="30"/>
+        <location filename="../ui/utils/systemTrayNotificationHandler.cpp" line="76"/>
+        <source>Connect</source>
+        <translation>Se connecter</translation>
+    </message>
+    <message>
+        <location filename="../ui/utils/systemTrayNotificationHandler.cpp" line="31"/>
+        <location filename="../ui/utils/systemTrayNotificationHandler.cpp" line="77"/>
+        <source>Disconnect</source>
+        <translation>Se déconnecter</translation>
+    </message>
+    <message>
+        <location filename="../ui/utils/systemTrayNotificationHandler.cpp" line="35"/>
+        <location filename="../ui/utils/systemTrayNotificationHandler.cpp" line="78"/>
+        <source>Visit Website</source>
+        <translation>Visiter le site web</translation>
+    </message>
+    <message>
+        <location filename="../ui/utils/systemTrayNotificationHandler.cpp" line="41"/>
+        <location filename="../ui/utils/systemTrayNotificationHandler.cpp" line="79"/>
+        <source>Quit</source>
+        <translation>Quitter</translation>
+    </message>
+</context>
+<context>
+    <name>TermsAndPrivacyText</name>
+    <message>
+        <location filename="../ui/qml/Components/TermsAndPrivacyText.qml" line="23"/>
+        <source>By continuing, you agree to the &lt;a href=&quot;%1&quot; style=&quot;color: %3;&quot;&gt;Terms of Use&lt;/a&gt; and &lt;a href=&quot;%2&quot; style=&quot;color: %3;&quot;&gt;Privacy Policy&lt;/a&gt;</source>
+        <translation>En continuant, vous acceptez les &lt;a href=&quot;%1&quot; style=&quot;color: %3;&quot;&gt;conditions d'utilisation&lt;/a&gt; et la &lt;a href=&quot;%2&quot; style=&quot;color: %3;&quot;&gt;politique de confidentialité&lt;/a&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>TextFieldWithHeaderType</name>
+    <message>
+        <location filename="../ui/qml/Controls2/TextFieldWithHeaderType.qml" line="145"/>
+        <source>The field can&apos;t be empty</source>
+        <translation>Le champ ne peut pas être vide</translation>
+    </message>
+</context>
+<context>
+    <name>UpdateUiController</name>
+    <message>
+        <location filename="../ui/controllers/updateUiController.cpp" line="20"/>
+        <source>New version released: %1</source>
+        <translation>Nouvelle version publiée : %1</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/updateUiController.cpp" line="23"/>
+        <source>New version released: %1 (%2)</source>
+        <translation>Nouvelle version publiée : %1 (%2)</translation>
+    </message>
+    <message>
+        <location filename="../ui/controllers/updateUiController.cpp" line="34"/>
+        <source>Failed to load changelog text</source>
+        <translation>Échec du chargement du texte des nouveautés</translation>
+    </message>
+</context>
+<context>
+    <name>VpnConnection</name>
+    <message>
+        <location filename="../vpnConnection.cpp" line="554"/>
+        <source>Mbps</source>
+        <translation>Mbps</translation>
+    </message>
+</context>
+<context>
+    <name>VpnProtocol</name>
+    <message>
+        <location filename="../core/protocols/vpnProtocol.cpp" line="136"/>
+        <source>Unknown</source>
+        <translation>Inconnu</translation>
+    </message>
+    <message>
+        <location filename="../core/protocols/vpnProtocol.cpp" line="137"/>
+        <source>Disconnected</source>
+        <translation>Déconnecté</translation>
+    </message>
+    <message>
+        <location filename="../core/protocols/vpnProtocol.cpp" line="138"/>
+        <source>Preparing</source>
+        <translation>Préparation</translation>
+    </message>
+    <message>
+        <location filename="../core/protocols/vpnProtocol.cpp" line="139"/>
+        <source>Connecting...</source>
+        <translation>Connexion...</translation>
+    </message>
+    <message>
+        <location filename="../core/protocols/vpnProtocol.cpp" line="140"/>
+        <source>Connected</source>
+        <translation>Connecté</translation>
+    </message>
+    <message>
+        <location filename="../core/protocols/vpnProtocol.cpp" line="141"/>
+        <source>Disconnecting...</source>
+        <translation>Déconnexion...</translation>
+    </message>
+    <message>
+        <location filename="../core/protocols/vpnProtocol.cpp" line="142"/>
+        <source>Reconnecting...</source>
+        <translation>Reconnexion...</translation>
+    </message>
+    <message>
+        <location filename="../core/protocols/vpnProtocol.cpp" line="143"/>
+        <source>Error</source>
+        <translation>Erreur</translation>
+    </message>
+</context>
+<context>
+    <name>XrayConfigModel</name>
+    <message>
+        <location filename="../ui/models/protocols/xrayConfigModel.cpp" line="707"/>
+        <source>Port must be in the range of 1 to 65535</source>
+        <translation>Le port doit être compris entre 1 et 65535</translation>
+    </message>
+    <message>
+        <location filename="../ui/models/protocols/xrayConfigModel.cpp" line="713"/>
+        <source>SNI: enter a valid IP address or domain name</source>
+        <translation>SNI : saisissez une adresse IP ou un nom de domaine valide</translation>
+    </message>
+    <message>
+        <location filename="../ui/models/protocols/xrayConfigModel.cpp" line="719"/>
+        <source>Host: enter a valid IP address or domain name</source>
+        <translation>Hôte : saisissez une adresse IP ou un nom de domaine valide</translation>
+    </message>
+    <message>
+        <location filename="../ui/models/protocols/xrayConfigModel.cpp" line="722"/>
+        <source>Path must start with &quot;/&quot;</source>
+        <translation>Le chemin doit commencer par « / »</translation>
+    </message>
+</context>
+<context>
+    <name>XrayConfigSnapshotsModel</name>
+    <message>
+        <location filename="../ui/models/protocols/xrayConfigSnapshotsModel.cpp" line="153"/>
+        <source>Invalid JSON format</source>
+        <translation>Format JSON invalide</translation>
+    </message>
+</context>
+<context>
+    <name>main2</name>
+    <message>
+        <location filename="../ui/qml/main2.qml" line="279"/>
+        <source>Private key passphrase</source>
+        <translation>Phrase secrète de la clé privée</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/main2.qml" line="300"/>
+        <source>Save</source>
+        <translation>Enregistrer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/main2.qml" line="394"/>
+        <source>This subscription format is no longer supported</source>
+        <translation>Ce format d'abonnement n'est plus pris en charge</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/main2.qml" line="395"/>
+        <source>This legacy Amnezia subscription type can no longer be used to connect in this application version.
+Remove the server from the app to continue.</source>
+        <translation>Cet ancien type d'abonnement Amnezia ne peut plus être utilisé pour se connecter dans cette version de l'application.
+Supprimez le serveur de l'application pour continuer.</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/main2.qml" line="396"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/main2.qml" line="397"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../ui/qml/main2.qml" line="401"/>
+        <source>Cannot remove server during active connection</source>
+        <translation>Impossible de supprimer un serveur pendant une connexion active</translation>
+    </message>
+</context>
+</TS>

--- a/client/translations/amneziavpn_fr_FR.ts
+++ b/client/translations/amneziavpn_fr_FR.ts
@@ -3255,8 +3255,8 @@ Créez-en une à partir des paramètres actuels.</translation>
     </message>
     <message>
         <location filename="../ui/qml/Pages2/PageSettingsAbout.qml" line="193"/>
-        <source>https://t.me/amnezia_vpn_en</source>
-        <translation>https://t.me/amnezia_vpn_en</translation>
+        <source>https://telegram.me/amnezia_vpn_en</source>
+        <translation>https://telegram.me/amnezia_vpn_en</translation>
     </message>
     <message>
         <location filename="../ui/qml/Pages2/PageSettingsAbout.qml" line="200"/>

--- a/client/ui/controllers/languageUiController.cpp
+++ b/client/ui/controllers/languageUiController.cpp
@@ -31,6 +31,7 @@ int LanguageUiController::getCurrentLanguageIndex() const
     case QLocale::Hindi: return static_cast<int>(LanguageSettings::AvailableLanguageEnum::Hindi); break;
     case QLocale::Korean: return static_cast<int>(LanguageSettings::AvailableLanguageEnum::Korean); break;
     case QLocale::Spanish: return static_cast<int>(LanguageSettings::AvailableLanguageEnum::Spanish); break;
+    case QLocale::French: return static_cast<int>(LanguageSettings::AvailableLanguageEnum::French); break;
     default: return static_cast<int>(LanguageSettings::AvailableLanguageEnum::English); break;
     }
 }
@@ -65,6 +66,7 @@ LanguageSettings::AvailableLanguageEnum LanguageUiController::getSystemLanguageE
     case QLocale::Korean: return LanguageSettings::AvailableLanguageEnum::Korean;
     case QLocale::English: return LanguageSettings::AvailableLanguageEnum::English;
     case QLocale::Spanish: return LanguageSettings::AvailableLanguageEnum::Spanish;
+    case QLocale::French: return LanguageSettings::AvailableLanguageEnum::French;
     default: return LanguageSettings::AvailableLanguageEnum::English;
     }
 }
@@ -111,6 +113,7 @@ QString LanguageUiController::getLocalLanguageName(const LanguageSettings::Avail
     case LanguageSettings::AvailableLanguageEnum::Hindi: strLanguage = "हिन्दी"; break;
     case LanguageSettings::AvailableLanguageEnum::Korean: strLanguage = "한국어"; break;
     case LanguageSettings::AvailableLanguageEnum::Spanish: strLanguage = "Español"; break;
+    case LanguageSettings::AvailableLanguageEnum::French: strLanguage = "Français"; break;
     default: break;
     }
 
@@ -131,6 +134,7 @@ QLocale LanguageUiController::languageEnumToLocale(const LanguageSettings::Avail
     case LanguageSettings::AvailableLanguageEnum::Hindi: return QLocale::Hindi;
     case LanguageSettings::AvailableLanguageEnum::Korean: return QLocale::Korean;
     case LanguageSettings::AvailableLanguageEnum::Spanish: return QLocale::Spanish;
+    case LanguageSettings::AvailableLanguageEnum::French: return QLocale::French;
     default: return QLocale::English;
     }
 }

--- a/client/ui/models/languageModel.cpp
+++ b/client/ui/models/languageModel.cpp
@@ -50,6 +50,7 @@ QString LanguageModel::getLocalLanguageName(const LanguageSettings::AvailableLan
     case LanguageSettings::AvailableLanguageEnum::Hindi: strLanguage = "हिन्दी"; break;
     case LanguageSettings::AvailableLanguageEnum::Spanish: strLanguage = "Español"; break;
     case LanguageSettings::AvailableLanguageEnum::Korean: strLanguage = "한국어"; break;
+    case LanguageSettings::AvailableLanguageEnum::French: strLanguage = "Français"; break;
     default: break;
     }
 

--- a/client/ui/models/languageModel.h
+++ b/client/ui/models/languageModel.h
@@ -18,7 +18,8 @@ namespace LanguageSettings
         Urdu,
         Hindi,
         Spanish,
-        Korean
+        Korean,
+        French
     };
     Q_ENUM_NS(AvailableLanguageEnum)
 


### PR DESCRIPTION
Adds French as a selectable UI language.

The catalogue covers all 1254 messages, 919 unique source strings, including the three numerus entries with the two French plural forms. Protocol identifiers, cipher and hash names, XRay and MTProxy config keys, documentation paths and contact URLs are left untranslated, matching the convention of the other locale files. Format placeholders and inline HTML markup were checked to match their English sources one for one.

French is registered in AvailableLanguageEnum, mapped to QLocale::French, and the .ts file is added to the translation sources in CMake. There is no French Telegram support channel, so that link keeps the English one.
