### PR TITLE
refactor: single table for language mapping

### DIFF
--- a/client/translations/amneziavpn_ar_EG.ts
+++ b/client/translations/amneziavpn_ar_EG.ts
@@ -5656,7 +5656,7 @@ Create one from the current settings.</source>
     </message>
     <message>
         <location filename="../ui/qml/Pages2/PageStart.qml" line="217"/>
-        <source>Logging is enabled. Note that logs will be automaticallydisabled after 14 days, and all log files will be deleted.</source>
+        <source>Logging is enabled. Note that logs will be automatically disabled after 14 days, and all log files will be deleted.</source>
         <translation>تسجيل السجلات مُشغَّل. لاحظ أنه سيُعطَّل تلقائيًا بعد 14 يومًا، وستُحذف جميع ملفات السجلات.</translation>
     </message>
 </context>

--- a/client/translations/amneziavpn_es_ES.ts
+++ b/client/translations/amneziavpn_es_ES.ts
@@ -5643,7 +5643,7 @@ Cree una a partir de los ajustes actuales.</translation>
     </message>
     <message>
         <location filename="../ui/qml/Pages2/PageStart.qml" line="217"/>
-        <source>Logging is enabled. Note that logs will be automaticallydisabled after 14 days, and all log files will be deleted.</source>
+        <source>Logging is enabled. Note that logs will be automatically disabled after 14 days, and all log files will be deleted.</source>
         <translation>El registro está habilitado. Ten en cuenta que los registros se desactivarán automáticamente después de 14 días y todos los archivos de registro serán eliminados.</translation>
     </message>
 </context>

--- a/client/translations/amneziavpn_fa_IR.ts
+++ b/client/translations/amneziavpn_fa_IR.ts
@@ -5640,7 +5640,7 @@ Create one from the current settings.</source>
     </message>
     <message>
         <location filename="../ui/qml/Pages2/PageStart.qml" line="217"/>
-        <source>Logging is enabled. Note that logs will be automaticallydisabled after 14 days, and all log files will be deleted.</source>
+        <source>Logging is enabled. Note that logs will be automatically disabled after 14 days, and all log files will be deleted.</source>
         <translation>ثبت گزارش فعال است. توجه کنید که پس از 14 روز به‌طور خودکار غیرفعال می‌شود و همه فایل‌های گزارش حذف می‌شوند.</translation>
     </message>
 </context>

--- a/client/translations/amneziavpn_hi_IN.ts
+++ b/client/translations/amneziavpn_hi_IN.ts
@@ -5643,7 +5643,7 @@ Create one from the current settings.</source>
     </message>
     <message>
         <location filename="../ui/qml/Pages2/PageStart.qml" line="217"/>
-        <source>Logging is enabled. Note that logs will be automaticallydisabled after 14 days, and all log files will be deleted.</source>
+        <source>Logging is enabled. Note that logs will be automatically disabled after 14 days, and all log files will be deleted.</source>
         <translation>लॉगिंग सक्षम है। ध्यान दें कि यह 14 दिनों बाद स्वतः बंद हो जाएगी और सभी लॉग फ़ाइलें मिटा दी जाएँगी।</translation>
     </message>
 </context>

--- a/client/translations/amneziavpn_ko_KR.ts
+++ b/client/translations/amneziavpn_ko_KR.ts
@@ -5640,7 +5640,7 @@ Create one from the current settings.</source>
     </message>
     <message>
         <location filename="../ui/qml/Pages2/PageStart.qml" line="217"/>
-        <source>Logging is enabled. Note that logs will be automaticallydisabled after 14 days, and all log files will be deleted.</source>
+        <source>Logging is enabled. Note that logs will be automatically disabled after 14 days, and all log files will be deleted.</source>
         <translation>로깅이 활성화되었습니다. 14일 후 자동으로 비활성화되며 모든 로그 파일이 삭제됩니다.</translation>
     </message>
 </context>

--- a/client/translations/amneziavpn_my_MM.ts
+++ b/client/translations/amneziavpn_my_MM.ts
@@ -5640,7 +5640,7 @@ Create one from the current settings.</source>
     </message>
     <message>
         <location filename="../ui/qml/Pages2/PageStart.qml" line="217"/>
-        <source>Logging is enabled. Note that logs will be automaticallydisabled after 14 days, and all log files will be deleted.</source>
+        <source>Logging is enabled. Note that logs will be automatically disabled after 14 days, and all log files will be deleted.</source>
         <translation>မှတ်တမ်းတင်မှု ဖွင့်ထားပါသည်။ ၁၄ ရက်အကြာတွင် အလိုအလျောက် ပိတ်သွားမည်ဖြစ်ပြီး မှတ်တမ်းဖိုင်အားလုံး ဖျက်မည်ကို သတိပြုပါ။</translation>
     </message>
 </context>

--- a/client/translations/amneziavpn_ru_RU.ts
+++ b/client/translations/amneziavpn_ru_RU.ts
@@ -5647,7 +5647,7 @@ Create one from the current settings.</source>
     </message>
     <message>
         <location filename="../ui/qml/Pages2/PageStart.qml" line="217"/>
-        <source>Logging is enabled. Note that logs will be automaticallydisabled after 14 days, and all log files will be deleted.</source>
+        <source>Logging is enabled. Note that logs will be automatically disabled after 14 days, and all log files will be deleted.</source>
         <translation>Логирование включено. Обратите внимание, что через 14 дней оно будет автоматически отключено, а все файлы логов будут удалены.</translation>
     </message>
 </context>

--- a/client/translations/amneziavpn_uk_UA.ts
+++ b/client/translations/amneziavpn_uk_UA.ts
@@ -5646,7 +5646,7 @@ Create one from the current settings.</source>
     </message>
     <message>
         <location filename="../ui/qml/Pages2/PageStart.qml" line="217"/>
-        <source>Logging is enabled. Note that logs will be automaticallydisabled after 14 days, and all log files will be deleted.</source>
+        <source>Logging is enabled. Note that logs will be automatically disabled after 14 days, and all log files will be deleted.</source>
         <translation>Логування увімкнено. Зверніть увагу: через 14 днів воно автоматично вимкнеться, а всі файли логів буде видалено.</translation>
     </message>
 </context>

--- a/client/translations/amneziavpn_ur_PK.ts
+++ b/client/translations/amneziavpn_ur_PK.ts
@@ -5653,7 +5653,7 @@ Create one from the current settings.</source>
     </message>
     <message>
         <location filename="../ui/qml/Pages2/PageStart.qml" line="217"/>
-        <source>Logging is enabled. Note that logs will be automaticallydisabled after 14 days, and all log files will be deleted.</source>
+        <source>Logging is enabled. Note that logs will be automatically disabled after 14 days, and all log files will be deleted.</source>
         <translation>لاگنگ فعال ہے۔ نوٹ کریں کہ یہ 14 دن بعد خودکار طور پر بند ہو جائے گی اور تمام لاگ فائلیں مٹا دی جائیں گی۔</translation>
     </message>
 </context>

--- a/client/translations/amneziavpn_zh_CN.ts
+++ b/client/translations/amneziavpn_zh_CN.ts
@@ -5640,7 +5640,7 @@ Create one from the current settings.</source>
     </message>
     <message>
         <location filename="../ui/qml/Pages2/PageStart.qml" line="217"/>
-        <source>Logging is enabled. Note that logs will be automaticallydisabled after 14 days, and all log files will be deleted.</source>
+        <source>Logging is enabled. Note that logs will be automatically disabled after 14 days, and all log files will be deleted.</source>
         <translation>日志记录已启用。请注意，14 天后将自动停用，且所有日志文件都会被删除。</translation>
     </message>
 </context>

--- a/client/ui/controllers/languageUiController.cpp
+++ b/client/ui/controllers/languageUiController.cpp
@@ -12,27 +12,13 @@ void LanguageUiController::onAppLanguageChanged(const QLocale &locale)
 
 void LanguageUiController::changeLanguage(const LanguageSettings::AvailableLanguageEnum language)
 {
-    QLocale locale = languageEnumToLocale(language);
+    QLocale locale = LanguageSettings::languageToLocale(language);
     m_settingsController->setAppLanguage(locale);
 }
 
 int LanguageUiController::getCurrentLanguageIndex() const
 {
-    auto locale = m_settingsController->getAppLanguage();
-    switch (locale.language()) {
-    case QLocale::English: return static_cast<int>(LanguageSettings::AvailableLanguageEnum::English); break;
-    case QLocale::Russian: return static_cast<int>(LanguageSettings::AvailableLanguageEnum::Russian); break;
-    case QLocale::Chinese: return static_cast<int>(LanguageSettings::AvailableLanguageEnum::China_cn); break;
-    case QLocale::Ukrainian: return static_cast<int>(LanguageSettings::AvailableLanguageEnum::Ukrainian); break;
-    case QLocale::Persian: return static_cast<int>(LanguageSettings::AvailableLanguageEnum::Persian); break;
-    case QLocale::Arabic: return static_cast<int>(LanguageSettings::AvailableLanguageEnum::Arabic); break;
-    case QLocale::Burmese: return static_cast<int>(LanguageSettings::AvailableLanguageEnum::Burmese); break;
-    case QLocale::Urdu: return static_cast<int>(LanguageSettings::AvailableLanguageEnum::Urdu); break;
-    case QLocale::Hindi: return static_cast<int>(LanguageSettings::AvailableLanguageEnum::Hindi); break;
-    case QLocale::Korean: return static_cast<int>(LanguageSettings::AvailableLanguageEnum::Korean); break;
-    case QLocale::Spanish: return static_cast<int>(LanguageSettings::AvailableLanguageEnum::Spanish); break;
-    default: return static_cast<int>(LanguageSettings::AvailableLanguageEnum::English); break;
-    }
+    return static_cast<int>(LanguageSettings::localeToLanguage(m_settingsController->getAppLanguage()));
 }
 
 int LanguageUiController::getLineHeightAppend() const
@@ -47,26 +33,12 @@ int LanguageUiController::getLineHeightAppend() const
 QString LanguageUiController::getCurrentLanguageName() const
 {
     int index = getCurrentLanguageIndex();
-    return getLocalLanguageName(static_cast<LanguageSettings::AvailableLanguageEnum>(index));
+    return LanguageSettings::nativeLanguageName(static_cast<LanguageSettings::AvailableLanguageEnum>(index));
 }
 
 LanguageSettings::AvailableLanguageEnum LanguageUiController::getSystemLanguageEnum() const
 {
-    QLocale locale = QLocale::system();
-    switch (locale.language()) {
-    case QLocale::Russian: return LanguageSettings::AvailableLanguageEnum::Russian;
-    case QLocale::Chinese: return LanguageSettings::AvailableLanguageEnum::China_cn;
-    case QLocale::Ukrainian: return LanguageSettings::AvailableLanguageEnum::Ukrainian;
-    case QLocale::Persian: return LanguageSettings::AvailableLanguageEnum::Persian;
-    case QLocale::Arabic: return LanguageSettings::AvailableLanguageEnum::Arabic;
-    case QLocale::Burmese: return LanguageSettings::AvailableLanguageEnum::Burmese;
-    case QLocale::Urdu: return LanguageSettings::AvailableLanguageEnum::Urdu;
-    case QLocale::Hindi: return LanguageSettings::AvailableLanguageEnum::Hindi;
-    case QLocale::Korean: return LanguageSettings::AvailableLanguageEnum::Korean;
-    case QLocale::English: return LanguageSettings::AvailableLanguageEnum::English;
-    case QLocale::Spanish: return LanguageSettings::AvailableLanguageEnum::Spanish;
-    default: return LanguageSettings::AvailableLanguageEnum::English;
-    }
+    return LanguageSettings::localeToLanguage(QLocale::system());
 }
 
 QString LanguageUiController::getCurrentSiteUrl(const QString &path) const
@@ -94,43 +66,4 @@ QString LanguageUiController::getCurrentHostUrl(const QString &path) const
         return "https://storage.googleapis.com/amnezia/host" + (path.isEmpty() ? "" : (QString("?m-path=/%1").arg(path)));
     }
     return QString("https://amnezia.host") + (path.isEmpty() ? "" : (QString("/%1").arg(path)));
-}
-
-QString LanguageUiController::getLocalLanguageName(const LanguageSettings::AvailableLanguageEnum language) const
-{
-    QString strLanguage("");
-    switch (language) {
-    case LanguageSettings::AvailableLanguageEnum::English: strLanguage = "English"; break;
-    case LanguageSettings::AvailableLanguageEnum::Russian: strLanguage = "Русский"; break;
-    case LanguageSettings::AvailableLanguageEnum::Ukrainian: strLanguage = "Українська"; break;
-    case LanguageSettings::AvailableLanguageEnum::China_cn: strLanguage = "\347\256\200\344\275\223\344\270\255\346\226\207"; break;
-    case LanguageSettings::AvailableLanguageEnum::Persian: strLanguage = "فارسی"; break;
-    case LanguageSettings::AvailableLanguageEnum::Arabic: strLanguage = "العربية"; break;
-    case LanguageSettings::AvailableLanguageEnum::Burmese: strLanguage = "မြန်မာဘာသာ"; break;
-    case LanguageSettings::AvailableLanguageEnum::Urdu: strLanguage = "اُرْدُوْ"; break;
-    case LanguageSettings::AvailableLanguageEnum::Hindi: strLanguage = "हिन्दी"; break;
-    case LanguageSettings::AvailableLanguageEnum::Korean: strLanguage = "한국어"; break;
-    case LanguageSettings::AvailableLanguageEnum::Spanish: strLanguage = "Español"; break;
-    default: break;
-    }
-
-    return strLanguage;
-}
-
-QLocale LanguageUiController::languageEnumToLocale(const LanguageSettings::AvailableLanguageEnum language) const
-{
-    switch (language) {
-    case LanguageSettings::AvailableLanguageEnum::English: return QLocale::English;
-    case LanguageSettings::AvailableLanguageEnum::Russian: return QLocale::Russian;
-    case LanguageSettings::AvailableLanguageEnum::China_cn: return QLocale::Chinese;
-    case LanguageSettings::AvailableLanguageEnum::Ukrainian: return QLocale::Ukrainian;
-    case LanguageSettings::AvailableLanguageEnum::Persian: return QLocale::Persian;
-    case LanguageSettings::AvailableLanguageEnum::Arabic: return QLocale::Arabic;
-    case LanguageSettings::AvailableLanguageEnum::Burmese: return QLocale::Burmese;
-    case LanguageSettings::AvailableLanguageEnum::Urdu: return QLocale::Urdu;
-    case LanguageSettings::AvailableLanguageEnum::Hindi: return QLocale::Hindi;
-    case LanguageSettings::AvailableLanguageEnum::Korean: return QLocale::Korean;
-    case LanguageSettings::AvailableLanguageEnum::Spanish: return QLocale::Spanish;
-    default: return QLocale::English;
-    }
 }

--- a/client/ui/controllers/languageUiController.h
+++ b/client/ui/controllers/languageUiController.h
@@ -36,9 +36,6 @@ signals:
     void translationsUpdated();
 
 private:
-    QString getLocalLanguageName(const LanguageSettings::AvailableLanguageEnum language) const;
-    QLocale languageEnumToLocale(const LanguageSettings::AvailableLanguageEnum language) const;
-
     SettingsController* m_settingsController;
     LanguageModel* m_languageModel;
 };

--- a/client/ui/models/languageModel.cpp
+++ b/client/ui/models/languageModel.cpp
@@ -2,27 +2,9 @@
 
 namespace LanguageSettings
 {
-    const QVector<LanguageEntry> &availableLanguages()
-    {
-        static const QVector<LanguageEntry> languages {
-            { AvailableLanguageEnum::English, QLocale::English, "English" },
-            { AvailableLanguageEnum::Russian, QLocale::Russian, "Русский" },
-            { AvailableLanguageEnum::China_cn, QLocale::Chinese, "\347\256\200\344\275\223\344\270\255\346\226\207" },
-            { AvailableLanguageEnum::Ukrainian, QLocale::Ukrainian, "Українська" },
-            { AvailableLanguageEnum::Persian, QLocale::Persian, "فارسی" },
-            { AvailableLanguageEnum::Arabic, QLocale::Arabic, "العربية" },
-            { AvailableLanguageEnum::Burmese, QLocale::Burmese, "မြန်မာဘာသာ" },
-            { AvailableLanguageEnum::Urdu, QLocale::Urdu, "اُرْدُوْ" },
-            { AvailableLanguageEnum::Hindi, QLocale::Hindi, "हिन्दी" },
-            { AvailableLanguageEnum::Spanish, QLocale::Spanish, "Español" },
-            { AvailableLanguageEnum::Korean, QLocale::Korean, "한국어" },
-        };
-        return languages;
-    }
-
     AvailableLanguageEnum localeToLanguage(const QLocale &locale)
     {
-        for (const auto &entry : availableLanguages()) {
+        for (const auto &entry : availableLanguages) {
             if (entry.locale == locale.language()) {
                 return entry.language;
             }
@@ -32,7 +14,7 @@ namespace LanguageSettings
 
     QLocale languageToLocale(const AvailableLanguageEnum language)
     {
-        for (const auto &entry : availableLanguages()) {
+        for (const auto &entry : availableLanguages) {
             if (entry.language == language) {
                 return entry.locale;
             }
@@ -42,7 +24,7 @@ namespace LanguageSettings
 
     QString nativeLanguageName(const AvailableLanguageEnum language)
     {
-        for (const auto &entry : availableLanguages()) {
+        for (const auto &entry : availableLanguages) {
             if (entry.language == language) {
                 return QString::fromUtf8(entry.nativeName);
             }
@@ -53,8 +35,7 @@ namespace LanguageSettings
 
 LanguageModel::LanguageModel(QObject *parent) : QAbstractListModel(parent)
 {
-    for (const auto &entry : LanguageSettings::availableLanguages()) {
-        Q_ASSERT(static_cast<int>(entry.language) == m_availableLanguages.size());
+    for (const auto &entry : LanguageSettings::availableLanguages) {
         m_availableLanguages.push_back(
                 LanguageModelData { LanguageSettings::nativeLanguageName(entry.language), entry.language });
     }

--- a/client/ui/models/languageModel.cpp
+++ b/client/ui/models/languageModel.cpp
@@ -1,11 +1,62 @@
 #include "languageModel.h"
 
+namespace LanguageSettings
+{
+    const QVector<LanguageEntry> &availableLanguages()
+    {
+        static const QVector<LanguageEntry> languages {
+            { AvailableLanguageEnum::English, QLocale::English, "English" },
+            { AvailableLanguageEnum::Russian, QLocale::Russian, "Русский" },
+            { AvailableLanguageEnum::China_cn, QLocale::Chinese, "\347\256\200\344\275\223\344\270\255\346\226\207" },
+            { AvailableLanguageEnum::Ukrainian, QLocale::Ukrainian, "Українська" },
+            { AvailableLanguageEnum::Persian, QLocale::Persian, "فارسی" },
+            { AvailableLanguageEnum::Arabic, QLocale::Arabic, "العربية" },
+            { AvailableLanguageEnum::Burmese, QLocale::Burmese, "မြန်မာဘာသာ" },
+            { AvailableLanguageEnum::Urdu, QLocale::Urdu, "اُرْدُوْ" },
+            { AvailableLanguageEnum::Hindi, QLocale::Hindi, "हिन्दी" },
+            { AvailableLanguageEnum::Spanish, QLocale::Spanish, "Español" },
+            { AvailableLanguageEnum::Korean, QLocale::Korean, "한국어" },
+        };
+        return languages;
+    }
+
+    AvailableLanguageEnum localeToLanguage(const QLocale &locale)
+    {
+        for (const auto &entry : availableLanguages()) {
+            if (entry.locale == locale.language()) {
+                return entry.language;
+            }
+        }
+        return AvailableLanguageEnum::English;
+    }
+
+    QLocale languageToLocale(const AvailableLanguageEnum language)
+    {
+        for (const auto &entry : availableLanguages()) {
+            if (entry.language == language) {
+                return entry.locale;
+            }
+        }
+        return QLocale::English;
+    }
+
+    QString nativeLanguageName(const AvailableLanguageEnum language)
+    {
+        for (const auto &entry : availableLanguages()) {
+            if (entry.language == language) {
+                return QString::fromUtf8(entry.nativeName);
+            }
+        }
+        return {};
+    }
+}
+
 LanguageModel::LanguageModel(QObject *parent) : QAbstractListModel(parent)
 {
-    QMetaEnum metaEnum = QMetaEnum::fromType<LanguageSettings::AvailableLanguageEnum>();
-    for (int i = 0; i < metaEnum.keyCount(); i++) {
-        m_availableLanguages.push_back(LanguageModelData { getLocalLanguageName(static_cast<LanguageSettings::AvailableLanguageEnum>(i)),
-                                                           static_cast<LanguageSettings::AvailableLanguageEnum>(i) });
+    for (const auto &entry : LanguageSettings::availableLanguages()) {
+        Q_ASSERT(static_cast<int>(entry.language) == m_availableLanguages.size());
+        m_availableLanguages.push_back(
+                LanguageModelData { LanguageSettings::nativeLanguageName(entry.language), entry.language });
     }
 }
 
@@ -33,25 +84,4 @@ QHash<int, QByteArray> LanguageModel::roleNames() const
     roles[NameRole] = "languageName";
     roles[IndexRole] = "languageIndex";
     return roles;
-}
-
-QString LanguageModel::getLocalLanguageName(const LanguageSettings::AvailableLanguageEnum language)
-{
-    QString strLanguage("");
-    switch (language) {
-    case LanguageSettings::AvailableLanguageEnum::English: strLanguage = "English"; break;
-    case LanguageSettings::AvailableLanguageEnum::Russian: strLanguage = "Русский"; break;
-    case LanguageSettings::AvailableLanguageEnum::Ukrainian: strLanguage = "Українська"; break;
-    case LanguageSettings::AvailableLanguageEnum::China_cn: strLanguage = "\347\256\200\344\275\223\344\270\255\346\226\207"; break;
-    case LanguageSettings::AvailableLanguageEnum::Persian: strLanguage = "فارسی"; break;
-    case LanguageSettings::AvailableLanguageEnum::Arabic: strLanguage = "العربية"; break;
-    case LanguageSettings::AvailableLanguageEnum::Burmese: strLanguage = "မြန်မာဘာသာ"; break;
-    case LanguageSettings::AvailableLanguageEnum::Urdu: strLanguage = "اُرْدُوْ"; break;
-    case LanguageSettings::AvailableLanguageEnum::Hindi: strLanguage = "हिन्दी"; break;
-    case LanguageSettings::AvailableLanguageEnum::Spanish: strLanguage = "Español"; break;
-    case LanguageSettings::AvailableLanguageEnum::Korean: strLanguage = "한국어"; break;
-    default: break;
-    }
-
-    return strLanguage;
 }

--- a/client/ui/models/languageModel.h
+++ b/client/ui/models/languageModel.h
@@ -2,7 +2,9 @@
 #define LANGUAGEMODEL_H
 
 #include <QAbstractListModel>
+#include <QLocale>
 #include <QQmlEngine>
+#include <QVector>
 
 namespace LanguageSettings
 {
@@ -21,6 +23,22 @@ namespace LanguageSettings
         Korean
     };
     Q_ENUM_NS(AvailableLanguageEnum)
+
+    struct LanguageEntry
+    {
+        AvailableLanguageEnum language;
+        QLocale::Language locale;
+        const char *nativeName;
+    };
+
+    // Single source of truth for the supported languages. Entries must stay in
+    // AvailableLanguageEnum order: the model exposes them as rows, and QML selects
+    // a row by the enum value.
+    const QVector<LanguageEntry> &availableLanguages();
+
+    AvailableLanguageEnum localeToLanguage(const QLocale &locale);
+    QLocale languageToLocale(const AvailableLanguageEnum language);
+    QString nativeLanguageName(const AvailableLanguageEnum language);
 
     static void declareQmlAvailableLanguageEnum()
     {
@@ -54,8 +72,6 @@ protected:
     QHash<int, QByteArray> roleNames() const override;
 
 private:
-    QString getLocalLanguageName(const LanguageSettings::AvailableLanguageEnum language);
-
     QVector<LanguageModelData> m_availableLanguages;
 };
 

--- a/client/ui/models/languageModel.h
+++ b/client/ui/models/languageModel.h
@@ -1,6 +1,8 @@
 #ifndef LANGUAGEMODEL_H
 #define LANGUAGEMODEL_H
 
+#include <array>
+
 #include <QAbstractListModel>
 #include <QLocale>
 #include <QQmlEngine>
@@ -31,10 +33,36 @@ namespace LanguageSettings
         const char *nativeName;
     };
 
-    // Single source of truth for the supported languages. Entries must stay in
-    // AvailableLanguageEnum order: the model exposes them as rows, and QML selects
-    // a row by the enum value.
-    const QVector<LanguageEntry> &availableLanguages();
+    // Single source of truth for the supported languages. The order is part of the
+    // contract, not a convention: the model exposes these as rows and QML selects a
+    // row by enum value. The static_assert below turns a wrong order into a build error.
+    inline constexpr std::array<LanguageEntry, 11> availableLanguages { {
+            { AvailableLanguageEnum::English, QLocale::English, "English" },
+            { AvailableLanguageEnum::Russian, QLocale::Russian, "Русский" },
+            { AvailableLanguageEnum::China_cn, QLocale::Chinese, "\347\256\200\344\275\223\344\270\255\346\226\207" },
+            { AvailableLanguageEnum::Ukrainian, QLocale::Ukrainian, "Українська" },
+            { AvailableLanguageEnum::Persian, QLocale::Persian, "فارسی" },
+            { AvailableLanguageEnum::Arabic, QLocale::Arabic, "العربية" },
+            { AvailableLanguageEnum::Burmese, QLocale::Burmese, "မြန်မာဘာသာ" },
+            { AvailableLanguageEnum::Urdu, QLocale::Urdu, "اُرْدُوْ" },
+            { AvailableLanguageEnum::Hindi, QLocale::Hindi, "हिन्दी" },
+            { AvailableLanguageEnum::Spanish, QLocale::Spanish, "Español" },
+            { AvailableLanguageEnum::Korean, QLocale::Korean, "한국어" },
+    } };
+
+    constexpr bool areLanguagesInEnumOrder()
+    {
+        for (std::size_t i = 0; i < availableLanguages.size(); ++i) {
+            if (static_cast<std::size_t>(availableLanguages[i].language) != i) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static_assert(areLanguagesInEnumOrder(),
+                  "availableLanguages must stay in AvailableLanguageEnum order: the model exposes it as rows "
+                  "and QML selects a row by enum value");
 
     AvailableLanguageEnum localeToLanguage(const QLocale &locale);
     QLocale languageToLocale(const AvailableLanguageEnum language);

--- a/client/ui/qml/Pages2/PageStart.qml
+++ b/client/ui/qml/Pages2/PageStart.qml
@@ -214,7 +214,7 @@ PageType {
 
         function onLoggingStateChanged() {
             if (SettingsController.isLoggingEnabled) {
-                var message = qsTr("Logging is enabled. Note that logs will be automatically" +
+                var message = qsTr("Logging is enabled. Note that logs will be automatically " +
                                    "disabled after 14 days, and all log files will be deleted.")
                 PageController.showNotificationMessage(message)
             }


### PR DESCRIPTION
QLocale and AvailableLanguageEnum were mapped by five hand-maintained switch statements, and getLocalLanguageName existed twice, verbatim, in LanguageModel and LanguageUiController. Adding a language meant editing five places and silently getting a half-registered language if one was missed.

They are replaced by a single table in the LanguageSettings namespace plus three lookups. A Q_ASSERT in the model constructor keeps the table in enum order, which QML relies on to select a row by enum value.

Also included: a missing space in the logging notification that rendered as "automaticallydisabled".
