### PR TITLE
fix: flush dns cache instead of restarting the resolver

### DIFF
--- a/client/platforms/linux/daemon/linuxfirewall.cpp
+++ b/client/platforms/linux/daemon/linuxfirewall.cpp
@@ -486,8 +486,6 @@ int LinuxFirewall::execute(const QString &command, bool ignoreErrors)
     auto err = p.readAllStandardError().trimmed();
     if ((exitCode != 0 || !err.isEmpty()) && !ignoreErrors)
         logger.warning()  << "(" << exitCode << ") $ " << command;
-    else if (false)
-        logger.debug() << "(" << exitCode << ") $ " << command;
     if (!out.isEmpty())
         logger.info() << out;
     if (!err.isEmpty())

--- a/service/server/killswitch.cpp
+++ b/service/server/killswitch.cpp
@@ -253,13 +253,13 @@ bool KillSwitch::enablePeerTraffic(const QJsonObject &configStr) {
     }
 
     if (splitTunnelType == 1) {
-        for (auto v : splitTunnelSites) {
-            QString ipRange = v.toString();
-            if (ipRange.split('/').size() > 1) {
+        for (const QJsonValue &v : splitTunnelSites) {
+            const QStringList parts = v.toString().split('/');
+            if (parts.size() > 1) {
                 config.m_allowedIPAddressRanges.append(
-                        IPAddress(QHostAddress(ipRange.split('/')[0]), atoi(ipRange.split('/')[1].toLocal8Bit())));
+                        IPAddress(QHostAddress(parts[0]), atoi(parts[1].toLocal8Bit())));
             } else {
-                config.m_allowedIPAddressRanges.append(IPAddress(QHostAddress(ipRange), 32));
+                config.m_allowedIPAddressRanges.append(IPAddress(QHostAddress(parts[0]), 32));
             }
         }
     }

--- a/service/server/router_linux.cpp
+++ b/service/server/router_linux.cpp
@@ -165,13 +165,15 @@ bool RouterLinux::flushDns()
     QProcess p;
     p.setProcessChannelMode(QProcess::MergedChannels);
 
-    //check what the dns manager use
-    if (isServiceActive("nscd.service")) {
-        qDebug() << "Restarting nscd.service";
-        p.start("systemctl", { "restart", "nscd" });
-    } else if (isServiceActive("systemd-resolved.service")) {
-        qDebug() << "Restarting systemd-resolved.service";
-        p.start("systemctl", { "restart", "systemd-resolved" });
+    // Flush the resolver cache instead of restarting the service. A restart drops the
+    // cache for the whole system and briefly breaks name resolution for every other
+    // process on the machine, which is far more than this needs to do.
+    if (isServiceActive("systemd-resolved.service")) {
+        qDebug() << "Flushing systemd-resolved caches";
+        p.start("resolvectl", { "flush-caches" });
+    } else if (isServiceActive("nscd.service")) {
+        qDebug() << "Invalidating nscd hosts cache";
+        p.start("nscd", { "-i", "hosts" });
     } else {
         qDebug() << "No suitable DNS manager found.";
         return false;
@@ -179,10 +181,15 @@ bool RouterLinux::flushDns()
 
     p.waitForFinished();
     QByteArray output(p.readAll());
+    if (p.error() == QProcess::FailedToStart || p.exitStatus() != QProcess::NormalExit || p.exitCode() != 0) {
+        qDebug().noquote() << "Flush dns failed: " + output;
+        return false;
+    }
+
     if (output.isEmpty())
         qDebug().noquote() << "Flush dns completed";
     else
-        qDebug().noquote() << "OUTPUT systemctl restart nscd/systemd-resolved: " + output;
+        qDebug().noquote() << "OUTPUT flush dns: " + output;
 
     return true;
 }


### PR DESCRIPTION
RouterLinux::flushDns restarts the whole resolver service, and it is called on every connect and every disconnect from VpnConnection. Restarting systemd-resolved drops the DNS cache for the entire machine and briefly breaks name resolution for every other process, which is a lot more than flushing the VPN's stale entries needs to do.

It now calls `resolvectl flush-caches`, which does exactly that job without a restart. It has been available since systemd 239. The nscd branch uses `nscd -i hosts` for the same reason, and systemd-resolved is checked first since it is the resolver in use on current systems.

The result of the command is also checked now. The previous version returned true unconditionally, so the "Failed to flush DNS" branch in the caller was unreachable even when the command failed.

Second commit is unrelated cleanup in the same area: a dead `else if (false)` logging branch in LinuxFirewall::execute, and a loop in killswitch that called `split('/')` three times per entry.
