### PR TITLE
feat: preserve system DNS for desktop WireGuard connections

### DIFF
--- a/client/core/controllers/connectionController.cpp
+++ b/client/core/controllers/connectionController.cpp
@@ -200,8 +200,16 @@ ErrorCode ConnectionController::prepareConnection(const QString &serverId,
         return ErrorCode::InternalError;
     }
 
+    // System DNS preservation is currently implemented by the desktop WG daemon.
+    // Reject unsupported protocols instead of silently replacing the system resolver.
+    if (m_appSettingsRepository->useSystemDns()
+            && !ContainerUtils::isAwgContainer(container) && container != DockerContainer::WireGuard) {
+        return ErrorCode::NotSupportedOnThisPlatform;
+    }
+
     vpnConfiguration = createConnectionConfiguration(dns, isApiConfig, hostName, description, configVersion,
                                                      containerConfigModel, container);
+    vpnConfiguration.insert(configKey::useSystemDns, m_appSettingsRepository->useSystemDns());
 
     return ErrorCode::NoError;
 }

--- a/client/core/controllers/coreSignalHandlers.cpp
+++ b/client/core/controllers/coreSignalHandlers.cpp
@@ -254,6 +254,7 @@ void CoreSignalHandlers::initAutoConnectHandler()
 void CoreSignalHandlers::initAmneziaDnsToggledHandler()
 {
     connect(m_coreController->m_appSettingsRepository, &SecureAppSettingsRepository::useAmneziaDnsChanged, m_coreController->m_serversUiController, &ServersUiController::updateModel);
+    connect(m_coreController->m_appSettingsRepository, &SecureAppSettingsRepository::useSystemDnsChanged, m_coreController->m_serversUiController, &ServersUiController::updateModel);
 }
 
 void CoreSignalHandlers::initServersModelUpdateHandler()

--- a/client/core/controllers/settingsController.cpp
+++ b/client/core/controllers/settingsController.cpp
@@ -40,6 +40,25 @@ SettingsController::SettingsController(SecureServersRepository* serversRepositor
     m_isDevModeEnabled = m_appSettingsRepository->isDevGatewayEnv();
 }
 
+bool SettingsController::isSystemDnsSupported() const
+{
+#if defined(Q_OS_WIN) || (defined(Q_OS_MACOS) && !defined(MACOS_NE))
+    return true;
+#else
+    return false;
+#endif
+}
+
+bool SettingsController::isSystemDnsEnabled() const
+{
+    return m_appSettingsRepository->useSystemDns();
+}
+
+void SettingsController::toggleSystemDns(bool enable)
+{
+    m_appSettingsRepository->setUseSystemDns(isSystemDnsSupported() && enable);
+}
+
 void SettingsController::toggleAmneziaDns(bool enable)
 {
     m_appSettingsRepository->setUseAmneziaDns(enable);

--- a/client/core/controllers/settingsController.h
+++ b/client/core/controllers/settingsController.h
@@ -23,6 +23,10 @@ public:
                                QObject* parent = nullptr);
     ~SettingsController() = default;
 
+    bool isSystemDnsSupported() const;
+    bool isSystemDnsEnabled() const;
+    void toggleSystemDns(bool enable);
+
     void toggleAmneziaDns(bool enable);
     bool isAmneziaDnsEnabled() const;
 

--- a/client/core/repositories/secureAppSettingsRepository.cpp
+++ b/client/core/repositories/secureAppSettingsRepository.cpp
@@ -49,6 +49,21 @@ void SecureAppSettingsRepository::setAppLanguage(QLocale locale)
     emit appLanguageChanged(locale);
 }
 
+bool SecureAppSettingsRepository::useSystemDns() const
+{
+#if defined(Q_OS_WIN) || (defined(Q_OS_MACOS) && !defined(MACOS_NE))
+    return value("Conf/useSystemDns", false).toBool();
+#else
+    return false;
+#endif
+}
+
+void SecureAppSettingsRepository::setUseSystemDns(bool enabled)
+{
+    setValue("Conf/useSystemDns", enabled);
+    emit useSystemDnsChanged(enabled);
+}
+
 bool SecureAppSettingsRepository::useAmneziaDns() const
 {
     return value("Conf/useAmneziaDns", true).toBool();

--- a/client/core/repositories/secureAppSettingsRepository.h
+++ b/client/core/repositories/secureAppSettingsRepository.h
@@ -27,6 +27,9 @@ public:
     QLocale getAppLanguage() const;
     void setAppLanguage(QLocale locale);
 
+    bool useSystemDns() const;
+    void setUseSystemDns(bool enabled);
+
     bool useAmneziaDns() const;
     void setUseAmneziaDns(bool enabled);
     QStringList getAllowedDnsServers() const;
@@ -101,6 +104,7 @@ public:
     void setXraySavedConfigs(const QByteArray &data);
 
 signals:
+    void useSystemDnsChanged(bool enabled);
     void appLanguageChanged(QLocale locale);
     void allowedDnsServersChanged(const QStringList &servers);
     void sitesChanged(RouteMode mode);
@@ -126,4 +130,3 @@ private:
 };
 
 #endif // SECUREAPPSETTINGSREPOSITORY_H
-

--- a/client/core/utils/constants/configKeys.h
+++ b/client/core/utils/constants/configKeys.h
@@ -150,6 +150,7 @@ namespace amnezia
         constexpr QLatin1String splitTunnelApps("splitTunnelApps");
         constexpr QLatin1String appSplitTunnelType("appSplitTunnelType");
 
+        constexpr QLatin1String useSystemDns("useSystemDns");
         constexpr QLatin1String allowedDnsServers("allowedDnsServers");
 
         constexpr QLatin1String killSwitchOption("killSwitchOption");

--- a/client/daemon/daemon.cpp
+++ b/client/daemon/daemon.cpp
@@ -53,7 +53,8 @@ Daemon* Daemon::instance() {
   return s_daemon;
 }
 
-bool Daemon::activate(const InterfaceConfig& config) {
+bool Daemon::activate(const InterfaceConfig& requestedConfig) {
+  InterfaceConfig config = requestedConfig;
   Q_ASSERT(wgutils() != nullptr);
 
   // There are 3 possible scenarios in which this method is called:
@@ -110,7 +111,30 @@ bool Daemon::activate(const InterfaceConfig& config) {
     return false;
   }
 
+  if (config.m_useSystemDns) {
+    config.m_systemDnsServers = dnsutils()->systemResolvers();
+    if (config.m_systemDnsServers.isEmpty()) {
+      logger.error() << "Cannot preserve system DNS: no system resolvers found";
+      return false;
+    }
+    config.m_primaryDnsServer.clear();
+    config.m_secondaryDnsServer.clear();
+    for (const QString& dns : config.m_systemDnsServers) {
+      QHostAddress address(dns);
+      // Firewall address tables match the IP, not an interface scope suffix.
+      address.setScopeId(QString());
+      config.m_allowedDnsServers.append(address.toString());
+    }
+    config.m_allowedDnsServers.removeDuplicates();
+  }
+
   prepareActivation(config);
+
+  auto systemDnsCleanup = qScopeGuard([&] {
+    if (config.m_useSystemDns) {
+      deactivate(false);
+    }
+  });
 
   // Bring up the wireguard interface if not already done.
   if (!wgutils()->interfaceExists()) {
@@ -136,6 +160,19 @@ bool Daemon::activate(const InterfaceConfig& config) {
     addExclusionRoute(IPAddress(i));
   }
 
+  // DNS routes must not become general firewall exclusions: only port 53
+  // is allowed by m_allowedDnsServers. Local resolvers retain their OS routes.
+  for (const QString& dns : config.m_systemDnsServers) {
+    const QHostAddress address(dns);
+    if (address.isLoopback() || address.isLinkLocal()) {
+      continue;
+    }
+    if (!addExclusionRoute(IPAddress(address))) {
+      logger.error() << "Cannot route system DNS outside the tunnel";
+      return false;
+    }
+  }
+
   // Add the peer to this interface.
   if (!wgutils()->updatePeer(config)) {
     logger.error() << "Peer creation failed.";
@@ -159,6 +196,7 @@ bool Daemon::activate(const InterfaceConfig& config) {
   if (status) {
     m_connections[config.m_hopType] = ConnectionState(config);
     m_handshakeTimer.start(HANDSHAKE_POLL_MSEC);
+    systemDnsCleanup.dismiss();
     emit_failure_guard.dismiss();
     return true;
   }
@@ -166,6 +204,9 @@ bool Daemon::activate(const InterfaceConfig& config) {
 }
 
 bool Daemon::maybeUpdateResolvers(const InterfaceConfig& config) {
+  if (config.m_useSystemDns) {
+    return true;
+  }
   if ((config.m_hopType == InterfaceConfig::MultiHopExit) ||
       (config.m_hopType == InterfaceConfig::SingleHop)) {
     QList<QHostAddress> resolvers;
@@ -284,6 +325,14 @@ bool Daemon::parseConfig(const QJsonObject& obj, InterfaceConfig& config) {
   config.m_serverIpv4Gateway = obj.value("serverIpv4Gateway").toString();
   config.m_serverIpv6Gateway = obj.value("serverIpv6Gateway").toString();
 
+  const QJsonValue useSystemDns = obj.value("useSystemDns");
+  if (!useSystemDns.isUndefined() && !useSystemDns.isBool()) {
+    logger.error() << "useSystemDns is not a boolean";
+    return false;
+  }
+  config.m_useSystemDns = useSystemDns.toBool();
+  config.m_systemDnsServers.clear();
+
   if (!obj.contains("primaryDnsServer")) {
     config.m_primaryDnsServer = QString();
   } else {
@@ -389,6 +438,19 @@ bool Daemon::parseConfig(const QJsonObject& obj, InterfaceConfig& config) {
   if (!parseStringList(obj, "allowedDnsServers", config.m_allowedDnsServers)) {
     return false;
   }
+  for (QString& dns : config.m_allowedDnsServers) {
+    QHostAddress address(dns);
+    if (address.isNull() || address.isMulticast() || address.isBroadcast()
+        || address == QHostAddress(QHostAddress::AnyIPv4)
+        || address == QHostAddress(QHostAddress::AnyIPv6)) {
+      logger.error() << "allowedDnsServers must contain unicast IP addresses";
+      return false;
+    }
+    // Only canonical addresses may reach the platform firewall command.
+    address.setScopeId(QString());
+    dns = address.toString();
+  }
+  config.m_allowedDnsServers.removeDuplicates();
 
   config.m_killSwitchEnabled = QVariant(obj.value("killSwitchOption").toString()).toBool();
 
@@ -529,7 +591,10 @@ bool Daemon::supportServerSwitching(const InterfaceConfig& config) const {
   const InterfaceConfig& current =
       m_connections.value(config.m_hopType).m_config;
 
-  return current.m_privateKey == config.m_privateKey &&
+  // A full teardown restores the original resolvers before sampling them
+  // again, and drops DNS exceptions from the previous network or mode.
+  return !current.m_useSystemDns && !config.m_useSystemDns &&
+         current.m_privateKey == config.m_privateKey &&
          current.m_deviceIpv4Address == config.m_deviceIpv4Address &&
          current.m_deviceIpv6Address == config.m_deviceIpv6Address &&
          current.m_serverIpv4Gateway == config.m_serverIpv4Gateway &&

--- a/client/daemon/dnsutils.h
+++ b/client/daemon/dnsutils.h
@@ -25,6 +25,10 @@ class DnsUtils : public QObject {
     return false;
   };
 
+  // Returns the current system resolvers without changing their configuration.
+  // An empty result means this mode cannot be activated safely.
+  virtual QStringList systemResolvers() const { return {}; }
+
   virtual bool restoreResolvers() {
     qFatal("Have you forgotten to implement DnsUtils::restoreResolvers?");
     return false;

--- a/client/daemon/interfaceconfig.cpp
+++ b/client/daemon/interfaceconfig.cpp
@@ -58,6 +58,7 @@ QJsonObject InterfaceConfig::toJson() const {
     jsAllowedDnsServers.append(QJsonValue(i));
   }
   json.insert("allowedDnsServers", jsAllowedDnsServers);
+  json.insert("useSystemDns", m_useSystemDns);
 
   QJsonArray disabledApps;
   for (const QString& i : m_vpnDisabledApps) {
@@ -104,7 +105,7 @@ QString InterfaceConfig::toWgConf(const QMap<QString, QString>& extra) const {
     out << "MTU = " << m_deviceMTU << "\n";
   }
 
-  if (!m_primaryDnsServer.isEmpty()) {
+  if (!m_useSystemDns && !m_primaryDnsServer.isEmpty()) {
     QStringList dnsServers;
     dnsServers.append(m_primaryDnsServer);
     if (!m_secondaryDnsServer.isEmpty()) {

--- a/client/daemon/interfaceconfig.h
+++ b/client/daemon/interfaceconfig.h
@@ -41,6 +41,9 @@ class InterfaceConfig {
   QStringList m_excludedAddresses;
   QStringList m_vpnDisabledApps;
   QStringList m_allowedDnsServers;
+  bool m_useSystemDns = false;
+  // Resolved by the daemon at activation time; never trusted from IPC.
+  QStringList m_systemDnsServers;
   bool m_killSwitchEnabled;
 #if defined(MZ_ANDROID) || defined(MZ_IOS)
   QString m_installationId;

--- a/client/mozilla/localsocketcontroller.cpp
+++ b/client/mozilla/localsocketcontroller.cpp
@@ -249,6 +249,7 @@ void LocalSocketController::activate(const QJsonObject &rawConfig) {
   json.insert("vpnDisabledApps", splitTunnelApps);
 
   json.insert("allowedDnsServers", allowedDns);
+  json.insert(amnezia::configKey::useSystemDns, rawConfig.value(amnezia::configKey::useSystemDns).toBool());
 
   json.insert(amnezia::configKey::killSwitchOption, rawConfig.value(amnezia::configKey::killSwitchOption));
 

--- a/client/platforms/macos/daemon/dnsutilsmacos.cpp
+++ b/client/platforms/macos/daemon/dnsutilsmacos.cpp
@@ -72,6 +72,68 @@ static QStringList cfParseStringList(CFTypeRef ref) {
   return result;
 }
 
+QStringList DnsUtilsMacos::systemResolvers() const {
+  if (!m_scStore) {
+    return {};
+  }
+  CFArrayRef keys = SCDynamicStoreCopyKeyList(
+      m_scStore, CFSTR("State:/Network/Service/[^/]+/(DNS|IPv4|IPv6)"));
+  if (!keys) {
+    return {};
+  }
+  auto keysGuard = qScopeGuard([&] { CFRelease(keys); });
+  QStringList services;
+  for (CFIndex i = 0; i < CFArrayGetCount(keys); ++i) {
+    CFTypeRef key = CFArrayGetValueAtIndex(keys, i);
+    if (CFGetTypeID(key) != CFStringGetTypeID()) {
+      continue;
+    }
+    services.append(cfParseString(key).section('/', 3, 3));
+  }
+  services.removeDuplicates();
+
+  auto readServers = [&](const QString& path) -> QStringList {
+    CFStringRef key = CFStringCreateWithCString(kCFAllocatorDefault,
+        path.toUtf8().constData(), kCFStringEncodingUTF8);
+    if (!key) {
+      return {};
+    }
+    auto keyGuard = qScopeGuard([&] { CFRelease(key); });
+    CFPropertyListRef value = SCDynamicStoreCopyValue(m_scStore, key);
+    if (!value) {
+      return {};
+    }
+    auto valueGuard = qScopeGuard([&] { CFRelease(value); });
+    if (CFGetTypeID(value) != CFDictionaryGetTypeID()) {
+      return {};
+    }
+    CFTypeRef servers = CFDictionaryGetValue((CFDictionaryRef)value, kSCPropNetDNSServerAddresses);
+    if (!servers || CFGetTypeID(servers) != CFArrayGetTypeID()) {
+      return {};
+    }
+    return cfParseStringList(servers);
+  };
+
+  QStringList resolvers;
+  for (const QString& service : services) {
+    // Manually configured DNS takes precedence over DHCP for this service.
+    QStringList servers = readServers(QStringLiteral("Setup:/Network/Service/%1/DNS").arg(service));
+    if (servers.isEmpty()) {
+      servers = readServers(QStringLiteral("State:/Network/Service/%1/DNS").arg(service));
+    }
+    for (const QString& server : servers) {
+      const QHostAddress address(server);
+      if (!address.isNull() && !address.isMulticast() && !address.isBroadcast()
+          && address != QHostAddress(QHostAddress::AnyIPv4)
+          && address != QHostAddress(QHostAddress::AnyIPv6)) {
+        resolvers.append(address.toString());
+      }
+    }
+  }
+  resolvers.removeDuplicates();
+  return resolvers;
+}
+
 static void cfDictSetString(CFMutableDictionaryRef dict, CFStringRef name,
                             const QString& value) {
   if (value.isNull()) {

--- a/client/platforms/macos/daemon/dnsutilsmacos.h
+++ b/client/platforms/macos/daemon/dnsutilsmacos.h
@@ -24,6 +24,7 @@ class DnsUtilsMacos final : public DnsUtils {
   bool updateResolvers(const QString& ifname,
                        const QList<QHostAddress>& resolvers) override;
   bool restoreResolvers() override;
+  QStringList systemResolvers() const override;
 
  private:
   void backupResolvers();

--- a/client/platforms/macos/daemon/wireguardutilsmacos.cpp
+++ b/client/platforms/macos/daemon/wireguardutilsmacos.cpp
@@ -178,7 +178,10 @@ bool WireguardUtilsMacos::addInterface(const InterfaceConfig& config) {
   } else {
     if (config.m_killSwitchEnabled) {
       FirewallParams params { };
-      params.dnsServers.append(config.m_primaryDnsServer);
+      if (!config.m_primaryDnsServer.isEmpty()) {
+          params.dnsServers.append(config.m_primaryDnsServer);
+      }
+      params.dnsServers.append(config.m_allowedDnsServers);
       if (!config.m_secondaryDnsServer.isEmpty()) {
           params.dnsServers.append(config.m_secondaryDnsServer);
       }

--- a/client/platforms/windows/daemon/dnsutilswindows.cpp
+++ b/client/platforms/windows/daemon/dnsutilswindows.cpp
@@ -12,6 +12,7 @@
 
 #include <QProcess>
 #include <QTextStream>
+#include <vector>
 
 #include "leakdetector.h"
 #include "logger.h"
@@ -38,6 +39,58 @@ DnsUtilsWindows::~DnsUtilsWindows() {
   MZ_COUNT_DTOR(DnsUtilsWindows);
   restoreResolvers();
   logger.debug() << "DnsUtilsWindows destroyed.";
+}
+
+QStringList DnsUtilsWindows::systemResolvers() const {
+  ULONG size = 16 * 1024;
+  std::vector<unsigned char> buffer(size);
+  ULONG result = ERROR_BUFFER_OVERFLOW;
+  for (int attempt = 0; attempt < 3 && result == ERROR_BUFFER_OVERFLOW; ++attempt) {
+    buffer.resize(size);
+    result = GetAdaptersAddresses(AF_UNSPEC,
+        GAA_FLAG_SKIP_UNICAST | GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST,
+        nullptr, reinterpret_cast<IP_ADAPTER_ADDRESSES*>(buffer.data()), &size);
+  }
+  if (result != NO_ERROR) {
+    logger.error() << "Cannot read system DNS:" << result;
+    return {};
+  }
+
+  QStringList resolvers;
+  const auto* adapters = reinterpret_cast<const IP_ADAPTER_ADDRESSES*>(buffer.data());
+  for (const auto* adapter = adapters; adapter; adapter = adapter->Next) {
+    // The loopback adapter can advertise obsolete fec0:: DNS placeholders.
+    // Real loopback resolvers are listed on the connected network adapters.
+    if (adapter->OperStatus != IfOperStatusUp || adapter->IfType == IF_TYPE_SOFTWARE_LOOPBACK) {
+      continue;
+    }
+    for (const auto* dns = adapter->FirstDnsServerAddress; dns; dns = dns->Next) {
+      const auto* socketAddress = dns->Address.lpSockaddr;
+      if (!socketAddress) {
+        continue;
+      }
+      QHostAddress address;
+      if (socketAddress->sa_family == AF_INET
+          && dns->Address.iSockaddrLength >= sizeof(sockaddr_in)) {
+        const auto* v4 = reinterpret_cast<const sockaddr_in*>(socketAddress);
+        address.setAddress(ntohl(v4->sin_addr.s_addr));
+      } else if (socketAddress->sa_family == AF_INET6
+                 && dns->Address.iSockaddrLength >= sizeof(sockaddr_in6)) {
+        const auto* v6 = reinterpret_cast<const sockaddr_in6*>(socketAddress);
+        address.setAddress(reinterpret_cast<const quint8*>(&v6->sin6_addr));
+        if (v6->sin6_scope_id) {
+          address.setScopeId(QString::number(v6->sin6_scope_id));
+        }
+      }
+      if (!address.isNull() && !address.isMulticast() && !address.isBroadcast()
+          && address != QHostAddress(QHostAddress::AnyIPv4)
+          && address != QHostAddress(QHostAddress::AnyIPv6)) {
+        resolvers.append(address.toString());
+      }
+    }
+  }
+  resolvers.removeDuplicates();
+  return resolvers;
 }
 
 bool DnsUtilsWindows::updateResolvers(const QString& ifname,

--- a/client/platforms/windows/daemon/dnsutilswindows.h
+++ b/client/platforms/windows/daemon/dnsutilswindows.h
@@ -22,6 +22,7 @@ class DnsUtilsWindows final : public DnsUtils {
   bool updateResolvers(const QString& ifname,
                        const QList<QHostAddress>& resolvers) override;
   bool restoreResolvers() override;
+  QStringList systemResolvers() const override;
 
  private:
   quint64 m_luid = 0;

--- a/client/translations/amneziavpn_ru_RU.ts
+++ b/client/translations/amneziavpn_ru_RU.ts
@@ -4039,6 +4039,14 @@ Create one from the current settings.</source>
 <context>
     <name>PageSettingsConnection</name>
     <message>
+        <source>Use system DNS</source>
+        <translation>Использовать системный DNS</translation>
+    </message>
+    <message>
+        <source>AmneziaWG and WireGuard only. Keep the operating system DNS settings. DNS requests may leave the VPN, even with Kill Switch enabled. Reconnect to apply.</source>
+        <translation>Только AmneziaWG и WireGuard. Сохраняет настройки DNS операционной системы. DNS-запросы могут идти вне VPN, даже при включённом Kill Switch. Для применения переподключитесь.</translation>
+    </message>
+    <message>
         <location filename="../ui/qml/Pages2/PageSettingsConnection.qml" line="49"/>
         <source>Connection</source>
         <translation>Соединение</translation>

--- a/client/ui/controllers/serversUiController.cpp
+++ b/client/ui/controllers/serversUiController.cpp
@@ -140,6 +140,23 @@ void ServersUiController::updateModel()
     QVector<ServerDescription> descriptions =
         m_serversController->buildServerDescriptions(m_settingsController->isAmneziaDnsEnabled());
 
+    if (m_settingsController->isSystemDnsEnabled()) {
+        const QString dnsLabel = QStringLiteral("Amnezia DNS | ");
+        for (ServerDescription& description : descriptions) {
+            if (!ContainerUtils::isAwgContainer(description.defaultContainer)
+                    && description.defaultContainer != DockerContainer::WireGuard) {
+                continue;
+            }
+            description.primaryDnsIsAmnezia = false;
+            for (QString* text : { &description.baseDescription, &description.expandedServerDescription,
+                                   &description.collapsedServerDescription }) {
+                if (text->startsWith(dnsLabel)) {
+                    text->remove(0, dnsLabel.size());
+                }
+            }
+        }
+    }
+
     const QString defaultServerId = m_serversController->getDefaultServerId();
     const bool hadServersFromGatewayBefore = descriptionsHaveGatewayServers(m_orderedServerDescriptions);
     const bool hasServersFromGatewayNow = descriptionsHaveGatewayServers(descriptions);

--- a/client/ui/controllers/settingsUiController.cpp
+++ b/client/ui/controllers/settingsUiController.cpp
@@ -39,6 +39,22 @@ SettingsUiController::SettingsUiController(SettingsController* settingsControlle
     }
 }
 
+bool SettingsUiController::isSystemDnsSupported() const
+{
+    return m_settingsController->isSystemDnsSupported();
+}
+
+bool SettingsUiController::isSystemDnsEnabled() const
+{
+    return m_settingsController->isSystemDnsEnabled();
+}
+
+void SettingsUiController::toggleSystemDns(bool enable)
+{
+    m_settingsController->toggleSystemDns(enable);
+    emit systemDnsChanged();
+}
+
 void SettingsUiController::toggleAmneziaDns(bool enable)
 {
     m_settingsController->toggleAmneziaDns(enable);

--- a/client/ui/controllers/settingsUiController.h
+++ b/client/ui/controllers/settingsUiController.h
@@ -17,6 +17,8 @@ public:
                                  ServersController* serversController,
                                  QObject *parent = nullptr);
 
+    Q_PROPERTY(bool systemDnsSupported READ isSystemDnsSupported CONSTANT)
+    Q_PROPERTY(bool systemDnsEnabled READ isSystemDnsEnabled WRITE toggleSystemDns NOTIFY systemDnsChanged)
     Q_PROPERTY(QString primaryDns READ getPrimaryDns WRITE setPrimaryDns NOTIFY primaryDnsChanged)
     Q_PROPERTY(QString secondaryDns READ getSecondaryDns WRITE setSecondaryDns NOTIFY secondaryDnsChanged)
     Q_PROPERTY(bool isLoggingEnabled READ isLoggingEnabled WRITE toggleLogging NOTIFY loggingStateChanged)
@@ -33,6 +35,10 @@ public:
     Q_PROPERTY(bool startMinimized READ isStartMinimizedEnabled NOTIFY startMinimizedChanged)
 
 public slots:
+    bool isSystemDnsSupported() const;
+    bool isSystemDnsEnabled() const;
+    void toggleSystemDns(bool enable);
+
     void toggleAmneziaDns(bool enable);
     bool isAmneziaDnsEnabled();
 
@@ -105,6 +111,7 @@ public slots:
     void disableHomeAdLabel();
 
 signals:
+    void systemDnsChanged();
     void primaryDnsChanged();
     void secondaryDnsChanged();
     void loggingStateChanged();

--- a/client/ui/qml/Pages2/PageSettingsConnection.qml
+++ b/client/ui/qml/Pages2/PageSettingsConnection.qml
@@ -57,7 +57,18 @@ PageType {
             width: listView.width
 
             SwitcherType {
+                Layout.fillWidth: true
+                Layout.margins: 16
+                visible: SettingsController.systemDnsSupported
+                text: qsTr("Use system DNS")
+                descriptionText: qsTr("AmneziaWG and WireGuard only. Keep the operating system DNS settings. DNS requests may leave the VPN, even with Kill Switch enabled. Reconnect to apply.")
+                checked: SettingsController.systemDnsEnabled
+                onToggled: SettingsController.systemDnsEnabled = checked
+            }
+
+            SwitcherType {
                 id: amneziaDnsSwitch
+                enabled: !SettingsController.systemDnsEnabled
 
                 Layout.fillWidth: true
                 Layout.margins: 16
@@ -77,6 +88,7 @@ PageType {
 
             LabelWithButtonType {
                 id: dnsServersButton
+                enabled: !SettingsController.systemDnsEnabled
 
                 Layout.fillWidth: true
 

--- a/client/vpnConnection.cpp
+++ b/client/vpnConnection.cpp
@@ -486,7 +486,8 @@ void VpnConnection::appendSplitTunnelingConfig()
 
             if (sitesJsonArray.isEmpty()) {
                 routeMode = amnezia::RouteMode::VpnAllSites;
-            } else if (routeMode == amnezia::RouteMode::VpnOnlyForwardSites) {
+            } else if (routeMode == amnezia::RouteMode::VpnOnlyForwardSites
+                       && !m_vpnConfiguration.value(configKey::useSystemDns).toBool()) {
                 // Allow traffic to Amnezia DNS
                 sitesJsonArray.append(m_vpnConfiguration.value(configKey::dns1).toString());
                 sitesJsonArray.append(m_vpnConfiguration.value(configKey::dns2).toString());

--- a/tests/systemdns/CMakeLists.txt
+++ b/tests/systemdns/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.25)
+project(SystemDnsTests LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_AUTOMOC ON)
+enable_testing()
+find_package(Qt6 6.10 REQUIRED COMPONENTS Core Network Test)
+set(ROOT "${CMAKE_CURRENT_LIST_DIR}/../..")
+add_executable(systemdns_test
+    tst_systemdns.cpp
+    ${ROOT}/client/daemon/daemon.cpp
+    ${ROOT}/client/daemon/daemon.h
+    ${ROOT}/client/daemon/dnsutils.h
+    ${ROOT}/client/daemon/wireguardutils.h
+    ${ROOT}/client/daemon/interfaceconfig.cpp
+    ${ROOT}/client/daemon/interfaceconfig.h
+    ${ROOT}/client/mozilla/shared/ipaddress.cpp
+)
+# Replace logging only; the daemon, configuration parser and routing decisions
+# under test are the production sources. No service or network changes are made.
+target_include_directories(systemdns_test PRIVATE
+    support ${ROOT}/client ${ROOT}/client/mozilla/shared)
+target_link_libraries(systemdns_test PRIVATE Qt6::Core Qt6::Network Qt6::Test)
+if(WIN32)
+    target_sources(systemdns_test PRIVATE
+        ${ROOT}/client/platforms/windows/daemon/dnsutilswindows.cpp
+        ${ROOT}/client/platforms/windows/daemon/dnsutilswindows.h)
+    target_compile_definitions(systemdns_test PRIVATE WIN32_LEAN_AND_MEAN NOMINMAX _WIN32_WINNT=0x0A00)
+    target_link_libraries(systemdns_test PRIVATE iphlpapi ws2_32)
+elseif(APPLE)
+    target_sources(systemdns_test PRIVATE
+        ${ROOT}/client/platforms/macos/daemon/dnsutilsmacos.cpp
+        ${ROOT}/client/platforms/macos/daemon/dnsutilsmacos.h)
+    target_link_libraries(systemdns_test PRIVATE "-framework SystemConfiguration" "-framework CoreFoundation")
+endif()
+add_test(NAME systemdns COMMAND systemdns_test)

--- a/tests/systemdns/README.md
+++ b/tests/systemdns/README.md
@@ -1,0 +1,69 @@
+# System DNS preservation
+
+This patch adds an opt-in **Use system DNS** setting for desktop Windows and
+macOS with AmneziaWG/WireGuard. It is disabled by default. Other protocols
+reject connection preparation while the setting is enabled; mobile platforms
+and macOS Network Extension do not expose this mode.
+
+The daemon reads DNS addresses at each activation after tearing down the old
+connection, skips resolver replacement, and allows those addresses through the
+existing DNS firewall rules. DNS route exclusions are kept separate from
+general traffic exclusions, so they do not grant access to other ports on DNS
+servers. Switching modes and reconnecting remove the previous DNS routes.
+Configured application/imported DNS values are retained for use when this mode
+is disabled. The UI explicitly warns that DNS may leave the VPN.
+
+## Automated checks
+
+The tests compile the production daemon, IPC parser, WireGuard configuration
+serializer, and native DNS reader. Network and firewall operations use fake
+backends. These tests never connect a VPN or modify system networking.
+
+With Qt 6.10+ and a C++17 toolchain:
+
+```sh
+cmake -S tests/systemdns -B build-systemdns -DCMAKE_PREFIX_PATH=/path/to/Qt
+cmake --build build-systemdns --config Release
+ctest --test-dir build-systemdns -C Release --output-on-failure
+```
+
+Ensure the Qt runtime libraries are on PATH on Windows. Set
+`AMNEZIA_TEST_SYSTEM_DNS=1` to also run the native resolver discovery check; it
+only reads the current system DNS configuration.
+
+## Integration validation matrix
+
+The Windows client and service were built in Release mode with Qt 6.10.3 and
+MSVC 19.44. The automated suite reported 19 passes (including initialization
+and cleanup), with native Windows DNS discovery enabled. A local tester ran
+the matching patched client and service and reported the VPN/DNS scenario
+working. This does not independently certify every scenario below. Native
+macOS build and runtime validation remain outstanding.
+
+Use a disposable host or VM with a test VPN endpoint and record DNS
+configuration, routes, and firewall state before and after each scenario:
+
+Install the matching patched client **and** service. An older service does not
+understand the new mode flag; running only the new UI is not a valid test.
+
+- Connect with system DNS enabled; resolve a hostname through the OS and query
+  every configured DNS directly over UDP and TCP port 53.
+- Check IPv4, IPv6, loopback/local resolvers, DHCP and manually assigned DNS.
+- Confirm DNS resolver/search-domain configuration is unchanged.
+- Disconnect, reconnect, switch servers, sleep/wake and change networks;
+  verify old DNS routes and firewall exceptions disappear.
+- Disable the setting and confirm the existing application DNS mode works.
+- With Kill Switch enabled, confirm non-DNS traffic to a DNS server is still
+  blocked outside the tunnel and the usual disconnected protection remains.
+- Verify both full tunnel and supported site/application split-tunnel modes.
+- Repeat on native macOS. A Windows build does not validate its platform code.
+
+## Limits of this first implementation
+
+The native readers enumerate adapter/network-service DNS servers. Corporate
+NRPT rules, macOS `/etc/resolver` overrides, arbitrary DNS ports, and local
+proxies requiring outbound DoH/DoT traffic need separate integration work.
+macOS uses the existing default-route exclusion mechanism for remote DNS;
+non-default uplinks and complex split-DNS routing have not been validated.
+System configuration is preserved, but reachability under Kill Switch must
+not be inferred for these cases from the unit tests.

--- a/tests/systemdns/support/logger.h
+++ b/tests/systemdns/support/logger.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <QDebug>
+
+// Keep test diagnostics on stderr instead of using the app's IPC/file logger.
+class Logger {
+public:
+    explicit Logger(const QString&) {}
+    QDebug debug() { return qDebug(); }
+    QDebug info() { return qInfo(); }
+    QDebug warning() { return qWarning(); }
+    QDebug error() { return qCritical(); }
+};

--- a/tests/systemdns/tst_systemdns.cpp
+++ b/tests/systemdns/tst_systemdns.cpp
@@ -1,0 +1,233 @@
+#include <QtTest>
+#include <QJsonObject>
+#include <QSignalSpy>
+#include "daemon/daemon.h"
+#ifdef Q_OS_WIN
+#include "platforms/windows/daemon/dnsutilswindows.h"
+#elif defined(Q_OS_MACOS)
+#include "platforms/macos/daemon/dnsutilsmacos.h"
+#endif
+
+class FakeDns final : public DnsUtils {
+public:
+    FakeDns() : DnsUtils(nullptr) {}
+    QStringList servers { "192.0.2.53", "2001:db8::53" };
+    mutable int reads = 0;
+    int updates = 0;
+    int restores = 0;
+    QStringList systemResolvers() const override { ++reads; return servers; }
+    bool updateResolvers(const QString&, const QList<QHostAddress>&) override {
+        ++updates;
+        return true;
+    }
+    bool restoreResolvers() override { ++restores; return true; }
+};
+
+class FakeWireguard final : public WireguardUtils {
+public:
+    FakeWireguard() : WireguardUtils(nullptr) {}
+    bool exists = false;
+    bool failRoute = false;
+    bool failPeer = false;
+    int creates = 0;
+    int deletes = 0;
+    InterfaceConfig applied;
+    QList<IPAddress> exclusions;
+    bool interfaceExists() override { return exists; }
+    bool addInterface(const InterfaceConfig&) override { ++creates; exists = true; return true; }
+    bool deleteInterface() override { ++deletes; exists = false; return true; }
+    bool updatePeer(const InterfaceConfig& config) override { applied = config; return !failPeer; }
+    bool deletePeer(const InterfaceConfig&) override { return true; }
+    QList<PeerStatus> getPeerStatus() override { return {}; }
+    bool updateRoutePrefix(const IPAddress&) override { return true; }
+    bool deleteRoutePrefix(const IPAddress&) override { return true; }
+    bool addExclusionRoute(const IPAddress& ip) override {
+        if (failRoute) return false;
+        exclusions.append(ip);
+        return true;
+    }
+    bool deleteExclusionRoute(const IPAddress& ip) override { exclusions.removeAll(ip); return true; }
+    bool excludeLocalNetworks(const QList<IPAddress>&) override { return true; }
+};
+
+class FakeDaemon final : public Daemon {
+public:
+    FakeDaemon() : Daemon(nullptr) {}
+    ~FakeDaemon() override { deactivate(false); }
+    FakeDns dns;
+    mutable FakeWireguard wg;
+protected:
+    WireguardUtils* wgutils() const override { return &wg; }
+    DnsUtils* dnsutils() override { return &dns; }
+};
+
+static InterfaceConfig config(bool systemDns = true) {
+    InterfaceConfig result;
+    result.m_hopType = InterfaceConfig::SingleHop;
+    result.m_privateKey = "test-private-key";
+    result.m_serverPublicKey = "test-server-key";
+    result.m_deviceIpv4Address = "10.8.0.2";
+    result.m_serverIpv4AddrIn = "198.51.100.1";
+    result.m_serverPort = 51820;
+    result.m_primaryDnsServer = "1.1.1.1";
+    result.m_secondaryDnsServer = "1.0.0.1";
+    result.m_useSystemDns = systemDns;
+    result.m_killSwitchEnabled = true;
+    result.m_allowedIPAddressRanges = { IPAddress(QStringLiteral("0.0.0.0/0")), IPAddress(QStringLiteral("::/0")) };
+    return result;
+}
+
+class SystemDnsTests : public QObject {
+    Q_OBJECT
+private slots:
+    void preservesResolversAndKillSwitch() {
+        FakeDaemon daemon;
+        auto requested = config();
+        requested.m_allowedDnsServers = { "203.0.113.53", "192.0.2.53" };
+        QVERIFY(daemon.activate(requested));
+        QCOMPARE(daemon.dns.updates, 0);
+        QCOMPARE(daemon.dns.reads, 1);
+        QVERIFY(daemon.wg.applied.m_killSwitchEnabled);
+        QVERIFY(daemon.wg.applied.m_primaryDnsServer.isEmpty());
+        QVERIFY(daemon.wg.applied.m_secondaryDnsServer.isEmpty());
+        QCOMPARE(daemon.wg.applied.m_allowedDnsServers.size(), 3);
+        QVERIFY(daemon.wg.applied.m_allowedDnsServers.contains("203.0.113.53"));
+        QVERIFY(daemon.wg.applied.m_allowedDnsServers.contains("2001:db8::53"));
+        // DNS exceptions must not grant access to all ports of a DNS server.
+        QVERIFY(daemon.wg.applied.m_excludedAddresses.isEmpty());
+        QCOMPARE(daemon.wg.exclusions.size(), 2);
+        QVERIFY(daemon.deactivate(false));
+        QVERIFY(daemon.wg.exclusions.isEmpty());
+        QCOMPARE(requested.m_primaryDnsServer, QString("1.1.1.1"));
+    }
+
+    void existingModeStillAppliesDns() {
+        FakeDaemon daemon;
+        QVERIFY(daemon.activate(config(false)));
+        QCOMPARE(daemon.dns.reads, 0);
+        QCOMPARE(daemon.dns.updates, 1);
+        QCOMPARE(daemon.wg.applied.m_primaryDnsServer, QString("1.1.1.1"));
+        QVERIFY(daemon.wg.exclusions.isEmpty());
+    }
+
+    void rereadsAfterNetworkChange() {
+        FakeDaemon daemon;
+        QVERIFY(daemon.activate(config()));
+        daemon.dns.servers = { "203.0.113.54" };
+        QVERIFY(daemon.activate(config()));
+        QCOMPARE(daemon.dns.reads, 2);
+        QCOMPARE(daemon.wg.creates, 2);
+        QCOMPARE(daemon.wg.deletes, 1);
+        QCOMPARE(daemon.wg.applied.m_allowedDnsServers, daemon.dns.servers);
+        QCOMPARE(daemon.wg.exclusions, QList<IPAddress>{IPAddress(QStringLiteral("203.0.113.54"))});
+    }
+
+    void modeChangeRestoresBeforeReading() {
+        FakeDaemon daemon;
+        QVERIFY(daemon.activate(config(false)));
+        QVERIFY(daemon.activate(config()));
+        QCOMPARE(daemon.dns.restores, 1);
+        QCOMPARE(daemon.dns.updates, 1);
+        QVERIFY(daemon.activate(config(false)));
+        QCOMPARE(daemon.dns.updates, 2);
+        QVERIFY(daemon.wg.exclusions.isEmpty());
+        QVERIFY(daemon.wg.applied.m_allowedDnsServers.isEmpty());
+    }
+
+    void missingDnsFailsBeforeInterfaceCreation() {
+        FakeDaemon daemon;
+        daemon.dns.servers.clear();
+        QSignalSpy failure(&daemon, &Daemon::activationFailure);
+        QVERIFY(!daemon.activate(config()));
+        QCOMPARE(failure.size(), 1);
+        QCOMPARE(daemon.wg.creates, 0);
+        QCOMPARE(daemon.dns.updates, 0);
+    }
+
+    void localResolversKeepTheirRoutes() {
+        FakeDaemon daemon;
+        daemon.dns.servers = { "127.0.0.1", "::1", "fe80::53%3" };
+        QVERIFY(daemon.activate(config()));
+        QVERIFY(daemon.wg.exclusions.isEmpty());
+        QCOMPARE(daemon.wg.applied.m_systemDnsServers, daemon.dns.servers);
+        QVERIFY(daemon.wg.applied.m_allowedDnsServers.contains("fe80::53"));
+        QVERIFY(!daemon.wg.applied.m_allowedDnsServers.contains("fe80::53%3"));
+    }
+
+    void routeFailureCleansUp() {
+        FakeDaemon daemon;
+        daemon.wg.failRoute = true;
+        QVERIFY(!daemon.activate(config()));
+        QVERIFY(!daemon.wg.exists);
+        QVERIFY(daemon.wg.exclusions.isEmpty());
+        QCOMPARE(daemon.dns.updates, 0);
+    }
+
+    void peerFailureRemovesDnsRoutes() {
+        FakeDaemon daemon;
+        daemon.wg.failPeer = true;
+        QVERIFY(!daemon.activate(config()));
+        QVERIFY(!daemon.wg.exists);
+        QVERIFY(daemon.wg.exclusions.isEmpty());
+        QCOMPARE(daemon.dns.updates, 0);
+    }
+
+    void ipcFlagValidation() {
+        QJsonObject json = config().toJson();
+        InterfaceConfig parsed;
+        QVERIFY(Daemon::parseConfig(json, parsed));
+        QVERIFY(parsed.m_useSystemDns);
+        json.insert("useSystemDns", "true");
+        QVERIFY(!Daemon::parseConfig(json, parsed));
+        json.remove("useSystemDns");
+        QVERIFY(Daemon::parseConfig(json, parsed));
+        QVERIFY(!parsed.m_useSystemDns);
+    }
+
+    void wireguardConfigDoesNotOverrideDns() {
+        QVERIFY(!config().toWgConf().contains("DNS ="));
+        QVERIFY(config(false).toWgConf().contains("DNS = 1.1.1.1, 1.0.0.1"));
+    }
+
+    void rejectsInvalidFirewallDns_data() {
+        QTest::addColumn<QString>("address");
+        QTest::newRow("shell") << "192.0.2.1; echo injected";
+        QTest::newRow("network") << "0.0.0.0/0";
+        QTest::newRow("unspecified") << "0.0.0.0";
+        QTest::newRow("empty") << "";
+        QTest::newRow("multicast") << "ff02::1";
+        QTest::newRow("hostname") << "dns.example.test";
+    }
+
+    void rejectsInvalidFirewallDns() {
+        QFETCH(QString, address);
+        auto requested = config();
+        requested.m_allowedDnsServers = { address };
+        InterfaceConfig parsed;
+        QVERIFY(!Daemon::parseConfig(requested.toJson(), parsed));
+    }
+
+    void readsNativeSystemResolvers() {
+        if (!qEnvironmentVariableIsSet("AMNEZIA_TEST_SYSTEM_DNS")) {
+            QSKIP("Set AMNEZIA_TEST_SYSTEM_DNS=1 for a read-only native resolver check");
+        }
+#if defined(Q_OS_WIN)
+        DnsUtilsWindows dns(nullptr);
+#elif defined(Q_OS_MACOS)
+        DnsUtilsMacos dns(nullptr);
+#else
+        QSKIP("Native resolver discovery is supported on Windows and macOS");
+#endif
+#if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
+        const QStringList servers = dns.systemResolvers();
+        QVERIFY(!servers.isEmpty());
+        for (const QString& server : servers) {
+            QVERIFY(!QHostAddress(server).isNull());
+        }
+        qInfo() << "System DNS:" << servers;
+#endif
+    }
+};
+
+QTEST_GUILESS_MAIN(SystemDnsTests)
+#include "tst_systemdns.moc"


### PR DESCRIPTION
Enabling a VPN currently replaces the operating system's DNS configuration. This adds an opt-in **Use system DNS** mode for desktop AmneziaWG/WireGuard connections on Windows and macOS. The default behavior stays the same.

The daemon discovers the current adapter/network-service DNS addresses at activation, skips resolver replacement, and adds those addresses to the existing DNS firewall allowlist. DNS route exclusions are separate from general traffic exclusions, so they do not grant access to other ports on a DNS server. Reconnection rereads the addresses after teardown; mode changes and activation failures clean up the DNS routes.

The change also forwards `allowedDnsServers` to the macOS WireGuard firewall path and validates/canonicalizes those IPC addresses before they reach platform firewall commands. The settings page warns that DNS may leave the VPN even with Kill Switch enabled, includes a Russian translation, and updates the server description when the mode changes. Saved application/imported DNS values are retained for the normal mode.

Related to #1972.

### Validation

- Windows Release builds of both the client and service succeeded with Qt 6.10.3 / MSVC 19.44.
- The standalone QtTest suite reported **19 passed, 0 failed, 0 skipped**, including initialization/cleanup and a read-only native Windows DNS discovery check. CTest passed 1/1 suite. The daemon/parser/serializer are production sources; network and firewall operations use fake backends.
- A manual Windows test used the matching patched client and service; the tester confirmed the VPN/DNS scenario works. Detailed per-scenario packet captures and negative Kill Switch checks were not independently recorded.
- Changed QML parsed successfully, the Russian translation compiled, and `git diff --check` passed.
- **macOS has not been built or run locally.** Its native implementation needs platform validation.

### Scope and remaining validation

The mode is disabled by default and is limited to the desktop WireGuard daemon. Other protocols reject connection preparation while it is enabled. Mobile platforms and macOS Network Extension do not expose it. Testing requires matching patched client and service versions.

The readers enumerate adapter/network-service DNS servers. Corporate NRPT rules, macOS `/etc/resolver`, nonstandard DNS ports, local DoH/DoT proxies, and complex routing across multiple uplinks need separate work. macOS uses the existing default-route exclusion mechanism for remote DNS. The unit tests do not establish reachability or Kill Switch behavior for those cases.

Reproducible test commands and the remaining integration matrix are in `tests/systemdns/README.md`.
