### PR TITLE
fix(windows): keep on-link routes off VPN capture

### DIFF
--- a/client/platforms/windows/daemon/windowsroutecapturepolicy.h
+++ b/client/platforms/windows/daemon/windowsroutecapturepolicy.h
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef WINDOWSROUTECAPTUREPOLICY_H
+#define WINDOWSROUTECAPTUREPOLICY_H
+
+#include <winsock2.h>
+#include <WS2tcpip.h>
+#include <ws2ipdef.h>
+#include <windows.h>
+#include <iphlpapi.h>
+
+#include <cstring>
+
+namespace WindowsRouteCapturePolicy {
+
+inline bool isVpnInterfaceRoute(const MIB_IPFORWARD_ROW2* row,
+                                unsigned long long vpnLuid) {
+  return row->InterfaceLuid.Value == vpnLuid;
+}
+
+inline bool isDefaultRoute(const MIB_IPFORWARD_ROW2* row) {
+  return row->DestinationPrefix.PrefixLength == 0;
+}
+
+inline bool isRouteCreatedByMonitor(const MIB_IPFORWARD_ROW2* row,
+                                    ULONG monitorMetric) {
+  return row->Protocol == MIB_IPPROTO_NETMGMT && row->Metric == monitorMetric;
+}
+
+inline bool isIpv6Unspecified(const IN6_ADDR& address) {
+  static const IN6_ADDR unspecified = {};
+  return std::memcmp(&address, &unspecified, sizeof(unspecified)) == 0;
+}
+
+inline bool isOnLinkRoute(const MIB_IPFORWARD_ROW2* row) {
+  // Connected routes have no gateway. Capturing them into the VPN tunnel
+  // breaks LAN, Hyper-V, WSL, and other locally attached networks.
+  if (row->NextHop.si_family == AF_UNSPEC) {
+    return true;
+  }
+
+  if (row->NextHop.si_family == AF_INET) {
+    return row->NextHop.Ipv4.sin_addr.s_addr == 0;
+  }
+
+  if (row->NextHop.si_family == AF_INET6) {
+    return isIpv6Unspecified(row->NextHop.Ipv6.sin6_addr);
+  }
+
+  return false;
+}
+
+inline bool shouldCaptureRoute(const MIB_IPFORWARD_ROW2* row,
+                               unsigned long long vpnLuid,
+                               bool routeExcluded, ULONG monitorMetric) {
+  if (isVpnInterfaceRoute(row, vpnLuid)) {
+    return false;
+  }
+  if (isDefaultRoute(row)) {
+    return false;
+  }
+  if (isRouteCreatedByMonitor(row, monitorMetric)) {
+    return false;
+  }
+  if (routeExcluded) {
+    return false;
+  }
+  // Default-route capture should only clone routed prefixes. Directly
+  // connected prefixes must stay bound to their real local interfaces.
+  if (isOnLinkRoute(row)) {
+    return false;
+  }
+
+  return true;
+}
+
+}  // namespace WindowsRouteCapturePolicy
+
+#endif  // WINDOWSROUTECAPTUREPOLICY_H

--- a/client/platforms/windows/daemon/windowsroutemonitor.cpp
+++ b/client/platforms/windows/daemon/windowsroutemonitor.cpp
@@ -8,6 +8,7 @@
 
 #include "leakdetector.h"
 #include "logger.h"
+#include "windowsroutecapturepolicy.h"
 
 namespace {
 Logger logger("WindowsRouteMonitor");
@@ -259,9 +260,12 @@ void WindowsRouteMonitor::updateCapturedRoutes(int family) {
   PMIB_IPFORWARD_TABLE2 table;
   DWORD error = GetIpForwardTable2(family, &table);
   if (error != NO_ERROR) {
-    updateCapturedRoutes(family, table);
-    FreeMibTable(table);
+    logger.error() << "Failed to fetch routing table:" << error;
+    return;
   }
+
+  updateCapturedRoutes(family, table);
+  FreeMibTable(table);
 }
 
 void WindowsRouteMonitor::updateCapturedRoutes(int family, void* ptable) {
@@ -272,23 +276,12 @@ void WindowsRouteMonitor::updateCapturedRoutes(int family, void* ptable) {
 
   for (ULONG i = 0; i < table->NumEntries; i++) {
     MIB_IPFORWARD_ROW2* row = &table->Table[i];
-    // Ignore routes into the VPN interface.
-    if (row->InterfaceLuid.Value == m_luid) {
+    bool routeExcluded = isRouteExcluded(&row->DestinationPrefix);
+    if (!WindowsRouteCapturePolicy::shouldCaptureRoute(
+            row, m_luid, routeExcluded, EXCLUSION_ROUTE_METRIC)) {
       continue;
     }
-    // Ignore the default route
-    if (row->DestinationPrefix.PrefixLength == 0) {
-      continue;
-    }
-    // Ignore routes of our own creation.
-    if ((row->Protocol == MIB_IPPROTO_NETMGMT) &&
-        (row->Metric == EXCLUSION_ROUTE_METRIC)) {
-      continue;
-    }
-    // Ignore routes which should be excluded.
-    if (isRouteExcluded(&row->DestinationPrefix)) {
-      continue;
-    }
+
     QHostAddress destination = prefixToAddress(&row->DestinationPrefix);
     if (destination.isLoopback() || destination.isBroadcast() ||
         destination.isLinkLocal() || destination.isMulticast()) {
@@ -424,11 +417,11 @@ bool WindowsRouteMonitor::addExclusionRoute(const IPAddress& prefix) {
     return false;
   }
   updateInterfaceMetrics(family);
-  updateCapturedRoutes(family, table);
   updateExclusionRoute(data, table);
+  m_exclusionRoutes[prefix] = data;
+  updateCapturedRoutes(family, table);
   FreeMibTable(table);
 
-  m_exclusionRoutes[prefix] = data;
   return true;
 }
 


### PR DESCRIPTION
## Summary

This PR addresses the Windows route-capture part of #2830.

When default route capture is enabled, directly connected/on-link routes can be cloned onto the AmneziaVPN interface with metric 0. This may override the physical LAN route and make local hosts unreachable while the VPN is active.

The change prevents directly connected/on-link routes from being captured into the VPN tunnel.

## What changed

Route capture now skips routes that:

- belong to the VPN interface;
- are default routes;
- were created by the route monitor itself;
- are explicitly excluded;
- are directly connected/on-link routes:
  - IPv4 next hop `0.0.0.0`;
  - IPv6 next hop `::`;
  - `AF_UNSPEC`.

Ordinary routed IPv4 and IPv6 prefixes remain eligible for capture.

The patch also keeps two adjacent correctness fixes:

- `GetIpForwardTable2()` output is only used after a successful call;
- a newly added exclusion is registered before captured-route reconciliation.

## Relation to #2835

The core implementation is based on and intentionally follows #2835.

This PR is not meant to claim the route-capture fix as independent work. It brings that approach onto the current `dev` branch and validates it against the newer reproduction described in #2830.

In that reproduction, Windows creates a competing LAN `/32` route on the AmneziaVPN interface with metric 0. Removing that route restores selection of the physical interface. Preventing on-link routes from being captured avoids creating that competing route in the first place.

## Scope

This PR intentionally contains only the Windows route-capture fix.

It does not include the broader changes from #3030. Those changes are complementary, particularly for the KillSwitch / site-exclusion part of #2830.

## Verification

The change has been exercised in Windows CI, including the Windows dependency build and full Windows build pipeline.

Related validation runs:

- https://github.com/HeisLuka/amnezia-client2/actions/runs/34650009472
- https://github.com/HeisLuka/amnezia-client2/actions/runs/34643999872
- https://github.com/HeisLuka/amnezia-client2/actions/runs/34644870746