### PR TITLE
Fix conan scripts syntax errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,6 @@ macos-with-sign-build.sh
 DeveloperIdApplicationCertificate.p12
 DeveloperIdInstallerCertificate.p12
 
+# Python files
+*.pyc
+

--- a/recipes/amnezia-xray-bindings/conanfile.py
+++ b/recipes/amnezia-xray-bindings/conanfile.py
@@ -110,9 +110,10 @@ class AmneziaXrayBindings(ConanFile):
                 env.define("CGO_CFLAGS", " ".join(cflags))
                 env.define("CGO_LDFLAGS", " ".join(ldflags))
                 with env.vars(self).apply():
+                    make_build_dir = build_dir.replace('\\', '/') if self._is_windows else build_dir
                     at = Autotools(self)
                     at.make(args=[
-                        f"BUILD_DIR={build_dir.replace("\\", "/") if self._is_windows else build_dir}"
+                        f"BUILD_DIR={make_build_dir}"
                     ])
 
             if is_apple_os(self) and self._is_multiarch:

--- a/recipes/hev-socks5-tunnel/conanfile.py
+++ b/recipes/hev-socks5-tunnel/conanfile.py
@@ -60,9 +60,9 @@ class HevSocks5Tunnel(ConanFile):
             self.run(
                 f"libtool -static -o {lib_path}"
                 f" {lib_path}"
-                f" {os.path.join(self.build_folder, "third-part", "lwip", "bin", "liblwip.a")}"
-                f" {os.path.join(self.build_folder, "third-part", "yaml", "bin", "libyaml.a")}"
-                f" {os.path.join(self.build_folder, "third-part", "hev-task-system", "bin", "libhev-task-system.a")}"
+                f" {os.path.join(self.build_folder, 'third-part', 'lwip', 'bin', 'liblwip.a')}"
+                f" {os.path.join(self.build_folder, 'third-part', 'yaml', 'bin', 'libyaml.a')}"
+                f" {os.path.join(self.build_folder, 'third-part', 'hev-task-system', 'bin', 'libhev-task-system.a')}"
             )
 
             include_dir = os.path.join(self.build_folder, "framework_include")

--- a/recipes/tun2socks/conanfile.py
+++ b/recipes/tun2socks/conanfile.py
@@ -113,9 +113,10 @@ class Tun2Socks(ConanFile):
                 env.define("CGO_LDFLAGS", " ".join(ldflags))
                 env.define("CGO_CFLAGS", " ".join(cflags))
                 with env.vars(self).apply():
+                    make_build_dir = build_dir.replace('\\', '/') if self._is_windows else build_dir
                     at = Autotools(self)
                     at.make("tun2socks", args=[
-                        f"BUILD_DIR={build_dir.replace("\\", "/") if self._is_windows else build_dir}"
+                        f"BUILD_DIR={make_build_dir}"
                     ])
                     if self._is_windows:
                         os.rename(


### PR DESCRIPTION
Conan uses bundled python 3.12. Conanfiles contain errors which lead to build failing on installing packages stage. 